### PR TITLE
feat: support private notes in `MockChain`

### DIFF
--- a/crates/miden-objects/src/block/nullifier_tree.rs
+++ b/crates/miden-objects/src/block/nullifier_tree.rs
@@ -74,6 +74,13 @@ impl NullifierTree {
         self.smt.num_entries()
     }
 
+    /// Returns an iterator over the nullifiers and their block numbers in the tree.
+    pub fn entries(&self) -> impl Iterator<Item = (Nullifier, BlockNumber)> {
+        self.smt.entries().map(|(nullifier, block_num)| {
+            (Nullifier::from(*nullifier), Self::leaf_value_to_block_num(*block_num))
+        })
+    }
+
     /// Returns a [`NullifierWitness`] of the leaf associated with the `nullifier`.
     ///
     /// Conceptually, such a witness is a Merkle path to the leaf, as well as the leaf itself.

--- a/crates/miden-test/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-test/src/kernel_tests/batch/proposed_batch.rs
@@ -275,10 +275,22 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
             .unauthenticated_notes(vec![note1.clone()])
             .build()?;
 
-    let input_note0 = chain.available_notes_map().get(&note0.id()).expect("note not found");
+    let input_note0: InputNote = chain
+        .available_notes_map()
+        .get(&note0.id())
+        .expect("note not found")
+        .clone()
+        .try_into()
+        .expect("note should be public");
     let note_inclusion_proof0 = input_note0.proof().expect("note should be of type authenticated");
 
-    let input_note1 = chain.available_notes_map().get(&note1.id()).expect("note not found");
+    let input_note1: InputNote = chain
+        .available_notes_map()
+        .get(&note1.id())
+        .expect("note not found")
+        .clone()
+        .try_into()
+        .expect("note should be public");
     let note_inclusion_proof1 = input_note1.proof().expect("note should be of type authenticated");
 
     // The partial blockchain will contain all blocks in the mock chain, in particular block2 which
@@ -350,7 +362,7 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
         batch
             .input_notes()
             .iter()
-            .any(|commitment| commitment == &InputNoteCommitment::from(input_note1))
+            .any(|commitment| commitment == &InputNoteCommitment::from(&input_note1))
     );
     assert_eq!(batch.output_notes().len(), 0);
 

--- a/crates/miden-test/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-test/src/kernel_tests/block/proposed_block_errors.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     block::{BlockInputs, BlockNumber, ProposedBlock},
     note::NoteInclusionProof,
     testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
