### PR TITLE
Use batch and block provers in `MockChain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix error when creating accounts with empty storage (#1307).
 - [BREAKING] Move `MockChain` and `TransactionContext` to new `miden-testing` crate (#1309).
 - [BREAKING] Add support for private notes in `MockChain` (#1310).
+- [BREAKING] Refactor `MockChain` to use batch and block provers (#1315).
 
 ## 0.8.2 (2025-04-18) - `miden-proving-service` crate only
 

--- a/bin/proving-service/src/main.rs
+++ b/bin/proving-service/src/main.rs
@@ -76,14 +76,14 @@ mod test {
 
         // Create a mock transaction to send to the server
         let mut mock_chain = MockChain::new();
-        let account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+        let account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
 
         let fungible_asset_1: Asset =
             FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap(), 100)
                 .unwrap()
                 .into();
         let note_1 = mock_chain
-            .add_p2id_note(
+            .add_pending_p2id_note(
                 ACCOUNT_ID_SENDER.try_into().unwrap(),
                 account.id(),
                 &[fungible_asset_1],

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -233,7 +233,7 @@ impl FungibleAssetDelta {
         self.add_delta(asset.faucet_id(), -amount)
     }
 
-    /// Returns the fungible asset with the given faucet ID.
+    /// Returns the amount of the fungible asset with the given faucet ID.
     pub fn amount(&self, faucet_id: &AccountId) -> Option<i64> {
         self.0.get(faucet_id).copied()
     }

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -233,6 +233,11 @@ impl FungibleAssetDelta {
         self.add_delta(asset.faucet_id(), -amount)
     }
 
+    /// Returns the fungible asset with the given faucet ID.
+    pub fn amount(&self, faucet_id: &AccountId) -> Option<i64> {
+        self.0.get(faucet_id).copied()
+    }
+
     /// Returns the number of fungible assets affected in the delta.
     pub fn num_assets(&self) -> usize {
         self.0.len()

--- a/crates/miden-objects/src/batch/account_update.rs
+++ b/crates/miden-objects/src/batch/account_update.rs
@@ -47,6 +47,7 @@ impl BatchAccountUpdate {
     }
 
     /// Creates a [`BatchAccountUpdate`] from the provided parts without checking any consistency.
+    #[cfg(any(feature = "testing", test))]
     pub fn new_unchecked(
         account_id: AccountId,
         initial_state_commitment: Digest,

--- a/crates/miden-objects/src/batch/account_update.rs
+++ b/crates/miden-objects/src/batch/account_update.rs
@@ -46,6 +46,21 @@ impl BatchAccountUpdate {
         }
     }
 
+    /// Creates a [`BatchAccountUpdate`] from the provided parts without checking any consistency.
+    pub fn new_unchecked(
+        account_id: AccountId,
+        initial_state_commitment: Digest,
+        final_state_commitment: Digest,
+        details: AccountUpdateDetails,
+    ) -> Self {
+        Self {
+            account_id,
+            initial_state_commitment,
+            final_state_commitment,
+            details,
+        }
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/crates/miden-objects/src/batch/batch_id.rs
+++ b/crates/miden-objects/src/batch/batch_id.rs
@@ -29,7 +29,7 @@ impl BatchId {
     }
 
     /// Calculates a batch ID from the given transaction ID and account ID tuple.
-    pub fn from_ids(iter: impl Iterator<Item = (TransactionId, AccountId)>) -> Self {
+    pub fn from_ids(iter: impl IntoIterator<Item = (TransactionId, AccountId)>) -> Self {
         let mut elements: Vec<Felt> = Vec::new();
         for (tx_id, account_id) in iter {
             elements.extend_from_slice(tx_id.as_elements());

--- a/crates/miden-objects/src/block/blockchain.rs
+++ b/crates/miden-objects/src/block/blockchain.rs
@@ -60,6 +60,11 @@ impl Blockchain {
         Some(BlockNumber::from(self.num_blocks() - 1))
     }
 
+    /// Returns the chain commitment.
+    pub fn commitment(&self) -> Digest {
+        self.peaks().hash_peaks()
+    }
+
     /// Returns the current peaks of the MMR.
     pub fn peaks(&self) -> MmrPeaks {
         self.mmr.peaks()

--- a/crates/miden-objects/src/block/partial_nullifier_tree.rs
+++ b/crates/miden-objects/src/block/partial_nullifier_tree.rs
@@ -23,6 +23,24 @@ impl PartialNullifierTree {
         PartialNullifierTree(PartialSmt::new())
     }
 
+    /// Returns a new [`PartialNullifierTree`] instantiated with the provided entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the merkle paths of the witnesses do not result in the same tree root.
+    pub fn with_witnesses(
+        witnesses: impl IntoIterator<Item = NullifierWitness>,
+    ) -> Result<Self, NullifierTreeError> {
+        let mut tree = Self::new();
+
+        for witness in witnesses {
+            tree.track_nullifier(witness)?;
+        }
+
+        Ok(tree)
+    }
+
     /// Adds the given nullifier witness to the partial tree and tracks it. Once a nullifier has
     /// been added to the tree, it can be marked as spent using [`Self::mark_spent`].
     ///

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -139,45 +139,29 @@ impl ProvenBlock {
         &self.transactions
     }
 
+    /// Returns a mutable reference to the block's account updates for testing purposes.
     #[cfg(any(feature = "testing", test))]
     pub fn updated_accounts_mut(&mut self) -> &mut Vec<BlockAccountUpdate> {
         &mut self.updated_accounts
     }
 
+    /// Returns a mutable reference to the block's nullifiers for testing purposes.
     #[cfg(any(feature = "testing", test))]
     pub fn created_nullifiers_mut(&mut self) -> &mut Vec<Nullifier> {
         &mut self.created_nullifiers
     }
 
+    /// Returns a mutable reference to the block's output note batches for testing purposes.
     #[cfg(any(feature = "testing", test))]
     pub fn output_note_batches_mut(&mut self) -> &mut Vec<OutputNoteBatch> {
         &mut self.output_note_batches
     }
 
+    /// Sets the block's header for testing purposes.
     #[cfg(any(feature = "testing", test))]
     pub fn set_block_header(&mut self, header: BlockHeader) {
         self.header = header;
     }
-
-    // /// Consumes the block and returns its parts.
-    // pub fn into_parts(
-    //     self,
-    // ) -> (
-    //     BlockHeader,
-    //     Vec<BlockAccountUpdate>,
-    //     Vec<OutputNoteBatch>,
-    //     Vec<Nullifier>,
-    //     OrderedTransactionHeaders,
-    // ) {
-    //     let Self {
-    //         header,
-    //         updated_accounts,
-    //         output_note_batches,
-    //         created_nullifiers,
-    //         transactions,
-    //     } = self;
-    //     (header, updated_accounts, output_note_batches, created_nullifiers, transactions)
-    // }
 }
 
 impl Serializable for ProvenBlock {

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -138,31 +138,10 @@ impl ProvenBlock {
     pub fn transactions(&self) -> &OrderedTransactionHeaders {
         &self.transactions
     }
-
-    /// Returns a mutable reference to the block's account updates for testing purposes.
-    #[cfg(any(feature = "testing", test))]
-    pub fn updated_accounts_mut(&mut self) -> &mut Vec<BlockAccountUpdate> {
-        &mut self.updated_accounts
-    }
-
-    /// Returns a mutable reference to the block's nullifiers for testing purposes.
-    #[cfg(any(feature = "testing", test))]
-    pub fn created_nullifiers_mut(&mut self) -> &mut Vec<Nullifier> {
-        &mut self.created_nullifiers
-    }
-
-    /// Returns a mutable reference to the block's output note batches for testing purposes.
-    #[cfg(any(feature = "testing", test))]
-    pub fn output_note_batches_mut(&mut self) -> &mut Vec<OutputNoteBatch> {
-        &mut self.output_note_batches
-    }
-
-    /// Sets the block's header for testing purposes.
-    #[cfg(any(feature = "testing", test))]
-    pub fn set_block_header(&mut self, header: BlockHeader) {
-        self.header = header;
-    }
 }
+
+// SERIALIZATION
+// ================================================================================================
 
 impl Serializable for ProvenBlock {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -185,5 +164,31 @@ impl Deserializable for ProvenBlock {
         };
 
         Ok(block)
+    }
+}
+
+// TESTING
+// ================================================================================================
+
+#[cfg(any(feature = "testing", test))]
+impl ProvenBlock {
+    /// Returns a mutable reference to the block's account updates for testing purposes.
+    pub fn updated_accounts_mut(&mut self) -> &mut Vec<BlockAccountUpdate> {
+        &mut self.updated_accounts
+    }
+
+    /// Returns a mutable reference to the block's nullifiers for testing purposes.
+    pub fn created_nullifiers_mut(&mut self) -> &mut Vec<Nullifier> {
+        &mut self.created_nullifiers
+    }
+
+    /// Returns a mutable reference to the block's output note batches for testing purposes.
+    pub fn output_note_batches_mut(&mut self) -> &mut Vec<OutputNoteBatch> {
+        &mut self.output_note_batches
+    }
+
+    /// Sets the block's header for testing purposes.
+    pub fn set_block_header(&mut self, header: BlockHeader) {
+        self.header = header;
     }
 }

--- a/crates/miden-objects/src/block/proven_block.rs
+++ b/crates/miden-objects/src/block/proven_block.rs
@@ -138,6 +138,46 @@ impl ProvenBlock {
     pub fn transactions(&self) -> &OrderedTransactionHeaders {
         &self.transactions
     }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn updated_accounts_mut(&mut self) -> &mut Vec<BlockAccountUpdate> {
+        &mut self.updated_accounts
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn created_nullifiers_mut(&mut self) -> &mut Vec<Nullifier> {
+        &mut self.created_nullifiers
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn output_note_batches_mut(&mut self) -> &mut Vec<OutputNoteBatch> {
+        &mut self.output_note_batches
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_block_header(&mut self, header: BlockHeader) {
+        self.header = header;
+    }
+
+    // /// Consumes the block and returns its parts.
+    // pub fn into_parts(
+    //     self,
+    // ) -> (
+    //     BlockHeader,
+    //     Vec<BlockAccountUpdate>,
+    //     Vec<OutputNoteBatch>,
+    //     Vec<Nullifier>,
+    //     OrderedTransactionHeaders,
+    // ) {
+    //     let Self {
+    //         header,
+    //         updated_accounts,
+    //         output_note_batches,
+    //         created_nullifiers,
+    //         transactions,
+    //     } = self;
+    //     (header, updated_accounts, output_note_batches, created_nullifiers, transactions)
+    // }
 }
 
 impl Serializable for ProvenBlock {

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::error::Error;
 
 use assembly::{Report, diagnostics::reporting::PrintDiagnostic};
@@ -811,7 +807,7 @@ pub enum ProposedBlockError {
 
     #[error(
         "account {account_id} with state {state_commitment} cannot transition to any of the remaining states {}",
-        remaining_state_commitments.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+        remaining_state_commitments.iter().map(Digest::to_hex).collect::<Vec<_>>().join(", ")
     )]
     InconsistentAccountStateTransition {
         account_id: AccountId,

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -1,4 +1,8 @@
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::error::Error;
 
 use assembly::{Report, diagnostics::reporting::PrintDiagnostic};
@@ -806,7 +810,8 @@ pub enum ProposedBlockError {
     MissingAccountWitness(AccountId),
 
     #[error(
-        "account {account_id} with state {state_commitment} cannot transition to any of the remaining states {remaining_state_commitments:?}"
+        "account {account_id} with state {state_commitment} cannot transition to any of the remaining states {}",
+        remaining_state_commitments.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
     )]
     InconsistentAccountStateTransition {
         account_id: AccountId,

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -23,7 +23,7 @@ masm-debug = ["miden-lib/with-debug-info"]
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 async-trait = "0.1"
-miden-block-prover = { workspace = true, features = ["testing"]}
+miden-block-prover = { workspace = true, features = ["testing"] }
 miden-crypto = { workspace = true }
 miden-lib = { workspace = true, features = ["testing"] }
 miden-objects = { workspace = true, features = ["testing"] }

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -21,7 +21,9 @@ async = ["winter-maybe-async/async"]
 masm-debug = ["miden-lib/with-debug-info"]
 
 [dependencies]
+anyhow = { version = "1.0", default-features = false, features = ["backtrace"]}
 async-trait = "0.1"
+miden-block-prover = { workspace = true, features = ["testing"]}
 miden-crypto = { workspace = true }
 miden-lib = { workspace = true, features = ["testing"] }
 miden-objects = { workspace = true, features = ["testing"] }
@@ -30,16 +32,14 @@ rand_chacha = { version = "0.9", default-features = false }
 rand = { workspace = true }
 vm-processor = { workspace = true }
 winter-maybe-async = { version = "0.12" }
+winterfell = { version = "0.12" }
 
 [dev-dependencies]
-anyhow = { version = "1.0", default-features = false, features = [
-  "std",
-  "backtrace",
-] }
+anyhow = { version = "1.0", features = ["std"]}
 assembly = { workspace = true }
 assert_matches = { workspace = true }
-miden-block-prover = { workspace = true }
-winterfell = { version = "0.12" }
+rand = { workspace = true, features = ["os_rng", "small_rng"] }
+miden-objects = { workspace = true, features = ["std"] }
 
 [package.metadata.cargo-machete]
 # cargo machete flags async-trait as unused but it is used by winter-maybe-async with the async feature

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -21,7 +21,7 @@ async = ["winter-maybe-async/async"]
 masm-debug = ["miden-lib/with-debug-info"]
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false, features = ["backtrace"]}
+anyhow = { version = "1.0", default-features = false }
 async-trait = "0.1"
 miden-block-prover = { workspace = true, features = ["testing"]}
 miden-crypto = { workspace = true }
@@ -35,7 +35,7 @@ winter-maybe-async = { version = "0.12" }
 winterfell = { version = "0.12" }
 
 [dev-dependencies]
-anyhow = { version = "1.0", features = ["std"]}
+anyhow = { version = "1.0", features = ["std", "backtrace"] }
 assembly = { workspace = true }
 assert_matches = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "small_rng"] }

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -45,7 +45,7 @@ fn setup_chain() -> TestSetup {
     let mut chain = MockChain::new();
     let account1 = chain.add_new_wallet(Auth::NoAuth);
     let account2 = chain.add_new_wallet(Auth::NoAuth);
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     TestSetup { chain, account1, account2 }
 }
@@ -72,7 +72,7 @@ fn empty_transaction_batch() -> anyhow::Result<()> {
 fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_next_block();
+    let block2 = chain.prove_next_block();
 
     let note = mock_note(40);
     let tx1 =
@@ -145,7 +145,7 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_next_block();
+    let block2 = chain.prove_next_block();
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.commitment())
@@ -185,7 +185,7 @@ fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_next_block();
+    let block2 = chain.prove_next_block();
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Digest::default(), account1.commitment())
@@ -264,9 +264,9 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
     let note0 = chain.add_p2id_note(account2.id(), account1.id(), &[], NoteType::Private, None)?;
     let note1 = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     // The just created note will be provable against block2.
-    let block2 = chain.seal_next_block();
-    let block3 = chain.seal_next_block();
-    let block4 = chain.seal_next_block();
+    let block2 = chain.prove_next_block();
+    let block3 = chain.prove_next_block();
+    let block4 = chain.prove_next_block();
 
     // Consume the authenticated note as an unauthenticated one in the transaction.
     let tx1 =
@@ -372,7 +372,7 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
     let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
-    let block2 = chain.seal_next_block();
+    let block2 = chain.prove_next_block();
 
     let note0 = mock_note(50);
     let tx1 =

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -43,8 +43,8 @@ struct TestSetup {
 
 fn setup_chain() -> TestSetup {
     let mut chain = MockChain::new();
-    let account1 = chain.add_new_wallet(Auth::NoAuth);
-    let account2 = chain.add_new_wallet(Auth::NoAuth);
+    let account1 = chain.add_pending_new_wallet(Auth::NoAuth);
+    let account2 = chain.add_pending_new_wallet(Auth::NoAuth);
     chain.prove_next_block();
 
     TestSetup { chain, account1, account2 }
@@ -143,7 +143,8 @@ fn duplicate_unauthenticated_input_notes() -> anyhow::Result<()> {
 #[test]
 fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
-    let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
+    let note =
+        chain.add_pending_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
     let block2 = chain.prove_next_block();
 
@@ -183,7 +184,8 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
 #[test]
 fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
-    let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
+    let note =
+        chain.add_pending_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
     let block2 = chain.prove_next_block();
 
@@ -261,8 +263,10 @@ fn duplicate_output_notes() -> anyhow::Result<()> {
 #[test]
 fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
-    let note0 = chain.add_p2id_note(account2.id(), account1.id(), &[], NoteType::Private, None)?;
-    let note1 = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
+    let note0 =
+        chain.add_pending_p2id_note(account2.id(), account1.id(), &[], NoteType::Private, None)?;
+    let note1 =
+        chain.add_pending_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     // The just created note will be provable against block2.
     let block2 = chain.prove_next_block();
     let block3 = chain.prove_next_block();
@@ -370,7 +374,8 @@ fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()> {
 #[test]
 fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
     let TestSetup { mut chain, account1, account2 } = setup_chain();
-    let note = chain.add_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
+    let note =
+        chain.add_pending_p2id_note(account1.id(), account2.id(), &[], NoteType::Private, None)?;
     let block1 = chain.block_header(1);
     let block2 = chain.prove_next_block();
 

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -11,12 +11,13 @@ use miden_objects::{
 };
 
 use super::utils::{
-    ProvenTransactionExt, TestSetup, generate_account, generate_batch,
-    generate_executed_tx_with_authenticated_notes, generate_fungible_asset, generate_output_note,
-    generate_tracked_note, generate_tracked_note_with_asset, generate_tx_with_authenticated_notes,
+    TestSetup, generate_account, generate_batch, generate_executed_tx_with_authenticated_notes,
+    generate_fungible_asset, generate_output_note, generate_tracked_note,
+    generate_tracked_note_with_asset, generate_tx_with_authenticated_notes,
     generate_tx_with_expiration, generate_tx_with_unauthenticated_notes, generate_untracked_note,
     generate_untracked_note_with_output_note, setup_chain,
 };
+use crate::ProvenTransactionExt;
 
 /// Tests that too many batches produce an error.
 #[test]
@@ -475,7 +476,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.apply_executed_transaction(&transaction);
+    alternative_chain.submit_transaction(&transaction);
     alternative_chain.seal_next_block();
     let spent_proof = alternative_chain.nullifiers().open(&note0.nullifier());
 
@@ -594,7 +595,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx0);
+    alternative_chain.submit_transaction(&executed_tx0);
     alternative_chain.seal_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
@@ -602,7 +603,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note1.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx1);
+    alternative_chain.submit_transaction(&executed_tx1);
     alternative_chain.seal_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
@@ -610,15 +611,15 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note2.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx2);
+    alternative_chain.submit_transaction(&executed_tx2);
 
     // We will only include tx0 and tx2 and leave out tx1, which will trigger the error condition
     // that there is no transition from tx0 -> tx2.
-    let tx0 = ProvenTransaction::from_executed_transaction_mocked(
+    let tx0 = ProvenTransaction::from_executed_transaction_mocked_ref_block(
         executed_tx0.clone(),
         &chain.latest_block_header(),
     );
-    let tx2 = ProvenTransaction::from_executed_transaction_mocked(
+    let tx2 = ProvenTransaction::from_executed_transaction_mocked_ref_block(
         executed_tx2.clone(),
         &chain.latest_block_header(),
     );

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -478,7 +478,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
     );
     alternative_chain.add_pending_executed_transaction(&transaction);
     alternative_chain.prove_next_block();
-    let spent_proof = alternative_chain.nullifiers().open(&note0.nullifier());
+    let spent_proof = alternative_chain.nullifier_tree().open(&note0.nullifier());
 
     let batches = vec![batch0.clone()];
     let mut block_inputs = chain.get_block_inputs(&batches);

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -476,7 +476,7 @@ fn proposed_block_fails_on_spent_nullifier_witness() -> anyhow::Result<()> {
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.submit_transaction(&transaction);
+    alternative_chain.add_pending_executed_transaction(&transaction);
     alternative_chain.prove_next_block();
     let spent_proof = alternative_chain.nullifiers().open(&note0.nullifier());
 
@@ -595,7 +595,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx0);
+    alternative_chain.add_pending_executed_transaction(&executed_tx0);
     alternative_chain.prove_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
@@ -603,7 +603,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note1.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx1);
+    alternative_chain.add_pending_executed_transaction(&executed_tx1);
     alternative_chain.prove_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
@@ -611,7 +611,7 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
         account1.id(),
         &[note2.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx2);
+    alternative_chain.add_pending_executed_transaction(&executed_tx2);
 
     // We will only include tx0 and tx2 and leave out tx1, which will trigger the error condition
     // that there is no transition from tx0 -> tx2.

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -598,14 +598,8 @@ fn proposed_block_fails_on_inconsistent_account_state_transition() -> anyhow::Re
 
     // We will only include tx0 and tx2 and leave out tx1, which will trigger the error condition
     // that there is no transition from tx0 -> tx2.
-    let tx0 = ProvenTransaction::from_executed_transaction_mocked_ref_block(
-        executed_tx0.clone(),
-        &chain.latest_block_header(),
-    );
-    let tx2 = ProvenTransaction::from_executed_transaction_mocked_ref_block(
-        executed_tx2.clone(),
-        &chain.latest_block_header(),
-    );
+    let tx0 = ProvenTransaction::from_executed_transaction_mocked(executed_tx0.clone());
+    let tx2 = ProvenTransaction::from_executed_transaction_mocked(executed_tx2.clone());
 
     let batch0 = generate_batch(&mut chain, vec![tx0]);
     let batch1 = generate_batch(&mut chain, vec![tx2]);

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -129,7 +129,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx0);
+    alternative_chain.add_pending_executed_transaction(&executed_tx0);
     alternative_chain.prove_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
@@ -137,7 +137,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note1.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx1);
+    alternative_chain.add_pending_executed_transaction(&executed_tx1);
     alternative_chain.prove_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
@@ -145,7 +145,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note2.id()],
     );
-    alternative_chain.submit_transaction(&executed_tx2);
+    alternative_chain.add_pending_executed_transaction(&executed_tx2);
 
     let [tx0, tx1, tx2] = [executed_tx0, executed_tx1, executed_tx2]
         .into_iter()

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -119,33 +119,14 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
     chain.prove_next_block();
 
     // Create three transactions on the same account that build on top of each other.
-    // The MockChain only updates the account state when sealing a block, but we don't want the
-    // transactions to actually be added to the chain because of unintended side effects like spent
-    // nullifiers. So we create an alternative chain on which we generate the transactions, but
-    // then actually use the transactions on the original chain.
-    let mut alternative_chain = chain.clone();
-    let executed_tx0 = generate_executed_tx_with_authenticated_notes(
-        &mut alternative_chain,
-        account1.id(),
-        &[note0.id()],
-    );
-    alternative_chain.add_pending_executed_transaction(&executed_tx0);
-    alternative_chain.prove_next_block();
+    let executed_tx0 =
+        generate_executed_tx_with_authenticated_notes(&chain, account1.id(), &[note0.id()]);
 
-    let executed_tx1 = generate_executed_tx_with_authenticated_notes(
-        &mut alternative_chain,
-        account1.id(),
-        &[note1.id()],
-    );
-    alternative_chain.add_pending_executed_transaction(&executed_tx1);
-    alternative_chain.prove_next_block();
+    let executed_tx1 =
+        generate_executed_tx_with_authenticated_notes(&chain, executed_tx0.clone(), &[note1.id()]);
 
-    let executed_tx2 = generate_executed_tx_with_authenticated_notes(
-        &mut alternative_chain,
-        account1.id(),
-        &[note2.id()],
-    );
-    alternative_chain.add_pending_executed_transaction(&executed_tx2);
+    let executed_tx2 =
+        generate_executed_tx_with_authenticated_notes(&chain, executed_tx1.clone(), &[note2.id()]);
 
     let [tx0, tx1, tx2] = [executed_tx0, executed_tx1, executed_tx2]
         .into_iter()

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -115,7 +115,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
     let note2 = generate_tracked_note_with_asset(&mut chain, account0.id(), account1.id(), asset);
 
     // Add notes to the chain.
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     // Create three transactions on the same account that build on top of each other.
     // The MockChain only updates the account state when sealing a block, but we don't want the
@@ -129,7 +129,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         &[note0.id()],
     );
     alternative_chain.submit_transaction(&executed_tx0);
-    alternative_chain.seal_next_block();
+    alternative_chain.prove_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,
@@ -137,7 +137,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         &[note1.id()],
     );
     alternative_chain.submit_transaction(&executed_tx1);
-    alternative_chain.seal_next_block();
+    alternative_chain.prove_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
         &mut alternative_chain,
@@ -210,7 +210,7 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
 
     chain.add_pending_note(OutputNote::Full(note0.clone()));
     chain.add_pending_note(OutputNote::Full(note1.clone()));
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let batches = [batch0, batch1];
     // This block will use block2 as the reference block.
@@ -255,7 +255,7 @@ fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
     // sanity check: batch 1 should expire at block 3.
     assert_eq!(batch1.batch_expiration_block_num().as_u32(), 3);
 
-    let _block2 = chain.seal_next_block();
+    let _block2 = chain.prove_next_block();
 
     let batches = vec![batch0.clone(), batch1.clone()];
 

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -1,8 +1,9 @@
 use std::{collections::BTreeMap, vec::Vec};
 
 use anyhow::Context;
+use assert_matches::assert_matches;
 use miden_objects::{
-    account::AccountId,
+    account::{AccountId, delta::AccountUpdateDetails},
     block::{BlockInputs, ProposedBlock},
     testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     transaction::{OutputNote, ProvenTransaction, TransactionHeader},
@@ -184,7 +185,10 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         [tx2.id(), tx0.id(), tx1.id()]
     );
 
-    assert!(account_update.details().is_private());
+    assert_matches!(account_update.details(), AccountUpdateDetails::Delta(delta) => {
+        assert_eq!(delta.vault().fungible().num_assets(), 1);
+        assert_eq!(delta.vault().fungible().amount(&asset.unwrap_fungible().faucet_id()).unwrap(), 300);
+    });
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -130,12 +130,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
 
     let [tx0, tx1, tx2] = [executed_tx0, executed_tx1, executed_tx2]
         .into_iter()
-        .map(|tx| {
-            ProvenTransaction::from_executed_transaction_mocked_ref_block(
-                tx,
-                &chain.latest_block_header(),
-            )
-        })
+        .map(ProvenTransaction::from_executed_transaction_mocked)
         .collect::<Vec<_>>()
         .try_into()
         .expect("we should have provided three executed txs");

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -9,10 +9,11 @@ use miden_objects::{
 };
 
 use super::utils::{
-    ProvenTransactionExt, TestSetup, generate_batch, generate_executed_tx_with_authenticated_notes,
+    TestSetup, generate_batch, generate_executed_tx_with_authenticated_notes,
     generate_fungible_asset, generate_tracked_note_with_asset, generate_tx_with_expiration,
     generate_tx_with_unauthenticated_notes, generate_untracked_note, setup_chain,
 };
+use crate::ProvenTransactionExt;
 
 /// Tests that we can build empty blocks.
 #[test]
@@ -127,7 +128,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note0.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx0);
+    alternative_chain.submit_transaction(&executed_tx0);
     alternative_chain.seal_next_block();
 
     let executed_tx1 = generate_executed_tx_with_authenticated_notes(
@@ -135,7 +136,7 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note1.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx1);
+    alternative_chain.submit_transaction(&executed_tx1);
     alternative_chain.seal_next_block();
 
     let executed_tx2 = generate_executed_tx_with_authenticated_notes(
@@ -143,12 +144,15 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
         account1.id(),
         &[note2.id()],
     );
-    alternative_chain.apply_executed_transaction(&executed_tx2);
+    alternative_chain.submit_transaction(&executed_tx2);
 
     let [tx0, tx1, tx2] = [executed_tx0, executed_tx1, executed_tx2]
         .into_iter()
         .map(|tx| {
-            ProvenTransaction::from_executed_transaction_mocked(tx, &chain.latest_block_header())
+            ProvenTransaction::from_executed_transaction_mocked_ref_block(
+                tx,
+                &chain.latest_block_header(),
+            )
         })
         .collect::<Vec<_>>()
         .try_into()

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -57,7 +57,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     let nullifier_root0 = chain.nullifiers().root();
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
-    chain.submit_transaction(&tx0);
+    chain.add_pending_executed_transaction(&tx0);
     chain.prove_next_block();
 
     let valid_block_inputs = chain.get_block_inputs(&batches);

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -44,8 +44,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     // Add note to chain.
     chain.prove_next_block();
 
-    let tx0 =
-        generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note.id()]);
+    let tx0 = generate_executed_tx_with_authenticated_notes(&chain, account0.id(), &[note.id()]);
     let tx1 = txs.remove(&1).unwrap();
     let tx2 = txs.remove(&2).unwrap();
 

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -54,7 +54,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     let stale_block_inputs = chain.get_block_inputs(&batches);
 
     let account_root0 = chain.account_tree().root();
-    let nullifier_root0 = chain.nullifiers().root();
+    let nullifier_root0 = chain.nullifier_tree().root();
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
     chain.add_pending_executed_transaction(&tx0);
@@ -65,7 +65,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     // Sanity check: This test requires that the tree roots change with the last sealed block so the
     // previously fetched block inputs become invalid.
     assert_ne!(chain.account_tree().root(), account_root0);
-    assert_ne!(chain.nullifiers().root(), nullifier_root0);
+    assert_ne!(chain.nullifier_tree().root(), nullifier_root0);
 
     WitnessTestSetup {
         stale_block_inputs,

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -42,7 +42,7 @@ fn witness_test_setup() -> WitnessTestSetup {
 
     let note = generate_tracked_note(&mut chain, account1.id(), account0.id());
     // Add note to chain.
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let tx0 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note.id()]);
@@ -58,7 +58,7 @@ fn witness_test_setup() -> WitnessTestSetup {
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
     chain.submit_transaction(&tx0);
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let valid_block_inputs = chain.get_block_inputs(&batches);
 
@@ -299,7 +299,7 @@ fn proven_block_fails_on_creating_account_with_existing_account_id_prefix() -> a
     let existing_account =
         Account::mock(existing_id.into(), Felt::ZERO, TransactionKernel::testing_assembler());
     mock_chain.add_pending_account(existing_account.clone());
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // Execute the account-creating transaction.
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -20,10 +20,10 @@ use miden_objects::{
 use winterfell::Proof;
 
 use super::utils::{
-    ProvenTransactionExt, TestSetup, generate_batch, generate_executed_tx_with_authenticated_notes,
+    TestSetup, generate_batch, generate_executed_tx_with_authenticated_notes,
     generate_tracked_note, setup_chain,
 };
-use crate::{MockChain, TransactionContextBuilder};
+use crate::{MockChain, ProvenTransactionExt, TransactionContextBuilder};
 
 struct WitnessTestSetup {
     stale_block_inputs: BlockInputs,
@@ -57,7 +57,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     let nullifier_root0 = chain.nullifiers().root();
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
-    chain.apply_executed_transaction(&tx0);
+    chain.submit_transaction(&tx0);
     chain.seal_next_block();
 
     let valid_block_inputs = chain.get_block_inputs(&batches);
@@ -310,8 +310,7 @@ fn proven_block_fails_on_creating_account_with_existing_account_id_prefix() -> a
         .tx_inputs(tx_inputs)
         .build();
     let tx = tx_context.execute().context("failed to execute account creating tx")?;
-    let tx =
-        ProvenTransaction::from_executed_transaction_mocked(tx, &mock_chain.latest_block_header());
+    let tx = ProvenTransaction::from_executed_transaction_mocked(tx);
 
     let batch = generate_batch(&mut mock_chain, vec![tx]);
     let batches = [batch];

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -53,7 +53,7 @@ fn witness_test_setup() -> WitnessTestSetup {
     let batches = vec![batch1];
     let stale_block_inputs = chain.get_block_inputs(&batches);
 
-    let account_root0 = chain.accounts().root();
+    let account_root0 = chain.account_tree().root();
     let nullifier_root0 = chain.nullifiers().root();
 
     // Apply the executed tx and seal a block. This invalidates the block inputs we've just fetched.
@@ -64,7 +64,7 @@ fn witness_test_setup() -> WitnessTestSetup {
 
     // Sanity check: This test requires that the tree roots change with the last sealed block so the
     // previously fetched block inputs become invalid.
-    assert_ne!(chain.accounts().root(), account_root0);
+    assert_ne!(chain.account_tree().root(), account_root0);
     assert_ne!(chain.nullifiers().root(), nullifier_root0);
 
     WitnessTestSetup {
@@ -318,8 +318,11 @@ fn proven_block_fails_on_creating_account_with_existing_account_id_prefix() -> a
     let block_inputs = mock_chain.get_block_inputs(batches.iter());
     // Sanity check: The mock chain account tree root should match the previous block header's
     // account tree root.
-    assert_eq!(mock_chain.accounts().root(), block_inputs.prev_block_header().account_root());
-    assert_eq!(mock_chain.accounts().num_accounts(), 1);
+    assert_eq!(
+        mock_chain.account_tree().root(),
+        block_inputs.prev_block_header().account_root()
+    );
+    assert_eq!(mock_chain.account_tree().num_accounts(), 1);
 
     // Sanity check: The block inputs should contain an account witness whose ID matches the
     // existing ID.

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -350,8 +350,8 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     let tx1 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account1.id(), &[note1.id()]);
 
-    chain.submit_transaction(&tx0);
-    chain.submit_transaction(&tx1);
+    chain.add_pending_executed_transaction(&tx0);
+    chain.add_pending_executed_transaction(&tx1);
     let blockx = chain.prove_next_block();
 
     // Build a block with empty inputs whose account tree and nullifier tree root are not the empty

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -350,8 +350,8 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     let tx1 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account1.id(), &[note1.id()]);
 
-    chain.apply_executed_transaction(&tx0);
-    chain.apply_executed_transaction(&tx1);
+    chain.submit_transaction(&tx0);
+    chain.submit_transaction(&tx1);
     let blockx = chain.seal_next_block();
 
     // Build a block with empty inputs whose account tree and nullifier tree root are not the empty

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -345,10 +345,8 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     let note1 = generate_tracked_note(&mut chain, account0.id(), account1.id());
     chain.prove_next_block();
 
-    let tx0 =
-        generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);
-    let tx1 =
-        generate_executed_tx_with_authenticated_notes(&mut chain, account1.id(), &[note1.id()]);
+    let tx0 = generate_executed_tx_with_authenticated_notes(&chain, account0.id(), &[note0.id()]);
+    let tx1 = generate_executed_tx_with_authenticated_notes(&chain, account1.id(), &[note1.id()]);
 
     chain.add_pending_executed_transaction(&tx0);
     chain.add_pending_executed_transaction(&tx1);

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -47,7 +47,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     chain.add_pending_note(OutputNote::Full(input_note1.clone()));
     chain.add_pending_note(OutputNote::Full(input_note2.clone()));
     chain.add_pending_note(OutputNote::Full(input_note3.clone()));
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[input_note0.id()]);
     let tx1 = generate_tx_with_authenticated_notes(&mut chain, account1.id(), &[input_note1.id()]);
@@ -216,7 +216,7 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
     chain.add_pending_note(OutputNote::Full(note0.clone()));
     chain.add_pending_note(OutputNote::Full(note2.clone()));
     chain.add_pending_note(OutputNote::Full(note3.clone()));
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);
     let tx1 =
@@ -343,7 +343,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     // Add notes to the chain we can consume.
     let note0 = generate_tracked_note(&mut chain, account1.id(), account0.id());
     let note1 = generate_tracked_note(&mut chain, account0.id(), account1.id());
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     let tx0 =
         generate_executed_tx_with_authenticated_notes(&mut chain, account0.id(), &[note0.id()]);
@@ -352,7 +352,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
 
     chain.submit_transaction(&tx0);
     chain.submit_transaction(&tx1);
-    let blockx = chain.seal_next_block();
+    let blockx = chain.prove_next_block();
 
     // Build a block with empty inputs whose account tree and nullifier tree root are not the empty
     // roots.

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -93,7 +93,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     // Compute expected nullifier root on the full SMT.
     // --------------------------------------------------------------------------------------------
 
-    let mut expected_nullifier_tree = chain.nullifiers().clone();
+    let mut expected_nullifier_tree = chain.nullifier_tree().clone();
     for nullifier in proposed_block.created_nullifiers().keys() {
         expected_nullifier_tree
             .mark_spent(*nullifier, proposed_block.block_num())
@@ -129,7 +129,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     // PartialBlockchain with chain length 2 when the prev block (block2) is added.
     assert_eq!(
         proven_block.header().chain_commitment(),
-        chain.block_chain().peaks().hash_peaks()
+        chain.blockchain().peaks().hash_peaks()
     );
 
     assert_eq!(proven_block.header().note_root(), expected_block_note_tree.root());
@@ -400,7 +400,7 @@ fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     // The previous block header should have been added to the chain.
     assert_eq!(
         proven_block.header().chain_commitment(),
-        chain.block_chain().peaks().hash_peaks()
+        chain.blockchain().peaks().hash_peaks()
     );
     assert_eq!(proven_block.header().block_num(), latest_block_header.block_num() + 1);
 

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -103,7 +103,7 @@ fn proven_block_success() -> anyhow::Result<()> {
     // Compute expected account root on the full account tree.
     // --------------------------------------------------------------------------------------------
 
-    let mut expected_account_tree = chain.accounts().clone();
+    let mut expected_account_tree = chain.account_tree().clone();
     for (account_id, witness) in proposed_block.updated_accounts() {
         expected_account_tree
             .insert(*account_id, witness.final_state_commitment())

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -222,7 +222,7 @@ pub fn setup_chain(num_accounts: usize) -> TestSetup {
         notes.insert(i, note);
     }
 
-    chain.seal_next_block();
+    chain.prove_next_block();
 
     for i in 0..num_accounts {
         let tx =

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -29,7 +29,7 @@ pub fn generate_account(chain: &mut MockChain) -> Account {
         .with_component(
             AccountMockComponent::new_with_empty_slots(TransactionKernel::assembler()).unwrap(),
         );
-    chain.add_from_account_builder(Auth::NoAuth, account_builder, AccountState::Exists)
+    chain.add_pending_account_from_builder(Auth::NoAuth, account_builder, AccountState::Exists)
 }
 
 pub fn generate_tracked_note(

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -3,24 +3,19 @@ use std::{collections::BTreeMap, vec, vec::Vec};
 use miden_crypto::rand::RpoRandomCoin;
 use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{
-    self, Felt,
-    account::{Account, AccountId, delta::AccountUpdateDetails},
+    Felt,
+    account::{Account, AccountId},
     asset::{Asset, FungibleAsset},
     batch::ProvenBatch,
-    block::{BlockHeader, BlockNumber},
+    block::BlockNumber,
     note::{Note, NoteId, NoteTag, NoteType},
     testing::{account_component::AccountMockComponent, note::NoteBuilder},
-    transaction::{
-        ExecutedTransaction, OutputNote, ProvenTransaction, ProvenTransactionBuilder,
-        TransactionScript,
-    },
+    transaction::{ExecutedTransaction, OutputNote, ProvenTransaction, TransactionScript},
     utils::word_to_masm_push_string,
-    vm::ExecutionProof,
 };
 use rand::{Rng, SeedableRng, rngs::SmallRng};
-use winterfell::Proof;
 
-use crate::{AccountState, Auth, MockChain};
+use crate::{AccountState, Auth, MockChain, mock_chain::ProvenTransactionExt};
 
 pub struct TestSetup {
     pub chain: MockChain,
@@ -143,7 +138,7 @@ pub fn generate_tx_with_authenticated_notes(
     notes: &[NoteId],
 ) -> ProvenTransaction {
     let executed_tx = generate_executed_tx_with_authenticated_notes(chain, account_id, notes);
-    ProvenTransaction::from_executed_transaction_mocked(executed_tx, &chain.latest_block_header())
+    ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
 /// Generates a transaction that expires at the given block number.
@@ -161,7 +156,7 @@ pub fn generate_tx_with_expiration(
         .tx_script(authenticate_mock_account_tx_script(expiration_delta.as_u32() as u16))
         .build();
     let executed_tx = tx_context.execute().unwrap();
-    ProvenTransaction::from_executed_transaction_mocked(executed_tx, &chain.latest_block_header())
+    ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
 pub fn generate_tx_with_unauthenticated_notes(
@@ -174,7 +169,7 @@ pub fn generate_tx_with_unauthenticated_notes(
         .tx_script(authenticate_mock_account_tx_script(u16::MAX))
         .build();
     let executed_tx = tx_context.execute().unwrap();
-    ProvenTransaction::from_executed_transaction_mocked(executed_tx, &chain.latest_block_header())
+    ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
 fn authenticate_mock_account_tx_script(expiration_delta: u16) -> TransactionScript {
@@ -236,48 +231,4 @@ pub fn setup_chain(num_accounts: usize) -> TestSetup {
     }
 
     TestSetup { chain, accounts, txs }
-}
-
-pub trait ProvenTransactionExt {
-    fn from_executed_transaction_mocked(
-        executed_tx: ExecutedTransaction,
-        block_reference: &BlockHeader,
-    ) -> ProvenTransaction;
-}
-
-impl ProvenTransactionExt for ProvenTransaction {
-    fn from_executed_transaction_mocked(
-        executed_tx: ExecutedTransaction,
-        block_reference: &BlockHeader,
-    ) -> ProvenTransaction {
-        let account_delta = executed_tx.account_delta().clone();
-        let initial_account = executed_tx.initial_account().clone();
-        let account_update_details = if initial_account.is_public() {
-            if initial_account.is_new() {
-                let mut account = initial_account;
-                account.apply_delta(&account_delta).expect("account delta should be applyable");
-
-                AccountUpdateDetails::New(account)
-            } else {
-                AccountUpdateDetails::Delta(account_delta)
-            }
-        } else {
-            AccountUpdateDetails::Private
-        };
-
-        ProvenTransactionBuilder::new(
-            executed_tx.account_id(),
-            executed_tx.initial_account().init_commitment(),
-            executed_tx.final_account().commitment(),
-            block_reference.block_num(),
-            block_reference.commitment(),
-            executed_tx.expiration_block_num(),
-            ExecutionProof::new(Proof::new_dummy(), Default::default()),
-        )
-        .add_input_notes(executed_tx.input_notes())
-        .add_output_notes(executed_tx.output_notes().iter().cloned())
-        .account_update_details(account_update_details)
-        .build()
-        .unwrap()
-    }
 }

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -4,7 +4,7 @@ use miden_crypto::rand::RpoRandomCoin;
 use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{
     Felt,
-    account::{Account, AccountId},
+    account::{Account, AccountId, AccountStorageMode},
     asset::{Asset, FungibleAsset},
     batch::ProvenBatch,
     block::BlockNumber,
@@ -24,9 +24,11 @@ pub struct TestSetup {
 }
 
 pub fn generate_account(chain: &mut MockChain) -> Account {
-    let account_builder = Account::builder(rand::rng().random()).with_component(
-        AccountMockComponent::new_with_empty_slots(TransactionKernel::assembler()).unwrap(),
-    );
+    let account_builder = Account::builder(rand::rng().random())
+        .storage_mode(AccountStorageMode::Public)
+        .with_component(
+            AccountMockComponent::new_with_empty_slots(TransactionKernel::assembler()).unwrap(),
+        );
     chain.add_from_account_builder(Auth::NoAuth, account_builder, AccountState::Exists)
 }
 

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -15,7 +15,7 @@ use miden_objects::{
 };
 use rand::{Rng, SeedableRng, rngs::SmallRng};
 
-use crate::{AccountState, Auth, MockChain, mock_chain::ProvenTransactionExt};
+use crate::{AccountState, Auth, MockChain, TxContextInput, mock_chain::ProvenTransactionExt};
 
 pub struct TestSetup {
     pub chain: MockChain,
@@ -123,12 +123,12 @@ pub fn generate_fungible_asset(amount: u64, faucet_id: AccountId) -> Asset {
 }
 
 pub fn generate_executed_tx_with_authenticated_notes(
-    chain: &mut MockChain,
-    account: AccountId,
+    chain: &MockChain,
+    input: impl Into<TxContextInput>,
     notes: &[NoteId],
 ) -> ExecutedTransaction {
     let tx_context = chain
-        .build_tx_context(account, notes, &[])
+        .build_tx_context(input, notes, &[])
         .tx_script(authenticate_mock_account_tx_script(u16::MAX))
         .build();
     tx_context.execute().unwrap()

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -93,7 +93,7 @@ fn test_fpi_memory() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
     let fpi_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id());
 
     let tx_context = mock_chain
@@ -356,7 +356,7 @@ fn test_fpi_memory_two_accounts() {
         foreign_account_1.clone(),
         foreign_account_2.clone(),
     ]);
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
     let foreign_account_inputs_1 = mock_chain.get_foreign_account_inputs(foreign_account_1.id());
 
     let foreign_account_inputs_2 = mock_chain.get_foreign_account_inputs(foreign_account_2.id());
@@ -549,7 +549,7 @@ fn test_fpi_execute_foreign_procedure() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let code = format!(
         "
@@ -769,7 +769,7 @@ fn test_nested_fpi_cyclic_invocation() {
         first_foreign_account.clone(),
         second_foreign_account.clone(),
     ]);
-    mock_chain.seal_block(None, None);
+    mock_chain.prove_next_block();
     let foreign_account_inputs = vec![
         mock_chain.get_foreign_account_inputs(first_foreign_account.id()),
         mock_chain.get_foreign_account_inputs(second_foreign_account.id()),
@@ -955,7 +955,7 @@ fn test_nested_fpi_stack_overflow() {
                 &[vec![native_account.clone()], foreign_accounts.clone()].concat(),
             );
 
-            mock_chain.seal_block(None, None);
+            mock_chain.prove_next_block();
 
             let foreign_accounts: Vec<ForeignAccountInputs> = foreign_accounts
                 .iter()
@@ -1071,7 +1071,7 @@ fn test_nested_fpi_native_account_invocation() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_block(None, None);
+    mock_chain.prove_next_block();
     let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id());
 
     // push the hash of the native procedure and native account IDs to the advice stack to be able
@@ -1174,7 +1174,7 @@ fn test_fpi_stale_account() {
 
     let mut mock_chain =
         MockChain::with_accounts(&[native_account.clone(), foreign_account.clone()]);
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // Make the foreign account invalid.
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -1127,7 +1127,7 @@ fn test_nested_fpi_native_account_invocation() {
     let err = tx_context.execute().unwrap_err();
 
     let TransactionExecutorError::TransactionProgramExecutionFailed(err) = err else {
-        panic!("unexpected error")
+        panic!("unexpected error: {err}")
     };
 
     assert_execution_error!(Err::<(), _>(err), ERR_FOREIGN_ACCOUNT_CONTEXT_AGAINST_NATIVE_ACCOUNT);

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -618,7 +618,7 @@ fn test_build_note_metadata() {
 #[test]
 pub fn test_timelock() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    let account = mock_chain.add_existing_wallet(Auth::NoAuth, vec![]);
+    let account = mock_chain.add_pending_existing_wallet(Auth::NoAuth, vec![]);
     const TIMESTAMP_ERROR: u32 = 123;
 
     let code = format!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -1,5 +1,6 @@
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
+use anyhow::Context;
 use miden_lib::{
     errors::tx_kernel_errors::ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SENDER_FROM_INCORRECT_CONTEXT,
     transaction::{TransactionKernel, memory::CURRENT_INPUT_NOTE_PTR},
@@ -615,7 +616,7 @@ fn test_build_note_metadata() {
 
 /// This serves as a test that setting a custom timestamp on mock chain blocks works.
 #[test]
-pub fn test_timelock() {
+pub fn test_timelock() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
     let account = mock_chain.add_existing_wallet(Auth::NoAuth, vec![]);
     const TIMESTAMP_ERROR: u32 = 123;
@@ -656,7 +657,9 @@ pub fn test_timelock() {
         .unwrap();
 
     mock_chain.add_pending_note(OutputNote::Full(timelock_note.clone()));
-    mock_chain.seal_block(None, Some(lock_timestamp - 100));
+    mock_chain
+        .prove_next_block_at(lock_timestamp - 100)
+        .context("failed to prove next block at lock timestamp - 100")?;
 
     // Attempt to consume note too early.
     // ----------------------------------------------------------------------------------------
@@ -673,9 +676,14 @@ pub fn test_timelock() {
 
     // Consume note where lock timestamp matches the block timestamp.
     // ----------------------------------------------------------------------------------------
-    mock_chain.seal_block(None, Some(lock_timestamp));
+    mock_chain
+        .prove_next_block_at(lock_timestamp)
+        .context("failed to prove next block at lock timestamp")?;
+
     let tx_inputs =
         mock_chain.get_transaction_inputs(account.clone(), None, &[timelock_note.id()], &[]);
     let tx_context = TransactionContextBuilder::new(account).tx_inputs(tx_inputs).build();
     tx_context.execute().unwrap();
+
+    Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -499,7 +499,7 @@ pub fn create_accounts_with_anchor_block_zero() -> anyhow::Result<()> {
 
     // Seal one more block to test the case where the transaction reference block is not the anchor
     // block.
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     create_multiple_accounts_test(&mock_chain, &genesis_block_header, AccountStorageMode::Public)
 }
@@ -511,7 +511,9 @@ pub fn create_accounts_with_anchor_block_zero() -> anyhow::Result<()> {
 #[test]
 pub fn create_accounts_with_non_zero_anchor_block() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(Some(1 << 16), None);
+    mock_chain
+        .prove_until_block(1u32 << 16)
+        .context("failed to prove multiple blocks")?;
 
     // Choose epoch block 1 whose block number is 2^16 as the anchor block.
     // Here the transaction reference block is also the anchor block.
@@ -521,7 +523,7 @@ pub fn create_accounts_with_non_zero_anchor_block() -> anyhow::Result<()> {
 
     // Seal one more block to test the case where the transaction reference block is not the anchor
     // block.
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     create_multiple_accounts_test(&mock_chain, &epoch1_block_header, AccountStorageMode::Public)
 }
@@ -567,7 +569,7 @@ fn compute_valid_account_id(
 #[test]
 pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
@@ -591,7 +593,7 @@ pub fn create_account_fungible_faucet_invalid_initial_balance() -> anyhow::Resul
 #[test]
 pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 
@@ -617,7 +619,7 @@ pub fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() -> any
 #[test]
 pub fn create_account_invalid_seed() {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let genesis_block_header = mock_chain.block_header(BlockNumber::GENESIS.as_usize());
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -236,11 +236,15 @@ fn partial_blockchain_memory_assertions(process: &Process, prepared_tx: &Transac
 
     for (i, peak) in partial_blockchain.peaks().peaks().iter().enumerate() {
         // The peaks should be stored at the PARTIAL_BLOCKCHAIN_PEAKS_PTR
-        let i: u32 = i.try_into().expect(
+        let peak_idx: u32 = i.try_into().expect(
             "Number of peaks is log2(number_of_leaves), this value won't be larger than 2**32",
         );
+        let word_aligned_peak_idx = peak_idx * 4;
         assert_eq!(
-            read_root_mem_word(&process.into(), PARTIAL_BLOCKCHAIN_PEAKS_PTR + i),
+            read_root_mem_word(
+                &process.into(),
+                PARTIAL_BLOCKCHAIN_PEAKS_PTR + word_aligned_peak_idx
+            ),
             Word::from(peak)
         );
     }

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -46,14 +46,14 @@ use crate::{
 fn test_fpi_anchoring_validations() {
     // Create a chain with an account
     let mut mock_chain = MockChain::new();
-    let account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
     mock_chain.prove_next_block();
 
     // Retrieve inputs which will become stale
     let inputs = mock_chain.get_foreign_account_inputs(account.id());
 
     // Add account to modify account tree
-    let new_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let new_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
     mock_chain.prove_next_block();
 
     // Attempt to execute with older foreign account inputs
@@ -73,12 +73,12 @@ fn test_fpi_anchoring_validations() {
 fn test_future_input_note_fails() -> anyhow::Result<()> {
     // Create a chain with an account
     let mut mock_chain = MockChain::new();
-    let account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
     mock_chain.prove_until_block(10u32)?;
 
     // Create note that will land on a future block
     let note = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             account.id(),
             ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
             &[],

--- a/crates/miden-testing/src/lib.rs
+++ b/crates/miden-testing/src/lib.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate alloc;
 
-// TODO #[cfg(test)]
+#[cfg(test)]
 extern crate std;
 
 mod mock_chain;

--- a/crates/miden-testing/src/lib.rs
+++ b/crates/miden-testing/src/lib.rs
@@ -7,7 +7,9 @@ extern crate alloc;
 extern crate std;
 
 mod mock_chain;
-pub use mock_chain::{AccountState, Auth, MockChain, MockChainNote, MockFungibleFaucet};
+pub use mock_chain::{
+    AccountState, Auth, MockChain, MockChainNote, MockFungibleFaucet, ProvenTransactionExt,
+};
 
 mod tx_context;
 pub use tx_context::{TransactionContext, TransactionContextBuilder};

--- a/crates/miden-testing/src/lib.rs
+++ b/crates/miden-testing/src/lib.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(test)]
+// TODO #[cfg(test)]
 extern crate std;
 
 mod mock_chain;

--- a/crates/miden-testing/src/lib.rs
+++ b/crates/miden-testing/src/lib.rs
@@ -9,6 +9,7 @@ extern crate std;
 mod mock_chain;
 pub use mock_chain::{
     AccountState, Auth, MockChain, MockChainNote, MockFungibleFaucet, ProvenTransactionExt,
+    TxContextInput,
 };
 
 mod tx_context;

--- a/crates/miden-testing/src/mock_chain/account.rs
+++ b/crates/miden-testing/src/mock_chain/account.rs
@@ -41,7 +41,7 @@ impl MockAccount {
         self.seed.as_ref()
     }
 
-    pub fn authenticator(&self) -> &Option<BasicAuthenticator<ChaCha20Rng>> {
-        &self.authenticator
+    pub fn authenticator(&self) -> Option<&BasicAuthenticator<ChaCha20Rng>> {
+        self.authenticator.as_ref()
     }
 }

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -29,7 +29,7 @@ use miden_objects::{
     transaction::{
         ExecutedTransaction, ForeignAccountInputs, InputNote, InputNotes,
         OrderedTransactionHeaders, OutputNote, PartialBlockchain, ProvenTransaction,
-        TransactionHeader, TransactionId, TransactionInputs, TransactionScript,
+        TransactionHeader, TransactionInputs, TransactionScript,
     },
 };
 use rand::{Rng, SeedableRng};
@@ -56,10 +56,6 @@ struct PendingObjects {
 
     /// Nullifiers produced in transactions in the block.
     created_nullifiers: Vec<Nullifier>,
-
-    /// Transaction IDs added to the block.
-    /// TODO: Remove or use in pending objects batch.
-    included_transactions: Vec<(TransactionId, AccountId)>,
 }
 
 impl PendingObjects {
@@ -68,7 +64,6 @@ impl PendingObjects {
             updated_accounts: BTreeMap::new(),
             output_notes: vec![],
             created_nullifiers: vec![],
-            included_transactions: vec![],
         }
     }
 
@@ -77,7 +72,6 @@ impl PendingObjects {
         self.updated_accounts.is_empty()
             && self.output_notes.is_empty()
             && self.created_nullifiers.is_empty()
-            && self.included_transactions.is_empty()
     }
 }
 

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -922,6 +922,7 @@ impl MockChain {
 
         self.committed_accounts
             .insert(account.id(), MockAccount::new(account.clone(), None, authenticator));
+        self.add_pending_account(account.clone());
 
         MockFungibleFaucet::new(account)
     }

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -42,39 +42,6 @@ use crate::{
     mock_chain::account::MockAccount,
 };
 
-// PENDING OBJECTS
-// ================================================================================================
-
-/// Aggregates all entities that were added to the blockchain in the last block (not yet finalized)
-#[derive(Default, Debug, Clone)]
-struct PendingObjects {
-    /// Account updates for the block.
-    updated_accounts: BTreeMap<AccountId, BlockAccountUpdate>,
-
-    /// Note batches created in transactions in the block.
-    output_notes: Vec<OutputNote>,
-
-    /// Nullifiers produced in transactions in the block.
-    created_nullifiers: Vec<Nullifier>,
-}
-
-impl PendingObjects {
-    pub fn new() -> PendingObjects {
-        PendingObjects {
-            updated_accounts: BTreeMap::new(),
-            output_notes: vec![],
-            created_nullifiers: vec![],
-        }
-    }
-
-    /// Returns `true` if there are no pending objects, `false` otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.updated_accounts.is_empty()
-            && self.output_notes.is_empty()
-            && self.created_nullifiers.is_empty()
-    }
-}
-
 // MOCK CHAIN
 // ================================================================================================
 
@@ -1354,7 +1321,40 @@ impl Default for MockChain {
     }
 }
 
-// HELPER TYPES
+// PENDING OBJECTS
+// ================================================================================================
+
+/// Aggregates all entities that were added using the _pending_ APIs of the [`MockChain`].
+#[derive(Default, Debug, Clone)]
+struct PendingObjects {
+    /// Account updates for the block.
+    updated_accounts: BTreeMap<AccountId, BlockAccountUpdate>,
+
+    /// Note batches created in transactions in the block.
+    output_notes: Vec<OutputNote>,
+
+    /// Nullifiers produced in transactions in the block.
+    created_nullifiers: Vec<Nullifier>,
+}
+
+impl PendingObjects {
+    pub fn new() -> PendingObjects {
+        PendingObjects {
+            updated_accounts: BTreeMap::new(),
+            output_notes: vec![],
+            created_nullifiers: vec![],
+        }
+    }
+
+    /// Returns `true` if there are no pending objects, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.updated_accounts.is_empty()
+            && self.output_notes.is_empty()
+            && self.created_nullifiers.is_empty()
+    }
+}
+
+// ACCOUNT STATE
 // ================================================================================================
 
 /// Helper type for increased readability at call-sites. Indicates whether to build a new (nonce =
@@ -1363,6 +1363,9 @@ pub enum AccountState {
     New,
     Exists,
 }
+
+// TX CONTEXT INPUT
+// ================================================================================================
 
 /// Helper type to abstract over the inputs to [`MockChain::build_tx_context`]. See that method's
 /// docs for details.

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -79,28 +79,6 @@ impl PendingObjects {
             && self.created_nullifiers.is_empty()
             && self.included_transactions.is_empty()
     }
-
-    // /// Creates a [BlockNoteTree] tree from the `notes`.
-    // ///
-    // /// The root of the tree is a commitment to all notes created in the block. The commitment
-    // /// is not for all fields of the [Note] struct, but only for note metadata + core fields of
-    // /// a note (i.e., vault, inputs, script, and serial number).
-    // pub fn build_notes_tree(&self) -> BlockNoteTree {
-    //     let entries =
-    //         self.output_note_batches.iter().enumerate().flat_map(|(batch_index, batch)| {
-    //             batch.iter().map(move |(note_index, note)| {
-    //                 (
-    //                     BlockNoteIndex::new(batch_index, *note_index).expect(
-    //                         "max batches in block and max notes in batches should be enforced",
-    //                     ),
-    //                     note.id(),
-    //                     *note.metadata(),
-    //                 )
-    //             })
-    //         });
-
-    //     BlockNoteTree::with_entries(entries).unwrap()
-    // }
 }
 
 // MOCK CHAIN

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -724,7 +724,7 @@ impl MockChain {
         );
 
         let mut last_block = None;
-        for _ in latest_block_num.as_usize()..=target_block_num.as_usize() {
+        for _ in latest_block_num.as_usize()..target_block_num.as_usize() {
             last_block = Some(self.prove_next_block());
         }
 
@@ -1433,5 +1433,15 @@ mod tests {
             tx_context.tx_inputs().block_header().account_root(),
             mock_chain.account_tree.root()
         );
+    }
+
+    #[test]
+    fn prove_until_block() -> anyhow::Result<()> {
+        let mut chain = MockChain::new();
+        let block = chain.prove_until_block(5)?;
+        assert_eq!(block.header().block_num(), 5u32.into());
+        assert_eq!(chain.proven_blocks().len(), 6);
+
+        Ok(())
     }
 }

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -11,7 +11,8 @@ use miden_lib::{
     transaction::{TransactionKernel, memory},
 };
 use miden_objects::{
-    NoteError, ProposedBatchError, ProposedBlockError,
+    MAX_BATCHES_PER_BLOCK, MAX_OUTPUT_NOTES_PER_BATCH, NoteError, ProposedBatchError,
+    ProposedBlockError,
     account::{
         Account, AccountBuilder, AccountHeader, AccountId, AccountIdAnchor, AccountType,
         StorageSlot, delta::AccountUpdateDetails,
@@ -19,9 +20,8 @@ use miden_objects::{
     asset::{Asset, TokenSymbol},
     batch::{ProposedBatch, ProvenBatch},
     block::{
-        AccountTree, AccountWitness, BlockAccountUpdate, BlockHeader, BlockInputs, BlockNoteIndex,
-        BlockNoteTree, BlockNumber, Blockchain, NullifierTree, NullifierWitness, OutputNoteBatch,
-        ProposedBlock, ProvenBlock,
+        AccountTree, AccountWitness, BlockAccountUpdate, Blockchain, BlockHeader, BlockInputs,
+        BlockNoteTree, BlockNumber, NullifierTree, NullifierWitness, ProposedBlock, ProvenBlock,
     },
     crypto::merkle::SmtProof,
     note::{Note, NoteHeader, NoteId, NoteInclusionProof, NoteType, Nullifier},
@@ -29,8 +29,7 @@ use miden_objects::{
     transaction::{
         ExecutedTransaction, ForeignAccountInputs, InputNote, InputNotes,
         OrderedTransactionHeaders, OutputNote, PartialBlockchain, ProvenTransaction,
-        ToInputNoteCommitments, TransactionHeader, TransactionId, TransactionInputs,
-        TransactionScript,
+        TransactionHeader, TransactionId, TransactionInputs, TransactionScript,
     },
 };
 use rand::{Rng, SeedableRng};
@@ -50,49 +49,58 @@ use crate::{
 #[derive(Default, Debug, Clone)]
 struct PendingObjects {
     /// Account updates for the block.
-    updated_accounts: Vec<BlockAccountUpdate>,
+    updated_accounts: BTreeMap<AccountId, BlockAccountUpdate>,
 
     /// Note batches created in transactions in the block.
-    output_note_batches: Vec<OutputNoteBatch>,
+    output_notes: Vec<OutputNote>,
 
     /// Nullifiers produced in transactions in the block.
     created_nullifiers: Vec<Nullifier>,
 
     /// Transaction IDs added to the block.
+    /// TODO: Remove or use in pending objects batch.
     included_transactions: Vec<(TransactionId, AccountId)>,
 }
 
 impl PendingObjects {
     pub fn new() -> PendingObjects {
         PendingObjects {
-            updated_accounts: vec![],
-            output_note_batches: vec![],
+            updated_accounts: BTreeMap::new(),
+            output_notes: vec![],
             created_nullifiers: vec![],
             included_transactions: vec![],
         }
     }
 
-    /// Creates a [BlockNoteTree] tree from the `notes`.
-    ///
-    /// The root of the tree is a commitment to all notes created in the block. The commitment
-    /// is not for all fields of the [Note] struct, but only for note metadata + core fields of
-    /// a note (i.e., vault, inputs, script, and serial number).
-    pub fn build_notes_tree(&self) -> BlockNoteTree {
-        let entries =
-            self.output_note_batches.iter().enumerate().flat_map(|(batch_index, batch)| {
-                batch.iter().map(move |(note_index, note)| {
-                    (
-                        BlockNoteIndex::new(batch_index, *note_index).expect(
-                            "max batches in block and max notes in batches should be enforced",
-                        ),
-                        note.id(),
-                        *note.metadata(),
-                    )
-                })
-            });
-
-        BlockNoteTree::with_entries(entries).unwrap()
+    /// Returns `true` if there are no pending objects, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.updated_accounts.is_empty()
+            && self.output_notes.is_empty()
+            && self.created_nullifiers.is_empty()
+            && self.included_transactions.is_empty()
     }
+
+    // /// Creates a [BlockNoteTree] tree from the `notes`.
+    // ///
+    // /// The root of the tree is a commitment to all notes created in the block. The commitment
+    // /// is not for all fields of the [Note] struct, but only for note metadata + core fields of
+    // /// a note (i.e., vault, inputs, script, and serial number).
+    // pub fn build_notes_tree(&self) -> BlockNoteTree {
+    //     let entries =
+    //         self.output_note_batches.iter().enumerate().flat_map(|(batch_index, batch)| {
+    //             batch.iter().map(move |(note_index, note)| {
+    //                 (
+    //                     BlockNoteIndex::new(batch_index, *note_index).expect(
+    //                         "max batches in block and max notes in batches should be enforced",
+    //                     ),
+    //                     note.id(),
+    //                     *note.metadata(),
+    //                 )
+    //             })
+    //         });
+
+    //     BlockNoteTree::with_entries(entries).unwrap()
+    // }
 }
 
 // MOCK CHAIN
@@ -161,7 +169,7 @@ pub struct MockChain {
     blocks: Vec<ProvenBlock>,
 
     /// Tree containing the latest `Nullifier`'s tree.
-    nullifiers: NullifierTree,
+    nullifier_tree: NullifierTree,
 
     /// Tree containing the latest state commitment of each account.
     account_tree: AccountTree,
@@ -183,26 +191,7 @@ pub struct MockChain {
     /// AccountId |-> Account mapping to simplify transaction creation
     available_accounts: BTreeMap<AccountId, MockAccount>,
 
-    removed_notes: Vec<NoteId>,
-
     rng: ChaCha20Rng, // RNG field
-}
-
-impl Default for MockChain {
-    fn default() -> Self {
-        MockChain {
-            chain: Blockchain::default(),
-            blocks: vec![],
-            nullifiers: NullifierTree::default(),
-            account_tree: AccountTree::new(),
-            pending_objects: PendingObjects::new(),
-            pending_transactions: Vec::new(),
-            available_notes: BTreeMap::new(),
-            available_accounts: BTreeMap::new(),
-            removed_notes: vec![],
-            rng: ChaCha20Rng::from_seed(Default::default()), // Initialize RNG with default seed
-        }
-    }
 }
 
 impl MockChain {
@@ -220,28 +209,33 @@ impl MockChain {
     // CONSTRUCTORS
     // ----------------------------------------------------------------------------------------
 
-    /// Creates a new `MockChain`.
-    pub fn empty() -> Self {
-        MockChain::default()
-    }
-
-    /// Creates a new `MockChain` with two blocks.
+    /// Creates a new `MockChain` with an empty genesis block.
     pub fn new() -> Self {
-        let mut chain = MockChain::default();
-        chain.seal_next_block();
-        chain
+        Self::with_accounts(&[])
     }
 
-    /// Creates a new `MockChain` with two blocks and accounts in the genesis block.
+    /// Creates a new `MockChain` with a genesis block containing the provided accounts.
     pub fn with_accounts(accounts: &[Account]) -> Self {
-        let mut chain = MockChain::default();
-        for account in accounts {
-            chain.add_pending_account(account.clone());
-            chain
-                .available_accounts
-                .insert(account.id(), MockAccount::new(account.clone(), None, None));
-        }
-        chain.seal_next_block();
+        let genesis_block = create_genesis_block(accounts.iter().cloned());
+
+        let mut chain = MockChain {
+            chain: Blockchain::default(),
+            blocks: vec![],
+            nullifier_tree: NullifierTree::default(),
+            account_tree: AccountTree::new(),
+            pending_objects: PendingObjects::new(),
+            pending_transactions: Vec::new(),
+            available_notes: BTreeMap::new(),
+            available_accounts: BTreeMap::new(),
+            // Initialize RNG with default seed.
+            rng: ChaCha20Rng::from_seed(Default::default()),
+        };
+
+        chain
+            .apply_block(genesis_block)
+            .context("failed to apply genesis block")
+            .unwrap();
+
         chain
     }
 
@@ -256,38 +250,40 @@ impl MockChain {
         let mut account = transaction.initial_account().clone();
         account.apply_delta(transaction.account_delta()).unwrap();
 
-        // disregard private accounts, so it's easier to retrieve data
-        let account_update_details = AccountUpdateDetails::New(account.clone());
-
-        let block_account_update = BlockAccountUpdate::new(
-            transaction.account_id(),
-            account.commitment(),
-            account_update_details,
-        );
-        self.pending_objects.updated_accounts.push(block_account_update);
-
-        for note in transaction.input_notes().iter() {
-            // TODO: check that nullifiers are not duplicate
-            self.pending_objects.created_nullifiers.push(note.nullifier());
-            self.removed_notes.push(note.id());
-        }
-
-        // TODO: check that notes are not duplicate
-        let output_notes: Vec<OutputNote> = transaction.output_notes().iter().cloned().collect();
-        self.pending_objects
-            .output_note_batches
-            .push(output_notes.into_iter().enumerate().collect());
-        self.pending_objects
-            .included_transactions
-            .push((transaction.id(), transaction.account_id()));
+        self.pending_transactions.push(transaction.clone());
 
         account
+
+        // disregard private accounts, so it's easier to retrieve data
+        // let account_update_details = AccountUpdateDetails::New(account.clone());
+
+        // let block_account_update = BatchAccountUpdate::new(
+        //     transaction.account_id(),
+        //     account.commitment(),
+        //     account_update_details,
+        // );
+        // self.pending_objects.updated_accounts.push(block_account_update);
+
+        // for note in transaction.input_notes().iter() {
+        //     // TODO: check that nullifiers are not duplicate
+        //     self.pending_objects.created_nullifiers.push(note.nullifier());
+        //     self.removed_notes.push(note.id());
+        // }
+
+        // TODO: check that notes are not duplicate
+        // let output_notes: Vec<OutputNote> = transaction.output_notes().iter().cloned().collect();
+        // self.pending_objects
+        //     .output_note_batches
+        //     .push(output_notes.into_iter().enumerate().collect());
+        // self.pending_objects
+        //     .included_transactions
+        //     .push((transaction.id(), transaction.account_id()));
     }
 
     /// Adds an [OutputNote] to the pending objects.
     /// A block has to be created to finalize the new entity.
     pub fn add_pending_note(&mut self, note: OutputNote) {
-        self.pending_objects.output_note_batches.push(vec![(0, note)]);
+        self.pending_objects.output_notes.push(note);
     }
 
     /// Adds a P2ID [Note] to the pending objects and returns it.
@@ -397,7 +393,26 @@ impl MockChain {
             batch_expiration_block_num,
             tx_headers,
         )
-        .expect("Failed to create ProvenBatch")
+        .expect("failed to create ProvenBatch")
+    }
+
+    /// Proposes a new block from the provided batches with the given timestamp and returns it.
+    ///
+    /// This method does not modify the chain state.
+    pub fn propose_block_at<I>(
+        &self,
+        batches: impl IntoIterator<Item = ProvenBatch, IntoIter = I>,
+        timestamp: u32,
+    ) -> Result<ProposedBlock, ProposedBlockError>
+    where
+        I: Iterator<Item = ProvenBatch> + Clone,
+    {
+        let batches: Vec<_> = batches.into_iter().collect();
+        let block_inputs = self.get_block_inputs(batches.iter());
+
+        let proposed_block = ProposedBlock::new_at(block_inputs, batches, timestamp)?;
+
+        Ok(proposed_block)
     }
 
     /// Proposes a new block from the provided batches and returns it.
@@ -410,15 +425,11 @@ impl MockChain {
     where
         I: Iterator<Item = ProvenBatch> + Clone,
     {
-        let batches: Vec<_> = batches.into_iter().collect();
-        let block_inputs = self.get_block_inputs(batches.iter());
         // We can't access system time because the testing feature does not depend on std at this
         // time. So we use the minimally correct next timestamp.
-        let timestamp = block_inputs.prev_block_header().timestamp() + 1;
+        let timestamp = self.latest_block_header().timestamp() + 1;
 
-        let proposed_block = ProposedBlock::new_at(block_inputs, batches, timestamp)?;
-
-        Ok(proposed_block)
+        self.propose_block_at(batches, timestamp)
     }
 
     pub fn prove_block(&self, proposed_block: ProposedBlock) -> anyhow::Result<ProvenBlock> {
@@ -535,12 +546,7 @@ impl MockChain {
         };
 
         let (account, seed) = if let AccountState::New = account_state {
-            let epoch_block_number = self
-                .blocks
-                .last()
-                .expect("one block should always exist")
-                .header()
-                .epoch_block_num();
+            let epoch_block_number = self.latest_block_header().epoch_block_num();
             let account_id_anchor =
                 self.blocks.get(epoch_block_number.as_usize()).unwrap().header();
             account_builder =
@@ -551,21 +557,27 @@ impl MockChain {
             account_builder.build_existing().map(|account| (account, None)).unwrap()
         };
 
+        // TODO: Check if this is necessary or if we can remove it.
         self.available_accounts
             .insert(account.id(), MockAccount::new(account.clone(), seed, authenticator));
-        self.account_tree.insert(account.id(), account.commitment()).unwrap();
+        // self.account_tree.insert(account.id(), account.commitment()).unwrap();
+        self.add_pending_account(account.clone());
 
         account
     }
 
     /// Adds a new `Account` to the list of pending objects.
+    ///
     /// A block has to be created to finalize the new entity.
     pub fn add_pending_account(&mut self, account: Account) {
-        self.pending_objects.updated_accounts.push(BlockAccountUpdate::new(
+        self.pending_objects.updated_accounts.insert(
             account.id(),
-            account.commitment(),
-            AccountUpdateDetails::New(account),
-        ));
+            BlockAccountUpdate::new(
+                account.id(),
+                account.commitment(),
+                AccountUpdateDetails::New(account),
+            ),
+        );
     }
 
     /// Initializes a [TransactionContextBuilder].
@@ -759,8 +771,41 @@ impl MockChain {
     /// Creates the next block in the mock chain.
     ///
     /// This will make all the objects currently pending available for use.
-    pub fn seal_next_block(&mut self) -> ProvenBlock {
-        self.seal_block(None, None)
+    pub fn prove_next_block(&mut self) -> ProvenBlock {
+        self.prove_block_inner(None).unwrap()
+    }
+
+    /// Proves the next block in the mock chain at the given timestamp.
+    pub fn prove_next_block_at(&mut self, timestamp: u32) -> anyhow::Result<ProvenBlock> {
+        self.prove_block_inner(Some(timestamp))
+    }
+
+    /// Proves new blocks until the block with the given target block number has been created.
+    ///
+    /// For example, if the latest block is `5` and this function is called with `10`, then blocks
+    /// `6..=10` will be created and block 10 will be returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - the given block number is smaller or equal to the number of the latest block in the chain.
+    pub fn prove_until_block(
+        &mut self,
+        target_block_num: impl Into<BlockNumber>,
+    ) -> anyhow::Result<ProvenBlock> {
+        let target_block_num = target_block_num.into();
+        let latest_block_num = self.latest_block_header().block_num();
+        assert!(
+            target_block_num > latest_block_num,
+            "target block number must be greater than the number of the latest block in the chain"
+        );
+
+        let mut last_block = None;
+        for _ in latest_block_num.as_usize()..=target_block_num.as_usize() {
+            last_block = Some(self.prove_next_block());
+        }
+
+        Ok(last_block.expect("at least one block should have been created"))
     }
 
     /// Creates a new block in the mock chain.
@@ -771,174 +816,368 @@ impl MockChain {
     /// block up to and including `block_num` will be created.
     ///
     /// If a `timestamp` is provided, it will be set on the block with `block_num`.
-    pub fn seal_block(&mut self, block_num: Option<u32>, timestamp: Option<u32>) -> ProvenBlock {
-        let next_block_num =
-            self.blocks.last().map_or(0, |b| b.header().block_num().child().as_u32());
+    fn prove_block_inner(&mut self, timestamp: Option<u32>) -> anyhow::Result<ProvenBlock> {
+        // Create batches.
+        // ----------------------------------------------------------------------------------------
 
-        let target_block_num = block_num.unwrap_or(next_block_num);
+        let mut batches = Vec::new();
 
-        assert!(
-            target_block_num >= next_block_num,
-            "target block number must be greater or equal to the number of the next block in the chain"
+        // If there are any pending objects, create the pending objects batch.
+        // If not, do not include it, so we don't have an empty batch in the block.
+        // if !self.pending_objects.is_empty() {
+        //     batches.push(
+        //         self.pending_objects_to_batch()
+        //             .context("failed to convert pending objects into batch")?,
+        //     );
+        // }
+
+        self.pending_transactions_to_batches(&mut batches)
+            .context("failed to convert pending transactions to batch")?;
+
+        // Create block.
+        // ----------------------------------------------------------------------------------------
+
+        let block_timestamp =
+            timestamp.unwrap_or(self.latest_block_header().timestamp() + Self::TIMESTAMP_STEP_SECS);
+
+        let mut proven_block = self
+            .propose_block_at(batches, block_timestamp)
+            .context("failed to propose block")
+            .and_then(|proposed_block| {
+                self.prove_block(proposed_block)
+                    .context("failed to prove proposed block into proven block")
+            })?;
+
+        self.apply_block_partially(&proven_block)
+            .context("failed to apply account and nullifier tree changes from block")?;
+
+        if !self.pending_objects.is_empty() {
+            self.add_pending_objects_to_block(&mut proven_block)
+                .context("failed to add pending objects to block")?;
+        }
+
+        self.apply_block(proven_block.clone())
+            .context("failed to apply proven block to chain state")?;
+
+        Ok(proven_block)
+    }
+
+    pub fn apply_block_partially(&mut self, proven_block: &ProvenBlock) -> anyhow::Result<()> {
+        for account_update in proven_block.updated_accounts() {
+            self.account_tree
+                .insert(account_update.account_id(), account_update.final_state_commitment())
+                .context("failed to insert account update into account tree")?;
+        }
+
+        for nullifier in proven_block.created_nullifiers() {
+            self.nullifier_tree
+                .mark_spent(*nullifier, proven_block.header().block_num())
+                .context("failed to mark block nullifier as spent")?;
+
+            // TODO: Remove from self.available_notes.
+        }
+
+        Ok(())
+    }
+
+    /// Applies the given block to the chain state, which means:
+    ///
+    /// - Updated accounts from the block are inserted into the account tree and into the available
+    ///   accounts.
+    /// - Created notes are inserted into the available notes.
+    /// - Consumed notes are removed from the available notes and their nullifiers are inserted into
+    ///   the nullifier tree.
+    /// - The block is appended to the [`BlockChain`] and the list of proven blocks.
+    pub fn apply_block(&mut self, proven_block: ProvenBlock) -> anyhow::Result<()> {
+        for account_update in proven_block.updated_accounts() {
+            // self.account_tree
+            //     .insert(account_update.account_id(), account_update.final_state_commitment())
+            //     .context("failed to insert account update into account tree")?;
+
+            if let Some(mock_account) = self.available_accounts.get(&account_update.account_id()) {
+                // TODO: This ignores deltas and private state
+                match account_update.details() {
+                    AccountUpdateDetails::New(account) => {
+                        self.available_accounts.insert(
+                            account_update.account_id(),
+                            MockAccount::new(
+                                account.clone(),
+                                mock_account.seed().copied(),
+                                mock_account.authenticator().clone(),
+                            ),
+                        );
+                    },
+                    AccountUpdateDetails::Delta(account_delta) => {
+                        match self.available_accounts.get_mut(&account_update.account_id()) {
+                            Some(committed_account) => {
+                                committed_account.apply_delta(account_delta).context(
+                                    "failed to apply account delta to committed account",
+                                )?;
+                            },
+                            None => {
+                                anyhow::bail!("account delta in block for non-existent account")
+                            },
+                        }
+                    },
+                    // TODO: Check what, if anything, we need to properly support private accounts.
+                    AccountUpdateDetails::Private => (),
+                }
+            }
+        }
+
+        // for nullifier in proven_block.created_nullifiers() {
+        //     self.nullifiers
+        //         .mark_spent(*nullifier, proven_block.header().block_num())
+        //         .context("failed to mark block nullifier as spent")?;
+
+        //     // TODO: Remove from self.available_notes.
+        // }
+
+        let notes_tree = proven_block.build_output_note_tree();
+        for (block_note_index, created_note) in proven_block.output_notes() {
+            let note_path = notes_tree.get_note_path(block_note_index);
+            let note_inclusion_proof = NoteInclusionProof::new(
+                proven_block.header().block_num(),
+                block_note_index.leaf_index_value(),
+                note_path,
+            )
+            .context("failed to construct note inclusion proof")?;
+
+            if let OutputNote::Full(note) = created_note {
+                self.available_notes
+                    .insert(note.id(), MockChainNote::Public(note.clone(), note_inclusion_proof));
+            } else {
+                self.available_notes.insert(
+                    created_note.id(),
+                    MockChainNote::Private(
+                        created_note.id(),
+                        *created_note.metadata(),
+                        note_inclusion_proof,
+                    ),
+                );
+            }
+        }
+
+        debug_assert_eq!(
+            self.chain.commitment(),
+            proven_block.header().chain_commitment(),
+            "current mock chain commitment and new block's chain commitment should match"
         );
+        debug_assert_eq!(
+            BlockNumber::from(self.chain.as_mmr().forest() as u32),
+            proven_block.header().block_num(),
+            "current mock chain length and new block's number should match"
+        );
+
+        self.chain.push(proven_block.header().commitment());
+        self.blocks.push(proven_block);
+
+        Ok(())
+    }
+
+    fn pending_transactions_to_batches(
+        &mut self,
+        batches: &mut Vec<ProvenBatch>,
+    ) -> anyhow::Result<()> {
+        // Batches must contian at least one transaction, so if there are no pending transactions,
+        // return early.
+        if self.pending_transactions.is_empty() {
+            return Ok(());
+        }
 
         let pending_transactions = core::mem::take(&mut self.pending_transactions);
 
         // TODO: Split into multiple batches if num of pending transactions exceeds max txs per
         // batch.
-        let proposed_batch = self
+        let proven_batch = self
             .propose_transaction_batch(pending_transactions.into_iter().map(|executed_tx| {
+                // This essentially transforms an executed tx into a proven tx with a dummy proof.
                 ProvenTransaction::from_executed_transaction_mocked(executed_tx)
             }))
-            .map(|proposed_batch| self.prove_transaction_batch(proposed_batch))
-            .unwrap();
+            .map(|proposed_batch| self.prove_transaction_batch(proposed_batch))?;
 
-        // TODO: Add pending objects into block.
-        self.propose_block([proposed_batch])
-            .map(|proposed_block| self.prove_block(proposed_block).unwrap())
-            .unwrap();
+        batches.push(proven_batch);
 
-        let mut last_block: Option<ProvenBlock> = None;
+        Ok(())
+    }
 
-        for current_block_num in next_block_num..=target_block_num {
-            for update in self.pending_objects.updated_accounts.iter() {
-                self.account_tree
-                    .insert(update.account_id(), update.final_state_commitment())
-                    .unwrap();
+    fn add_pending_objects_to_block(
+        &mut self,
+        proven_block: &mut ProvenBlock,
+    ) -> anyhow::Result<()> {
+        // Add pending accounts to block.
+        let pending_account_updates = core::mem::take(&mut self.pending_objects.updated_accounts);
 
-                if let Some(mock_account) = self.available_accounts.get(&update.account_id()) {
-                    let account = match update.details() {
-                        AccountUpdateDetails::New(acc) => acc.clone(),
-                        _ => panic!("The mockchain should have full account details"),
-                    };
-                    self.available_accounts.insert(
-                        update.account_id(),
-                        MockAccount::new(
-                            account,
-                            mock_account.seed().copied(),
-                            mock_account.authenticator().clone(),
-                        ),
-                    );
-                }
+        // let committed_witnesses = self
+        //     .account_tree
+        //     .account_commitments()
+        //     .map(|(committed_id, _)| self.account_tree.open(committed_id));
+        // let mut partial_account_tree = PartialAccountTree::with_witnesses(committed_witnesses)
+        //     .context("failed to rebuild partial account tree from full tree")?;
+        // partial_account_tree
+        //     .upsert_state_commitments(proven_block.updated_accounts().iter().map(|block_update| {
+        //         (block_update.account_id(), block_update.final_state_commitment())
+        //     }))
+        //     .context("failed to apply updates from block to partial account tree")?;
+
+        // partial_account_tree
+        //     .upsert_state_commitments(
+        //         pending_account_updates
+        //             .iter()
+        //             .map(|(id, update)| (*id, update.final_state_commitment())),
+        //     )
+        //     .context("failed to apply pending account updates to partial account tree")?;
+        // let new_account_root = partial_account_tree.root();
+
+        let updated_accounts_block: BTreeSet<AccountId> = proven_block
+            .updated_accounts()
+            .iter()
+            .map(|update| update.account_id())
+            .collect();
+
+        for (id, account_update) in pending_account_updates {
+            if updated_accounts_block.contains(&id) {
+                anyhow::bail!(
+                    "account {id} is already modified through a transaction in the block so it cannot also be modified through pending objects"
+                );
             }
 
-            // TODO: Implement nullifier tree reset once defined at the protocol level.
-            for nullifier in self.pending_objects.created_nullifiers.iter() {
-                self.nullifiers
-                    .mark_spent(*nullifier, BlockNumber::from(current_block_num))
-                    .expect("nullifier should not already be spent");
-            }
-            let notes_tree = self.pending_objects.build_notes_tree();
+            self.account_tree
+                .insert(id, account_update.final_state_commitment())
+                .context("failed to insert pending account into tree")?;
 
-            let version = 0;
-            let previous = self.blocks.last();
-            let peaks = self.chain.peaks();
-            let chain_commitment: Digest = peaks.hash_peaks();
-            let account_root = self.account_tree.root();
-            let prev_block_commitment =
-                previous.map_or(Digest::default(), |block| block.commitment());
-            let nullifier_root = self.nullifiers.root();
-            let note_root = notes_tree.root();
-
-            let mut block_timestamp = previous.map_or(Self::TIMESTAMP_START_SECS, |block| {
-                block.header().timestamp() + Self::TIMESTAMP_STEP_SECS
-            });
-
-            // Overwrite the block timestamp if we're building the target block.
-            if current_block_num == target_block_num {
-                if let Some(provided_timestamp) = timestamp {
-                    if let Some(prev_block) = previous {
-                        assert!(
-                            provided_timestamp > prev_block.header().timestamp(),
-                            "provided timestamp must be strictly greater than the previous block's timestamp"
-                        );
-                    }
-                    block_timestamp = provided_timestamp;
-                }
-            }
-
-            let tx_commitment = OrderedTransactionHeaders::compute_commitment(
-                self.pending_objects.included_transactions.clone().into_iter(),
-            );
-
-            let tx_kernel_commitment = TransactionKernel::kernel_commitment();
-
-            // TODO: Set `proof_commitment` to the correct value once the kernel is available.
-            let proof_commitment = Digest::default();
-
-            let header = BlockHeader::new(
-                version,
-                prev_block_commitment,
-                BlockNumber::from(current_block_num),
-                chain_commitment,
-                account_root,
-                nullifier_root,
-                note_root,
-                tx_commitment,
-                tx_kernel_commitment,
-                proof_commitment,
-                block_timestamp,
-            );
-
-            let block = ProvenBlock::new_unchecked(
-                header.clone(),
-                self.pending_objects.updated_accounts.clone(),
-                self.pending_objects.output_note_batches.clone(),
-                self.pending_objects.created_nullifiers.clone(),
-                // TODO: For now we can't easily compute the verified transactions of this block.
-                // Let's do this as part of miden-base/#1224.
-                OrderedTransactionHeaders::new_unchecked(vec![]),
-            );
-
-            for (batch_index, note_batch) in
-                self.pending_objects.output_note_batches.iter().enumerate()
-            {
-                for (note_index, note) in note_batch.iter() {
-                    let block_note_index = BlockNoteIndex::new(batch_index, *note_index)
-                        .expect("max batches in block and max notes in batches should be enforced");
-                    let note_path = notes_tree.get_note_path(block_note_index);
-                    let note_inclusion_proof = NoteInclusionProof::new(
-                        block.header().block_num(),
-                        block_note_index.leaf_index_value(),
-                        note_path,
-                    )
-                    .unwrap();
-                    if let OutputNote::Full(note) = note {
-                        self.available_notes.insert(
-                            note.id(),
-                            MockChainNote::Public(note.clone(), note_inclusion_proof),
-                        );
-                    } else {
-                        self.available_notes.insert(
-                            note.id(),
-                            MockChainNote::Private(
-                                note.id(),
-                                *note.metadata(),
-                                note_inclusion_proof,
-                            ),
-                        );
-                    }
-                }
-            }
-
-            for removed_note in self.removed_notes.iter() {
-                self.available_notes.remove(removed_note);
-            }
-
-            self.blocks.push(block.clone());
-            self.chain.push(header.commitment());
-            self.reset_pending();
-
-            last_block = Some(block);
+            proven_block.updated_accounts_mut().push(account_update);
         }
 
-        last_block.expect("There should be at least one block generated")
+        // Add pending nullifiers to block.
+        let pending_created_nullifiers =
+            core::mem::take(&mut self.pending_objects.created_nullifiers);
+        // let nullifier_witnesses =
+        //     self.nullifiers.entries().map(|(nullifier, _)| self.nullifiers.open(&nullifier));
+        // let mut partial_nullifier_tree =
+        // PartialNullifierTree::with_witnesses(nullifier_witnesses)     .context("failed to
+        // reconstruct partial nullifier tree from full nullifier tree")?;
+        // partial_nullifier_tree.mark_spent(nullifiers, block_num);
+
+        let created_nullifiers_block: BTreeSet<Nullifier> =
+            proven_block.created_nullifiers().iter().copied().collect();
+
+        for nullifier in pending_created_nullifiers {
+            if created_nullifiers_block.contains(&nullifier) {
+                anyhow::bail!(
+                    "nullifier {nullifier} is already created by a transaction in the block so it cannot also be added through pending objects"
+                );
+            }
+
+            self.nullifier_tree
+                .mark_spent(nullifier, proven_block.header().block_num())
+                .context("failed to insert pending nullifier into tree")?;
+
+            proven_block.created_nullifiers_mut().push(nullifier);
+        }
+
+        // Add pending output notes to block.
+        let output_notes_block: BTreeSet<NoteId> =
+            proven_block.output_notes().map(|(_, output_note)| output_note.id()).collect();
+
+        // We could distribute notes over multiple batches (if space is available), but most likely
+        // one is sufficient.
+        if self.pending_objects.output_notes.len() > MAX_OUTPUT_NOTES_PER_BATCH {
+            anyhow::bail!(
+                "cannot create more than {MAX_OUTPUT_NOTES_PER_BATCH} notes through pending objects"
+            );
+        }
+
+        let mut pending_note_batch = Vec::with_capacity(self.pending_objects.output_notes.len());
+        let pending_output_notes = core::mem::take(&mut self.pending_objects.output_notes);
+        for (note_idx, output_note) in pending_output_notes.into_iter().enumerate() {
+            if output_notes_block.contains(&output_note.id()) {
+                anyhow::bail!(
+                    "output note {} is already created by a transaction in the block so it cannot also be created through pending objects",
+                    output_note.id()
+                );
+            }
+
+            pending_note_batch.push((note_idx, output_note));
+        }
+
+        if (proven_block.output_note_batches().len() + 1) > MAX_BATCHES_PER_BLOCK {
+            anyhow::bail!(
+                "failed to add pending notes to block because max number of batches is already reached"
+            )
+        }
+
+        proven_block.output_note_batches_mut().push(pending_note_batch);
+
+        let updated_block_note_tree = proven_block.build_output_note_tree().root();
+
+        // Update account tree and nullifier tree root in the block.
+        let block_header = proven_block.header();
+        let updated_header = BlockHeader::new(
+            block_header.version(),
+            block_header.prev_block_commitment(),
+            block_header.block_num(),
+            block_header.chain_commitment(),
+            self.account_tree.root(),
+            self.nullifier_tree.root(),
+            updated_block_note_tree,
+            block_header.tx_commitment(),
+            block_header.tx_kernel_commitment(),
+            block_header.proof_commitment(),
+            block_header.timestamp(),
+        );
+        proven_block.set_block_header(updated_header);
+
+        Ok(())
     }
 
-    fn reset_pending(&mut self) {
-        self.pending_objects = PendingObjects::new();
-        self.removed_notes = vec![];
-    }
+    // fn pending_objects_to_batch(&mut self) -> anyhow::Result<ProvenBatch> {
+    //     let random_id = self.random_batch_id();
+    //     let latest_block_header = self.latest_block_header();
+    //     let reference_block_commitment = latest_block_header.commitment();
+    //     let reference_block_num = latest_block_header.block_num();
+    //     let account_updates = core::mem::take(&mut self.pending_objects.updated_accounts);
+    //     let created_nullifiers = core::mem::take(&mut self.pending_objects.created_nullifiers);
+    //     let input_notes = InputNotes::new(
+    //         created_nullifiers.into_iter().map(InputNoteCommitment::from).collect(),
+    //     )
+    //     .context("failed to convert pending nullifiers into input notes")?;
+    //     let output_notes = core::mem::take(&mut self.pending_objects.output_notes);
+
+    //     // This special batch never expires.
+    //     let batch_expiration_block_num = BlockNumber::from(u32::MAX);
+
+    //     // We don't have any transactions for pending objects, so this batch's transactions
+    //     // will appear as empty.
+    //     let transactions = OrderedTransactionHeaders::new_unchecked(vec![]);
+
+    //     ProvenBatch::new(
+    //         random_id,
+    //         reference_block_commitment,
+    //         reference_block_num,
+    //         account_updates,
+    //         input_notes,
+    //         output_notes,
+    //         batch_expiration_block_num,
+    //         transactions,
+    //     )
+    //     .map_err(Into::into)
+    // }
+
+    // fn random_batch_id(&self) -> BatchId {
+    //     let mut random_coin = RpoRandomCoin::new([Felt::new(self.blocks.len() as u64); 4]);
+
+    //     let random_tx_id = TransactionId::new(
+    //         random_coin.draw_word().into(),
+    //         random_coin.draw_word().into(),
+    //         random_coin.draw_word().into(),
+    //         random_coin.draw_word().into(),
+    //     );
+
+    //     let random_account_id = AccountIdBuilder::new().build_with_rng(&mut random_coin);
+
+    //     BatchId::from_ids([(random_tx_id, random_account_id)])
+    // }
 
     // ACCESSORS
     // =========================================================================================
@@ -1008,7 +1247,7 @@ impl MockChain {
         let mut nullifier_proofs = BTreeMap::new();
 
         for nullifier in nullifiers {
-            let witness = self.nullifiers.open(&nullifier);
+            let witness = self.nullifier_tree.open(&nullifier);
             nullifier_proofs.insert(nullifier, witness);
         }
 
@@ -1051,7 +1290,7 @@ impl MockChain {
 
     /// Gets a reference to the nullifier tree.
     pub fn nullifiers(&self) -> &NullifierTree {
-        &self.nullifiers
+        &self.nullifier_tree
     }
 
     /// Get the vector of IDs of the currently available notes.
@@ -1083,6 +1322,63 @@ impl MockChain {
     /// Get the reference to the account tree.
     pub fn accounts(&self) -> &AccountTree {
         &self.account_tree
+    }
+}
+
+fn create_genesis_block(accounts: impl IntoIterator<Item = Account>) -> ProvenBlock {
+    let block_account_updates = accounts
+        .into_iter()
+        .map(|account| {
+            BlockAccountUpdate::new(
+                account.id(),
+                account.commitment(),
+                AccountUpdateDetails::New(account),
+            )
+        })
+        .collect();
+
+    let output_note_batches = Vec::new();
+    let created_nullifiers = Vec::new();
+    let transactions = OrderedTransactionHeaders::new_unchecked(Vec::new());
+
+    let version = 0;
+    let prev_block_commitment = Digest::default();
+    let block_num = BlockNumber::from(0u32);
+    let chain_commitment = Blockchain::new().commitment();
+    let account_root = AccountTree::new().root();
+    let nullifier_root = NullifierTree::new().root();
+    let note_root = BlockNoteTree::empty().root();
+    let tx_commitment = transactions.commitment();
+    let tx_kernel_commitment = TransactionKernel::kernel_commitment();
+    let proof_commitment = Digest::default();
+    let timestamp = MockChain::TIMESTAMP_START_SECS;
+
+    let header = BlockHeader::new(
+        version,
+        prev_block_commitment,
+        block_num,
+        chain_commitment,
+        account_root,
+        nullifier_root,
+        note_root,
+        tx_commitment,
+        tx_kernel_commitment,
+        proof_commitment,
+        timestamp,
+    );
+
+    ProvenBlock::new_unchecked(
+        header,
+        block_account_updates,
+        output_note_batches,
+        created_nullifiers,
+        transactions,
+    )
+}
+
+impl Default for MockChain {
+    fn default() -> Self {
+        MockChain::new()
     }
 }
 

--- a/crates/miden-testing/src/mock_chain/mod.rs
+++ b/crates/miden-testing/src/mock_chain/mod.rs
@@ -3,8 +3,10 @@ mod auth;
 mod chain;
 mod fungible_faucet;
 mod note;
+mod proven_tx_ext;
 
 pub use auth::Auth;
 pub use chain::{AccountState, MockChain};
 pub use fungible_faucet::MockFungibleFaucet;
 pub use note::MockChainNote;
+pub use proven_tx_ext::ProvenTransactionExt;

--- a/crates/miden-testing/src/mock_chain/mod.rs
+++ b/crates/miden-testing/src/mock_chain/mod.rs
@@ -6,7 +6,7 @@ mod note;
 mod proven_tx_ext;
 
 pub use auth::Auth;
-pub use chain::{AccountState, MockChain};
+pub use chain::{AccountState, MockChain, TxContextInput};
 pub use fungible_faucet::MockFungibleFaucet;
 pub use note::MockChainNote;
 pub use proven_tx_ext::ProvenTransactionExt;

--- a/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
+++ b/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
@@ -1,0 +1,69 @@
+use miden_objects::{
+    account::delta::AccountUpdateDetails,
+    block::BlockHeader,
+    transaction::{ExecutedTransaction, ProvenTransaction, ProvenTransactionBuilder},
+    vm::ExecutionProof,
+};
+use winterfell::Proof;
+
+/// TODO
+pub trait ProvenTransactionExt {
+    /// TODO
+    fn from_executed_transaction_mocked(executed_tx: ExecutedTransaction) -> ProvenTransaction;
+
+    /// TODO: Remove this if we can find a way to build multiple transactions against the same
+    /// account in the mock chain without submitting those transactions.
+    fn from_executed_transaction_mocked_ref_block(
+        executed_tx: ExecutedTransaction,
+        block_reference: &BlockHeader,
+    ) -> ProvenTransaction;
+}
+
+impl ProvenTransactionExt for ProvenTransaction {
+    fn from_executed_transaction_mocked(executed_tx: ExecutedTransaction) -> ProvenTransaction {
+        from_executed_transaction_mocked(executed_tx, None)
+    }
+
+    fn from_executed_transaction_mocked_ref_block(
+        executed_tx: ExecutedTransaction,
+        block_reference: &BlockHeader,
+    ) -> ProvenTransaction {
+        from_executed_transaction_mocked(executed_tx, Some(block_reference))
+    }
+}
+
+fn from_executed_transaction_mocked(
+    executed_tx: ExecutedTransaction,
+    block_reference: Option<&BlockHeader>,
+) -> ProvenTransaction {
+    let block_reference = block_reference.unwrap_or(executed_tx.block_header());
+    let account_delta = executed_tx.account_delta().clone();
+    let initial_account = executed_tx.initial_account().clone();
+    let account_update_details = if initial_account.is_public() {
+        if initial_account.is_new() {
+            let mut account = initial_account;
+            account.apply_delta(&account_delta).expect("account delta should be applyable");
+
+            AccountUpdateDetails::New(account)
+        } else {
+            AccountUpdateDetails::Delta(account_delta)
+        }
+    } else {
+        AccountUpdateDetails::Private
+    };
+
+    ProvenTransactionBuilder::new(
+        executed_tx.account_id(),
+        executed_tx.initial_account().init_commitment(),
+        executed_tx.final_account().commitment(),
+        block_reference.block_num(),
+        block_reference.commitment(),
+        executed_tx.expiration_block_num(),
+        ExecutionProof::new(Proof::new_dummy(), Default::default()),
+    )
+    .add_input_notes(executed_tx.input_notes())
+    .add_output_notes(executed_tx.output_notes().iter().cloned())
+    .account_update_details(account_update_details)
+    .build()
+    .unwrap()
+}

--- a/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
+++ b/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
@@ -1,69 +1,48 @@
 use miden_objects::{
     account::delta::AccountUpdateDetails,
-    block::BlockHeader,
     transaction::{ExecutedTransaction, ProvenTransaction, ProvenTransactionBuilder},
     vm::ExecutionProof,
 };
 use winterfell::Proof;
 
-/// TODO
+/// Extension trait to convert an [`ExecutedTransaction`] into a [`ProvenTransaction`] with a dummy
+/// proof for testing purposes.
 pub trait ProvenTransactionExt {
-    /// TODO
+    /// Converts the transaction into a proven transaction with a dummy proof.
     fn from_executed_transaction_mocked(executed_tx: ExecutedTransaction) -> ProvenTransaction;
-
-    /// TODO: Remove this if we can find a way to build multiple transactions against the same
-    /// account in the mock chain without submitting those transactions.
-    fn from_executed_transaction_mocked_ref_block(
-        executed_tx: ExecutedTransaction,
-        block_reference: &BlockHeader,
-    ) -> ProvenTransaction;
 }
 
 impl ProvenTransactionExt for ProvenTransaction {
     fn from_executed_transaction_mocked(executed_tx: ExecutedTransaction) -> ProvenTransaction {
-        from_executed_transaction_mocked(executed_tx, None)
-    }
+        let block_reference = executed_tx.block_header();
+        let account_delta = executed_tx.account_delta().clone();
+        let initial_account = executed_tx.initial_account().clone();
+        let account_update_details = if initial_account.is_public() {
+            if initial_account.is_new() {
+                let mut account = initial_account;
+                account.apply_delta(&account_delta).expect("account delta should be applyable");
 
-    fn from_executed_transaction_mocked_ref_block(
-        executed_tx: ExecutedTransaction,
-        block_reference: &BlockHeader,
-    ) -> ProvenTransaction {
-        from_executed_transaction_mocked(executed_tx, Some(block_reference))
-    }
-}
-
-fn from_executed_transaction_mocked(
-    executed_tx: ExecutedTransaction,
-    block_reference: Option<&BlockHeader>,
-) -> ProvenTransaction {
-    let block_reference = block_reference.unwrap_or(executed_tx.block_header());
-    let account_delta = executed_tx.account_delta().clone();
-    let initial_account = executed_tx.initial_account().clone();
-    let account_update_details = if initial_account.is_public() {
-        if initial_account.is_new() {
-            let mut account = initial_account;
-            account.apply_delta(&account_delta).expect("account delta should be applyable");
-
-            AccountUpdateDetails::New(account)
+                AccountUpdateDetails::New(account)
+            } else {
+                AccountUpdateDetails::Delta(account_delta)
+            }
         } else {
-            AccountUpdateDetails::Delta(account_delta)
-        }
-    } else {
-        AccountUpdateDetails::Private
-    };
+            AccountUpdateDetails::Private
+        };
 
-    ProvenTransactionBuilder::new(
-        executed_tx.account_id(),
-        executed_tx.initial_account().init_commitment(),
-        executed_tx.final_account().commitment(),
-        block_reference.block_num(),
-        block_reference.commitment(),
-        executed_tx.expiration_block_num(),
-        ExecutionProof::new(Proof::new_dummy(), Default::default()),
-    )
-    .add_input_notes(executed_tx.input_notes())
-    .add_output_notes(executed_tx.output_notes().iter().cloned())
-    .account_update_details(account_update_details)
-    .build()
-    .unwrap()
+        ProvenTransactionBuilder::new(
+            executed_tx.account_id(),
+            executed_tx.initial_account().init_commitment(),
+            executed_tx.final_account().commitment(),
+            block_reference.block_num(),
+            block_reference.commitment(),
+            executed_tx.expiration_block_num(),
+            ExecutionProof::new(Proof::new_dummy(), Default::default()),
+        )
+        .add_input_notes(executed_tx.input_notes())
+        .add_output_notes(executed_tx.output_notes().iter().cloned())
+        .account_update_details(account_update_details)
+        .build()
+        .unwrap()
+    }
 }

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -650,8 +650,8 @@ impl TransactionContextBuilder {
                     mock_chain.add_pending_note(OutputNote::Full(i));
                 }
 
-                mock_chain.seal_next_block();
-                mock_chain.seal_next_block();
+                mock_chain.prove_next_block();
+                mock_chain.prove_next_block();
 
                 let input_note_ids: Vec<NoteId> =
                     mock_chain.available_notes().iter().map(|n| n.id()).collect();

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -654,7 +654,7 @@ impl TransactionContextBuilder {
                 mock_chain.prove_next_block();
 
                 let input_note_ids: Vec<NoteId> =
-                    mock_chain.available_notes().iter().map(|n| n.id()).collect();
+                    mock_chain.committed_notes().values().map(|note| note.id()).collect();
 
                 mock_chain.get_transaction_inputs(
                     self.account.clone(),

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -34,7 +34,7 @@ use rand_chacha::ChaCha20Rng;
 use vm_processor::{AdviceInputs, Felt, Word};
 
 use super::TransactionContext;
-use crate::MockChain;
+use crate::{MockChain, MockChainNote};
 
 pub type MockAuthenticator = BasicAuthenticator<ChaCha20Rng>;
 
@@ -654,7 +654,7 @@ impl TransactionContextBuilder {
                 mock_chain.prove_next_block();
 
                 let input_note_ids: Vec<NoteId> =
-                    mock_chain.committed_notes().values().map(|note| note.id()).collect();
+                    mock_chain.committed_notes().values().map(MockChainNote::id).collect();
 
                 mock_chain.get_transaction_inputs(
                     self.account.clone(),

--- a/crates/miden-testing/tests/integration/scripts/faucet.rs
+++ b/crates/miden-testing/tests/integration/scripts/faucet.rs
@@ -26,7 +26,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() {
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
     let mut mock_chain = MockChain::new();
-    let faucet = mock_chain.add_existing_faucet(Auth::BasicAuth, "TST", 200, None);
+    let faucet = mock_chain.add_pending_existing_faucet(Auth::BasicAuth, "TST", 200, None);
 
     let recipient = [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)];
     let tag = NoteTag::for_local_use_case(0, 0).unwrap();
@@ -102,7 +102,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
     // --------------------------------------------------------------------------------------------
     let mut mock_chain = MockChain::new();
     let faucet: MockFungibleFaucet =
-        mock_chain.add_existing_faucet(Auth::BasicAuth, "TST", 200u64, None);
+        mock_chain.add_pending_existing_faucet(Auth::BasicAuth, "TST", 200u64, None);
 
     let recipient = [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)];
     let aux = Felt::new(27);
@@ -159,7 +159,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() {
 #[test]
 fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     let mut mock_chain = MockChain::new();
-    let faucet = mock_chain.add_existing_faucet(Auth::BasicAuth, "TST", 200, Some(100));
+    let faucet = mock_chain.add_pending_existing_faucet(Auth::BasicAuth, "TST", 200, Some(100));
 
     let fungible_asset = FungibleAsset::new(faucet.account().id(), 100).unwrap();
 

--- a/crates/miden-testing/tests/integration/scripts/faucet.rs
+++ b/crates/miden-testing/tests/integration/scripts/faucet.rs
@@ -196,7 +196,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     let note = get_note_with_fungible_asset_and_script(fungible_asset, note_script);
 
     mock_chain.add_pending_note(OutputNote::Full(note.clone()));
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-testing/tests/integration/scripts/p2id.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2id.rs
@@ -48,7 +48,7 @@ fn p2id_script_multiple_assets() {
         )
         .unwrap();
 
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ fn p2id_script_multiple_assets() {
     // A "malicious" account tries to consume the note, we expect an error (not the correct target)
 
     let malicious_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // Execute the transaction and get the result
     let executed_transaction_2 = mock_chain
@@ -113,7 +113,7 @@ fn prove_consume_note_with_new_account() {
         )
         .unwrap();
 
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
@@ -169,7 +169,7 @@ fn prove_consume_multiple_notes() {
         )
         .unwrap();
 
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[note_1.id(), note_2.id()], &[])
@@ -220,7 +220,7 @@ fn test_create_consume_multiple_notes() {
         )
         .unwrap();
 
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let output_note_1 = create_p2id_note(
         account.id(),

--- a/crates/miden-testing/tests/integration/scripts/p2id.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2id.rs
@@ -117,6 +117,7 @@ fn prove_consume_note_with_new_account() {
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
+
     // Execute the transaction and get the witness
     let executed_transaction = mock_chain
         .build_tx_context(target_account.id(), &[note.id()], &[])

--- a/crates/miden-testing/tests/integration/scripts/p2id.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2id.rs
@@ -34,12 +34,12 @@ fn p2id_script_multiple_assets() {
             .into();
 
     // Create sender and target account
-    let sender_account = mock_chain.add_new_wallet(Auth::BasicAuth);
-    let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let sender_account = mock_chain.add_pending_new_wallet(Auth::BasicAuth);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
 
     // Create the note
     let note = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             sender_account.id(),
             target_account.id(),
             &[fungible_asset_1, fungible_asset_2],
@@ -77,7 +77,7 @@ fn p2id_script_multiple_assets() {
     // --------------------------------------------------------------------------------------------
     // A "malicious" account tries to consume the note, we expect an error (not the correct target)
 
-    let malicious_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let malicious_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
     mock_chain.prove_next_block();
 
     // Execute the transaction and get the result
@@ -99,12 +99,12 @@ fn prove_consume_note_with_new_account() {
     let fungible_asset: Asset = FungibleAsset::mock(123);
 
     // Create faucet account and target account
-    let faucet_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
-    let target_account = mock_chain.add_new_wallet(Auth::BasicAuth);
+    let faucet_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_new_wallet(Auth::BasicAuth);
 
     // Create the note
     let note = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             faucet_account.id(),
             target_account.id(),
             &[fungible_asset],
@@ -145,13 +145,13 @@ fn prove_consume_note_with_new_account() {
 #[test]
 fn prove_consume_multiple_notes() {
     let mut mock_chain = MockChain::new();
-    let mut account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let mut account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
 
     let fungible_asset_1: Asset = FungibleAsset::mock(100);
     let fungible_asset_2: Asset = FungibleAsset::mock(23);
 
     let note_1 = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             ACCOUNT_ID_SENDER.try_into().unwrap(),
             account.id(),
             &[fungible_asset_1],
@@ -160,7 +160,7 @@ fn prove_consume_multiple_notes() {
         )
         .unwrap();
     let note_2 = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             ACCOUNT_ID_SENDER.try_into().unwrap(),
             account.id(),
             &[fungible_asset_2],
@@ -193,7 +193,7 @@ fn prove_consume_multiple_notes() {
 fn test_create_consume_multiple_notes() {
     let mut mock_chain = MockChain::new();
     let mut account =
-        mock_chain.add_existing_wallet(Auth::BasicAuth, vec![FungibleAsset::mock(20)]);
+        mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![FungibleAsset::mock(20)]);
 
     let input_note_faucet_id = ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET.try_into().unwrap();
     let input_note_asset_1: Asset = FungibleAsset::new(input_note_faucet_id, 11).unwrap().into();
@@ -201,7 +201,7 @@ fn test_create_consume_multiple_notes() {
     let input_note_asset_2: Asset = FungibleAsset::new(input_note_faucet_id, 100).unwrap().into();
 
     let input_note_1 = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             ACCOUNT_ID_SENDER.try_into().unwrap(),
             account.id(),
             &[input_note_asset_1],
@@ -211,7 +211,7 @@ fn test_create_consume_multiple_notes() {
         .unwrap();
 
     let input_note_2 = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE_2.try_into().unwrap(),
             account.id(),
             &[input_note_asset_2],

--- a/crates/miden-testing/tests/integration/scripts/p2idr.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2idr.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use miden_lib::errors::note_script_errors::{
     ERR_P2IDR_RECLAIM_ACCT_IS_NOT_SENDER, ERR_P2IDR_RECLAIM_HEIGHT_NOT_REACHED,
 };
@@ -12,9 +13,9 @@ use miden_testing::{Auth, MockChain};
 use crate::assert_transaction_executor_error;
 
 #[test]
-fn p2idr_script() {
+fn p2idr_script() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
-    mock_chain.seal_block(Some(3), None);
+    mock_chain.prove_until_block(3u32).context("failed to prove multiple blocks")?;
 
     // Create assets
     let fungible_asset: Asset = FungibleAsset::mock(100);
@@ -49,7 +50,7 @@ fn p2idr_script() {
         )
         .unwrap();
 
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     // --------------------------------------------------------------------------------------------
     // Case "in time": Only the target account can consume the note.
@@ -126,4 +127,6 @@ fn p2idr_script() {
         executed_transaction_6,
         ERR_P2IDR_RECLAIM_ACCT_IS_NOT_SENDER
     );
+
+    Ok(())
 }

--- a/crates/miden-testing/tests/integration/scripts/p2idr.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2idr.rs
@@ -21,9 +21,9 @@ fn p2idr_script() -> anyhow::Result<()> {
     let fungible_asset: Asset = FungibleAsset::mock(100);
 
     // Create sender and target and malicious account
-    let sender_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
-    let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
-    let malicious_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![]);
+    let sender_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let malicious_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
 
     // Create the reclaim block heights
     let reclaim_block_height_in_time = 7.into();
@@ -31,7 +31,7 @@ fn p2idr_script() -> anyhow::Result<()> {
 
     // Create the notes with the P2IDR script
     let note_in_time = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             sender_account.id(),
             target_account.id(),
             &[fungible_asset],
@@ -41,7 +41,7 @@ fn p2idr_script() -> anyhow::Result<()> {
         .unwrap();
 
     let note_reclaimable = mock_chain
-        .add_p2id_note(
+        .add_pending_p2id_note(
             sender_account.id(),
             target_account.id(),
             &[fungible_asset],

--- a/crates/miden-testing/tests/integration/scripts/send_note.rs
+++ b/crates/miden-testing/tests/integration/scripts/send_note.rs
@@ -19,7 +19,7 @@ use miden_testing::{Auth, MockChain};
 fn test_send_note_script_basic_wallet() {
     let mut mock_chain = MockChain::new();
     let sender_basic_wallet_account =
-        mock_chain.add_existing_wallet(Auth::BasicAuth, vec![FungibleAsset::mock(100)]);
+        mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![FungibleAsset::mock(100)]);
 
     let sender_account_interface = AccountInterface::from(&sender_basic_wallet_account);
 
@@ -65,7 +65,7 @@ fn test_send_note_script_basic_wallet() {
 fn test_send_note_script_basic_fungible_faucet() {
     let mut mock_chain = MockChain::new();
     let sender_basic_fungible_faucet_account =
-        mock_chain.add_existing_faucet(Auth::BasicAuth, "POL", 200, None);
+        mock_chain.add_pending_existing_faucet(Auth::BasicAuth, "POL", 200, None);
 
     let sender_account_interface =
         AccountInterface::from(sender_basic_fungible_faucet_account.account());

--- a/crates/miden-testing/tests/integration/scripts/swap.rs
+++ b/crates/miden-testing/tests/integration/scripts/swap.rs
@@ -16,9 +16,11 @@ use crate::prove_and_verify_transaction;
 #[test]
 pub fn prove_send_swap_note() {
     let mut mock_chain = MockChain::new();
-    let offered_asset = mock_chain.add_new_faucet(Auth::BasicAuth, "USDT", 100000u64).mint(2000);
+    let offered_asset =
+        mock_chain.add_pending_new_faucet(Auth::BasicAuth, "USDT", 100000u64).mint(2000);
     let requested_asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
-    let sender_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![offered_asset]);
+    let sender_account =
+        mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![offered_asset]);
 
     let (note, _payback) = get_swap_notes(sender_account.id(), offered_asset, requested_asset);
 
@@ -60,7 +62,7 @@ pub fn prove_send_swap_note() {
         .execute()
         .unwrap();
 
-    let sender_account = mock_chain.submit_transaction(&create_swap_note_tx);
+    let sender_account = mock_chain.add_pending_executed_transaction(&create_swap_note_tx);
 
     assert!(
         create_swap_note_tx
@@ -79,16 +81,19 @@ pub fn prove_send_swap_note() {
 #[test]
 fn prove_consume_swap_note() {
     let mut mock_chain = MockChain::new();
-    let offered_asset = mock_chain.add_new_faucet(Auth::BasicAuth, "USDT", 100000u64).mint(2000);
+    let offered_asset =
+        mock_chain.add_pending_new_faucet(Auth::BasicAuth, "USDT", 100000u64).mint(2000);
     let requested_asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
-    let sender_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![offered_asset]);
+    let sender_account =
+        mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![offered_asset]);
 
     let (note, payback_note) = get_swap_notes(sender_account.id(), offered_asset, requested_asset);
 
     // CONSUME CREATED NOTE
     // --------------------------------------------------------------------------------------------
 
-    let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
+    let target_account =
+        mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
     mock_chain.add_pending_note(OutputNote::Full(note.clone()));
     mock_chain.prove_next_block();
 
@@ -98,7 +103,7 @@ fn prove_consume_swap_note() {
         .execute()
         .unwrap();
 
-    let target_account = mock_chain.submit_transaction(&consume_swap_note_tx);
+    let target_account = mock_chain.add_pending_executed_transaction(&consume_swap_note_tx);
 
     let output_payback_note = consume_swap_note_tx.output_notes().iter().next().unwrap().clone();
     assert!(output_payback_note.id() == payback_note.id());
@@ -123,7 +128,7 @@ fn prove_consume_swap_note() {
         .execute()
         .unwrap();
 
-    let sender_account = mock_chain.submit_transaction(&consume_payback_tx);
+    let sender_account = mock_chain.add_pending_executed_transaction(&consume_payback_tx);
     assert!(sender_account.vault().assets().any(|asset| asset == requested_asset));
     assert!(prove_and_verify_transaction(consume_payback_tx).is_ok());
 }

--- a/crates/miden-testing/tests/integration/scripts/swap.rs
+++ b/crates/miden-testing/tests/integration/scripts/swap.rs
@@ -90,7 +90,7 @@ fn prove_consume_swap_note() {
 
     let target_account = mock_chain.add_existing_wallet(Auth::BasicAuth, vec![requested_asset]);
     mock_chain.add_pending_note(OutputNote::Full(note.clone()));
-    mock_chain.seal_next_block();
+    mock_chain.prove_next_block();
 
     let consume_swap_note_tx = mock_chain
         .build_tx_context(target_account.id(), &[note.id()], &[])

--- a/crates/miden-testing/tests/integration/scripts/swap.rs
+++ b/crates/miden-testing/tests/integration/scripts/swap.rs
@@ -60,7 +60,7 @@ pub fn prove_send_swap_note() {
         .execute()
         .unwrap();
 
-    let sender_account = mock_chain.apply_executed_transaction(&create_swap_note_tx);
+    let sender_account = mock_chain.submit_transaction(&create_swap_note_tx);
 
     assert!(
         create_swap_note_tx
@@ -98,7 +98,7 @@ fn prove_consume_swap_note() {
         .execute()
         .unwrap();
 
-    let target_account = mock_chain.apply_executed_transaction(&consume_swap_note_tx);
+    let target_account = mock_chain.submit_transaction(&consume_swap_note_tx);
 
     let output_payback_note = consume_swap_note_tx.output_notes().iter().next().unwrap().clone();
     assert!(output_payback_note.id() == payback_note.id());
@@ -123,7 +123,7 @@ fn prove_consume_swap_note() {
         .execute()
         .unwrap();
 
-    let sender_account = mock_chain.apply_executed_transaction(&consume_payback_tx);
+    let sender_account = mock_chain.submit_transaction(&consume_payback_tx);
     assert!(sender_account.vault().assets().any(|asset| asset == requested_asset));
     assert!(prove_and_verify_transaction(consume_payback_tx).is_ok());
 }


### PR DESCRIPTION
Refactors the `MockChain` to use the existing batch and block code to drive its state.

closes #1224 

## Relevant Changes

This PR requires that the MockChain always has a genesis block, i.e. its blocks cannot be empty. This is a consequence of the batch/block API assuming that a previous block always exists. Since this moves the mock chain closer to how the real miden-node works, I think this is fine.

On the naming front I changed some things - happy to discuss these of course:
- "sealing" a block is now "proving" a block, which is more in line with our naming elsewhere.
- "available notes/accounts" are now "committed notes/accounts" to make it a bit clearer that these are part of the chain state and better differentiate them from the pending objects. This is not completely true in all cases, i.e. for the "add pending account/faucet" APIs, but those should go away if we use the builder-style initialization mentioned above.
- all APIs that add a pending object now have "pending" in their name to make this very clear.
- Untangle the previous `seal_next_block` and `seal_block(block_num, timestamp)` APIs into `prove_next_block()`, `prove_next_block_at(timestamp)`, and `prove_until_block(block_num)` for clarity.

This PR uses a more propagation-based than panic-based error handling approach in the newly added or refactored methods. This was suggested in https://github.com/0xMiden/miden-base/issues/980. For now, this is not applied holistically because it would introduce a lot of unrelated changes in this PR (which would once again mean manually updating a lot of tests) and can be done in a subsequent PR.

`MockChain::build_tx_context` now takes a `impl Into<TxContextInput>` instead of `AccountId`. `AccountId`, `Account` and `ExecutedTransaction` can all be converted into `TxContextInput`. This enables use of this API to build a chain of transactions against an account that build on top of each other, by providing the account from which the tx context should be build directly rather than being fetched from the chain state. See `proposed_block_aggregates_account_state_transition` for an example of how this is used.

A significant caveat is that private accounts are not supported when submitted as part of transactions, because the mock chain's internal representation assumes the full `Account` is available. See also https://github.com/0xMiden/miden-base/issues/1314.

## Pending API

The main difficulty here was supporting both regular transaction submission by users as well as supporting the "pending objects" API. This API allows adding a note, account or nullifier into the chain state without actually creating a transaction that creates the note, account or nullifier. Instead, for example, adding two pending notes to the chain essentially creates them out of thin air whenever the next block is created. This is very useful for testing purposes to quickly create the initial state of a chain for a test. However, because this sidesteps the regular mechanism for modifying accounts and creating notes it is tricky to reconciliate with the regular mechanism.

There are two main areas where this API results in some messiness (and this also serves as an explanation of block building in the mock chain):

The APIs for adding new or existing accounts in particular are quite messy. They do not interact nicely with the regular batch/block building at all. For example, when applying the changes from a block, if we encounter a `AccountUpdateDetails::New`, it should be fine to assume that that account is indeed new and does not yet exist. However, it could have been added with `add_pending_new_wallet` before, which doesn't add it to the chain state but to the committed accounts. This is so we can provide a nice API, i.e. so we can easily build a transaction context from this new account. But when encountering the `AccountUpdateDetails::New`, we also can't overwrite it, because the mock chain tracks authenticators and seeds of accounts. See `MockChain::apply_block` for how this is handled now. This is all just to point out the messiness resulting from the pending API.

Block building is divided into a few steps:
1. Build batches from pending transactions and a block from those batches. This is the regular way. This results in a block.
2. Take that block and apply only its account/nullifier tree updates to the chain.
3. Then take the pending objects and insert them directly into the proven block. This means we have to update the header of the block as well now, with the newly inserted pending accounts/nullifiers/notes. This is why we already did step 2, so that we can insert the pending objects directly into the account/nullifier tree to get the latest correct state of those trees. We can then just take the root of the trees and update them in the header. This should be pretty efficient because we don't have to do any tree insertions multiple times (which would be slow). The downside is that it works with side effects, so it's not easy to understand.
4. Finally, now the block contains both the updates from the regular transactions/batches as well as the pending objects. Now insert all the remaining updates into the chain state.

I think a better way forward to make the chain less complex would be to investigate if we can remove the "pending APIs" in favor of declaring the genesis state in a builder-style API, as already suggested in https://github.com/0xMiden/miden-base/issues/980. This would work for "existing" accounts. Once the chain is created, notes or accounts could no longer be magically added to the chain. I didn't go for this right away, because this would have been an even larger refactor, also requiring refactoring close to all tests and I'm not sure if it's ergonomic enough for tests, so some investigation and discussion is needed.

The API I have in mind would be:

```rust
let mut chain_builder: MockChainBuilder = MockChain::builder();
let wallet1: Account = chain_builder.add_wallet(Auth::BasicAuth, vec![]);
let chain: MockChain = chain_builder.build();
```

For "new" accounts, I think we can provide a very similar API as today, but without the caveats of the pending APIs. The above-mentioned changes for `build_tx_context` already are a step in that direction. It's easiest to show how this could work. I've made the necessary changes in a separate branch and changed the `prove_consume_note_with_new_account` test and it passes with those changes.

https://github.com/0xMiden/miden-base/compare/71861832355c656a4caa6987c4e1b8c329a2919f...pgackst-mock-chain-pending-accounts

With those two changes, we could at least remove the "pending account" APIs which would already make the chain a bit easier. Whether we could also remove the "pending note" APIs and move them to the builder as well needs some more investigation.

## Follow-Ups

To summarize, the follow-ups could be:
- Remove "pending account" APIs and add `MockChainBuilder` and change how accounts are added to the mock chain.
- Finish the refactor to convert panics in `MockChain` to `anyhow::Result`s.
- Add support for private accounts https://github.com/0xMiden/miden-base/issues/1314
- The other points from https://github.com/0xMiden/miden-base/issues/980.