### PR TITLE
Fix typos: withing -> within, beggining -> beginning, identifed -> identified

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Polygon Miden is currently on release v0.8. This is an early version of the prot
 ### Planned features
 
 - **Network transactions**. Users will be able to create notes intended for network execution. Such notes will be included into transactions executed and proven by the Miden operator.
-- **Encrypted notes**. With encrypted notes users will be able to put all note details on-chain, but the data contained withing the notes would be encrypted with the recipients key.
+- **Encrypted notes**. With encrypted notes users will be able to put all note details on-chain, but the data contained within the notes would be encrypted with the recipients key.
 
 ## Project structure
 

--- a/bin/proving-service/src/proxy/mod.rs
+++ b/bin/proving-service/src/proxy/mod.rs
@@ -124,7 +124,7 @@ impl LoadBalancerState {
     ///
     /// If the worker is not in the list, it won't be added.
     /// The worker is moved to the end of the list to avoid overloading since the selection of the
-    /// worker is done in order, causing the workers at the beggining of the list to be selected
+    /// worker is done in order, causing the workers at the beginning of the list to be selected
     /// more often.
     pub async fn add_available_worker(&self, worker: Worker) {
         let mut workers = self.workers.write().await;

--- a/crates/miden-tx/src/testing/mock_chain/mod.rs
+++ b/crates/miden-tx/src/testing/mock_chain/mod.rs
@@ -1068,7 +1068,7 @@ impl MockChain {
         &self.available_notes
     }
 
-    /// Returns a reference to the account identifed by the given account ID and panics if it does
+    /// Returns a reference to the account identified by the given account ID and panics if it does
     /// not exist.
     pub fn available_account(&self, account_id: AccountId) -> &Account {
         self.available_accounts


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- README.md: Corrects "withing" to "within" in encrypted notes description
- bin/proving-service/src/proxy/mod.rs: Fixes "beggining" to "beginning" in worker selection comment
- crates/miden-tx/src/testing/mock_chain/mod.rs: Corrects "identifed" to "identified" in account reference documentation

No functional changes, just documentation and comment improvements.