-    transaction::ProvenTransaction,
+    transaction::{OutputNote, ProvenTransaction},
 };
 
 use super::utils::{
@@ -285,8 +285,8 @@ fn proposed_block_fails_on_duplicate_output_note() -> anyhow::Result<()> {
     let note0 = generate_untracked_note_with_output_note(account.id(), output_note.clone());
     let note1 = generate_untracked_note_with_output_note(account.id(), output_note);
 
-    chain.add_pending_note(note0.clone());
-    chain.add_pending_note(note1.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
+    chain.add_pending_note(OutputNote::Full(note1.clone()));
 
     chain.seal_next_block();
 
@@ -330,7 +330,7 @@ fn proposed_block_fails_on_invalid_proof_or_missing_note_inclusion_reference_blo
     let batch0 = generate_batch(&mut chain, vec![tx0]);
 
     // Add the note to the chain so we can retrieve an inclusion proof for it.
-    chain.add_pending_note(note0.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
     let block2 = chain.seal_next_block();
 
     // Seal another block so that the next block will use this one as the reference block and block2
@@ -430,7 +430,7 @@ fn proposed_block_fails_on_missing_nullifier_witness() -> anyhow::Result<()> {
     let batch0 = generate_batch(&mut chain, vec![tx0]);
 
     // Add the note to the chain so we can retrieve an inclusion proof for it.
-    chain.add_pending_note(note0.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
     let _block2 = chain.seal_next_block();
 
     let batches = vec![batch0.clone()];
@@ -468,7 +468,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
     let batch0 = generate_batch(&mut chain, vec![tx0]);
 
     // Add the note to the chain so we can consume it in the next step.
-    chain.add_pending_note(note0.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
     let _block2 = chain.seal_next_block();
 
     // Create an alternative chain where we consume the note so it is marked as spent in the

--- a/crates/miden-test/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-test/src/kernel_tests/block/proposed_block_success.rs
@@ -5,7 +5,7 @@ use miden_objects::{
     account::AccountId,
     block::{BlockInputs, ProposedBlock},
     testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
-    transaction::{ProvenTransaction, TransactionHeader},
+    transaction::{OutputNote, ProvenTransaction, TransactionHeader},
 };
 
 use super::utils::{
@@ -204,8 +204,8 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
     let batch0 = generate_batch(&mut chain, vec![tx0.clone()]);
     let batch1 = generate_batch(&mut chain, vec![tx1.clone()]);
 
-    chain.add_pending_note(note0.clone());
-    chain.add_pending_note(note1.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
+    chain.add_pending_note(OutputNote::Full(note1.clone()));
     chain.seal_next_block();
 
     let batches = [batch0, batch1];

--- a/crates/miden-test/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-test/src/kernel_tests/block/proven_block_success.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     MIN_PROOF_SECURITY_LEVEL,
     batch::BatchNoteTree,
     block::{AccountTree, BlockInputs, BlockNoteIndex, BlockNoteTree, ProposedBlock},
-    transaction::InputNoteCommitment,
+    transaction::{InputNoteCommitment, OutputNote},
 };
 use rand::Rng;
 
@@ -43,10 +43,10 @@ fn proven_block_success() -> anyhow::Result<()> {
     let input_note3 = generate_untracked_note_with_output_note(account3.id(), output_note3);
 
     // Add input notes to chain so we can consume them.
-    chain.add_pending_note(input_note0.clone());
-    chain.add_pending_note(input_note1.clone());
-    chain.add_pending_note(input_note2.clone());
-    chain.add_pending_note(input_note3.clone());
+    chain.add_pending_note(OutputNote::Full(input_note0.clone()));
+    chain.add_pending_note(OutputNote::Full(input_note1.clone()));
+    chain.add_pending_note(OutputNote::Full(input_note2.clone()));
+    chain.add_pending_note(OutputNote::Full(input_note3.clone()));
     chain.seal_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[input_note0.id()]);
@@ -213,9 +213,9 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
     let note3 = generate_untracked_note_with_output_note(account3.id(), output_note3.clone());
 
     // Add note{0,2,3} to the chain so we can consume them.
-    chain.add_pending_note(note0.clone());
-    chain.add_pending_note(note2.clone());
-    chain.add_pending_note(note3.clone());
+    chain.add_pending_note(OutputNote::Full(note0.clone()));
+    chain.add_pending_note(OutputNote::Full(note2.clone()));
+    chain.add_pending_note(OutputNote::Full(note3.clone()));
     chain.seal_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);

--- a/crates/miden-test/src/kernel_tests/block/utils.rs
+++ b/crates/miden-test/src/kernel_tests/block/utils.rs
@@ -11,7 +11,8 @@ use miden_objects::{
     note::{Note, NoteId, NoteTag, NoteType},
     testing::{account_component::AccountMockComponent, note::NoteBuilder},
     transaction::{
-        ExecutedTransaction, ProvenTransaction, ProvenTransactionBuilder, TransactionScript,
+        ExecutedTransaction, OutputNote, ProvenTransaction, ProvenTransactionBuilder,
+        TransactionScript,
     },
     utils::word_to_masm_push_string,
     vm::ExecutionProof,
@@ -40,7 +41,7 @@ pub fn generate_tracked_note(
     receiver: AccountId,
 ) -> Note {
     let note = generate_untracked_note_internal(sender, receiver, vec![]);
-    chain.add_pending_note(note.clone());
+    chain.add_pending_note(OutputNote::Full(note.clone()));
     note
 }
 
@@ -51,7 +52,7 @@ pub fn generate_tracked_note_with_asset(
     asset: Asset,
 ) -> Note {
     let note = generate_untracked_note_internal(sender, receiver, vec![asset]);
-    chain.add_pending_note(note.clone());
+    chain.add_pending_note(OutputNote::Full(note.clone()));
     note
 }
 

--- a/crates/miden-test/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-test/src/kernel_tests/tx/test_note.rs
@@ -11,7 +11,7 @@ use miden_objects::{
         Note, NoteExecutionHint, NoteExecutionMode, NoteInputs, NoteMetadata, NoteTag, NoteType,
     },
     testing::{account_id::ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE, note::NoteBuilder},
-    transaction::{ForeignAccountInputs, TransactionArgs},
+    transaction::{ForeignAccountInputs, OutputNote, TransactionArgs},
 };
 use miden_tx::TransactionExecutorError;
 use rand::SeedableRng;
@@ -655,7 +655,7 @@ pub fn test_timelock() {
         .build(&TransactionKernel::testing_assembler_with_mock_account())
         .unwrap();
 
-    mock_chain.add_pending_note(timelock_note.clone());
+    mock_chain.add_pending_note(OutputNote::Full(timelock_note.clone()));
     mock_chain.seal_block(None, Some(lock_timestamp - 100));
 
     // Attempt to consume note too early.

--- a/crates/miden-test/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-test/src/kernel_tests/tx/test_tx.rs
@@ -32,7 +32,7 @@ use miden_objects::{
         },
         constants::NON_FUNGIBLE_ASSET_DATA_2,
     },
-    transaction::{InputNotes, OutputNote, OutputNotes, TransactionArgs},
+    transaction::{InputNote, InputNotes, OutputNote, OutputNotes, TransactionArgs},
 };
 use miden_tx::{TransactionExecutor, TransactionExecutorError};
 
@@ -90,12 +90,14 @@ fn test_future_input_note_fails() {
 
     // Get as input note, and assert that the note was created after block 1 (which we'll
     // use as reference)
-    let input_note = mock_chain
+    let input_note: InputNote = mock_chain
         .available_notes()
         .iter()
         .find(|n| n.id() == note.id())
         .unwrap()
-        .clone();
+        .clone()
+        .try_into()
+        .expect("note should be public");
     assert!(input_note.location().unwrap().block_num() > 1.into());
 
     mock_chain.seal_next_block();

--- a/crates/miden-test/src/lib.rs
+++ b/crates/miden-test/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 extern crate std;
 
 mod mock_chain;
-pub use mock_chain::{AccountState, Auth, MockChain, MockFungibleFaucet};
+pub use mock_chain::{AccountState, Auth, MockChain, MockChainNote, MockFungibleFaucet};
 
 mod tx_context;
 pub use tx_context::{TransactionContext, TransactionContextBuilder};

--- a/crates/miden-test/src/mock_chain/chain.rs
+++ b/crates/miden-test/src/mock_chain/chain.rs
@@ -276,10 +276,10 @@ impl MockChain {
         account
     }
 
-    /// Adds a public [Note] to the pending objects.
+    /// Adds an [OutputNote] to the pending objects.
     /// A block has to be created to finalize the new entity.
-    pub fn add_pending_note(&mut self, note: Note) {
-        self.pending_objects.output_note_batches.push(vec![(0, OutputNote::Full(note))]);
+    pub fn add_pending_note(&mut self, note: OutputNote) {
+        self.pending_objects.output_note_batches.push(vec![(0, note)]);
     }
 
     /// Adds a P2ID [Note] to the pending objects and returns it.
@@ -315,7 +315,7 @@ impl MockChain {
             )?
         };
 
-        self.add_pending_note(note.clone());
+        self.add_pending_note(OutputNote::Full(note.clone()));
 
         Ok(note)
     }

--- a/crates/miden-test/src/mock_chain/mod.rs
+++ b/crates/miden-test/src/mock_chain/mod.rs
@@ -2,7 +2,9 @@ mod account;
 mod auth;
 mod chain;
 mod fungible_faucet;
+mod note;
 
 pub use auth::Auth;
 pub use chain::{AccountState, MockChain};
 pub use fungible_faucet::MockFungibleFaucet;
+pub use note::MockChainNote;

--- a/crates/miden-test/src/mock_chain/note.rs
+++ b/crates/miden-test/src/mock_chain/note.rs
@@ -1,0 +1,65 @@
+use miden_objects::{
+    NoteError,
+    note::{Note, NoteId, NoteInclusionProof, NoteMetadata, NoteType},
+    transaction::InputNote,
+};
+
+// MOCK CHAIN NOTE
+// ================================================================================================
+
+/// Represents a note that is stored in the mock chain.
+#[derive(Debug, Clone)]
+pub enum MockChainNote {
+    /// Details for a private note only include its [`NoteMetadata`] and [`NoteInclusionProof`].
+    /// Other details needed to consume the note are expected to be stored locally, off-chain.
+    Private(NoteId, NoteMetadata, NoteInclusionProof),
+    /// Contains the full [`Note`] object alongside its [`NoteInclusionProof`].
+    Public(Note, NoteInclusionProof),
+}
+
+impl MockChainNote {
+    /// Returns the note's inclusion details.
+    pub fn inclusion_proof(&self) -> &NoteInclusionProof {
+        match self {
+            MockChainNote::Private(_, _, inclusion_proof)
+            | MockChainNote::Public(_, inclusion_proof) => inclusion_proof,
+        }
+    }
+
+    /// Returns the note's metadata.
+    pub fn metadata(&self) -> &NoteMetadata {
+        match self {
+            MockChainNote::Private(_, metadata, _) => metadata,
+            MockChainNote::Public(note, _) => note.metadata(),
+        }
+    }
+
+    /// Returns the note's ID.
+    pub fn id(&self) -> NoteId {
+        match self {
+            MockChainNote::Private(id, ..) => *id,
+            MockChainNote::Public(note, _) => note.id(),
+        }
+    }
+
+    /// Returns the underlying note if it is public.
+    pub fn note(&self) -> Option<&Note> {
+        match self {
+            MockChainNote::Private(..) => None,
+            MockChainNote::Public(note, _) => Some(note),
+        }
+    }
+}
+
+impl TryFrom<MockChainNote> for InputNote {
+    type Error = NoteError;
+
+    fn try_from(value: MockChainNote) -> Result<Self, Self::Error> {
+        match value {
+            MockChainNote::Private(..) => {
+                Err(NoteError::PublicUseCaseRequiresPublicNote(NoteType::Private))
+            },
+            MockChainNote::Public(note, proof) => Ok(InputNote::Authenticated { note, proof }),
+        }
+    }
+}

--- a/crates/miden-test/src/tx_context/builder.rs
+++ b/crates/miden-test/src/tx_context/builder.rs
@@ -647,7 +647,7 @@ impl TransactionContextBuilder {
 
                 let mut mock_chain = MockChain::default();
                 for i in self.input_notes {
-                    mock_chain.add_pending_note(i);
+                    mock_chain.add_pending_note(OutputNote::Full(i));
                 }
 
                 mock_chain.seal_next_block();

--- a/crates/miden-test/tests/integration/scripts/faucet.rs
+++ b/crates/miden-test/tests/integration/scripts/faucet.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     Felt,
     asset::{Asset, FungibleAsset},
     note::{NoteAssets, NoteExecutionHint, NoteId, NoteMetadata, NoteTag, NoteType},
-    transaction::TransactionScript,
+    transaction::{OutputNote, TransactionScript},
 };
 use miden_test::{Auth, MockChain, MockFungibleFaucet};
 use miden_tx::utils::word_to_masm_push_string;
@@ -195,7 +195,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
 
     let note = get_note_with_fungible_asset_and_script(fungible_asset, note_script);
 
-    mock_chain.add_pending_note(note.clone());
+    mock_chain.add_pending_note(OutputNote::Full(note.clone()));
     mock_chain.seal_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)

--- a/crates/miden-test/tests/integration/scripts/swap.rs
+++ b/crates/miden-test/tests/integration/scripts/swap.rs
@@ -89,7 +89,7 @@ fn prove_consume_swap_note() {
     // --------------------------------------------------------------------------------------------
 
     let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
-    mock_chain.add_pending_note(note.clone());
+    mock_chain.add_pending_note(OutputNote::Full(note.clone()));
     mock_chain.seal_next_block();
 
     let consume_swap_note_tx = mock_chain


### PR DESCRIPTION
In https://github.com/0xPolygonMiden/miden-client/pull/882 I'm working towards moving some of the integration tests into unit tests that use the `MockChain`. These tests are significantly faster, and can be used to test some basic client functionality that doesn't depend on having a real running node.

One of the main features missing from the `MockChain` that prevented the migration of some tests was the use of private notes. This PR adds support for these kinds of notes via the `MockChainNote` struct.

The other big feature that is missing is private account support. I didn't implement this as it didn't seem as straightforward and we don't really want a 100% compatible `MockChain`, but we could consider adding it in the future. 

Then there's functionality that I added on client side that could be also added to the `MockChain`. Specifically accessors for proven blocks and committed transactions (for context, we are simulating it by [tracking them client side](https://github.com/0xMiden/miden-client/blob/7c34bdf3e631fa6b2e982c2e57970aaff6e2118b/crates/rust-client/src/test_utils/mock.rs#L49-L50)). If we want, I can try to add it to this PR.