### PR TITLE
fix: replace deprecated #[clap(...)] with #[command(...)] and #[arg(...)]

### DIFF
--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -16,49 +16,49 @@ pub(crate) const PROXY_HOST: &str = "0.0.0.0";
 pub(crate) struct ProxyConfig {
     /// Interval in milliseconds at which the system polls for available workers to assign new
     /// tasks.
-    #[clap(long, default_value = "20", env = "MPS_AVAILABLE_WORKERS_POLLING_INTERVAL_MS")]
+    #[arg(long, default_value = "20", env = "MPS_AVAILABLE_WORKERS_POLLING_INTERVAL_MS")]
     pub(crate) available_workers_polling_interval_ms: u64,
     /// Maximum time in seconds to establish a connection.
-    #[clap(long, default_value = "10", env = "MPS_CONNECTION_TIMEOUT_SECS")]
+    #[arg(long, default_value = "10", env = "MPS_CONNECTION_TIMEOUT_SECS")]
     pub(crate) connection_timeout_secs: u64,
     /// Health check interval in seconds.
-    #[clap(long, default_value = "10", env = "MPS_HEALTH_CHECK_INTERVAL_SECS")]
+    #[arg(long, default_value = "10", env = "MPS_HEALTH_CHECK_INTERVAL_SECS")]
     pub(crate) health_check_interval_secs: u64,
     /// Maximum number of items in the queue.
-    #[clap(long, default_value = "10", env = "MPS_MAX_QUEUE_ITEMS")]
+    #[arg(long, default_value = "10", env = "MPS_MAX_QUEUE_ITEMS")]
     pub(crate) max_queue_items: usize,
     /// Maximum number of requests per second per IP address.
-    #[clap(long, default_value = "5", env = "MPS_MAX_REQ_PER_SEC")]
+    #[arg(long, default_value = "5", env = "MPS_MAX_REQ_PER_SEC")]
     pub(crate) max_req_per_sec: isize,
     /// Maximum number of retries per request.
-    #[clap(long, default_value = "1", env = "MPS_MAX_RETRIES_PER_REQUEST")]
+    #[arg(long, default_value = "1", env = "MPS_MAX_RETRIES_PER_REQUEST")]
     pub(crate) max_retries_per_request: usize,
     /// Metrics configurations.
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) metrics_config: MetricsConfig,
     /// Port of the proxy.
-    #[clap(long, default_value = "8082", env = "MPS_PORT")]
+    #[arg(long, default_value = "8082", env = "MPS_PORT")]
     pub(crate) port: u16,
     /// Maximum time in seconds allowed for a request to complete. Once exceeded, the request is
     /// aborted.
-    #[clap(long, default_value = "100", env = "MPS_TIMEOUT_SECS")]
+    #[arg(long, default_value = "100", env = "MPS_TIMEOUT_SECS")]
     pub(crate) timeout_secs: u64,
     /// Control port.
     ///
     /// Port used to add and remove workers from the proxy.
-    #[clap(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
+    #[arg(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
     pub(crate) control_port: u16,
     /// Supported prover type.
     ///
     /// The type of proof the proxy will handle. Only workers that support the same prover type
     /// will be able to connect to the proxy.
-    #[clap(long, default_value = "transaction", env = "MPS_PROVER_TYPE")]
+    #[arg(long, default_value = "transaction", env = "MPS_PROVER_TYPE")]
     pub(crate) prover_type: ProverType,
     /// Status port.
     ///
     /// Port used to get the status of the proxy. It is used to get the list of workers and their
     /// statuses, as well as the supported prover type and version of the proxy.
-    #[clap(long, default_value = "8084", env = "MPS_STATUS_PORT")]
+    #[arg(long, default_value = "8084", env = "MPS_STATUS_PORT")]
     pub(crate) status_port: u16,
 }
 
@@ -73,14 +73,14 @@ pub struct MetricsConfig {
 
 /// Root CLI struct
 #[derive(Parser, Debug)]
-#[clap(
+#[command(
     name = "miden-proving-service",
     about = "A stand-alone service for proving Miden transactions.",
     version,
     rename_all = "kebab-case"
 )]
 pub struct Cli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     action: Command,
 }
 

--- a/bin/proving-service/src/commands/proxy.rs
+++ b/bin/proving-service/src/commands/proxy.rs
@@ -27,10 +27,10 @@ pub struct StartProxy {
     /// List of workers as host:port strings.
     ///
     /// Example: `127.0.0.1:8080 192.168.1.1:9090`
-    #[clap(value_name = "WORKERS")]
+    #[arg(value_name = "WORKERS")]
     workers: Vec<String>,
     /// Proxy configurations.
-    #[clap(flatten)]
+    #[command(flatten)]
     proxy_config: ProxyConfig,
 }
 

--- a/bin/proving-service/src/commands/update_workers.rs
+++ b/bin/proving-service/src/commands/update_workers.rs
@@ -13,10 +13,10 @@ pub struct AddWorkers {
     /// Workers to be added to the proxy.
     ///
     /// The workers are passed as host:port strings.
-    #[clap(value_name = "WORKERS")]
+    #[arg(value_name = "WORKERS")]
     workers: Vec<String>,
     /// Port of the proxy endpoint to update workers.
-    #[clap(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
+    #[arg(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
     control_port: u16,
 }
 
@@ -31,7 +31,7 @@ pub struct RemoveWorkers {
     /// The workers are passed as host:port strings.
     workers: Vec<String>,
     /// Port of the proxy endpoint to update workers.
-    #[clap(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
+    #[arg(long, default_value = "8083", env = "MPS_CONTROL_PORT")]
     control_port: u16,
 }
 

--- a/bin/proving-service/src/commands/worker.rs
+++ b/bin/proving-service/src/commands/worker.rs
@@ -57,13 +57,13 @@ impl std::str::FromStr for ProverType {
 #[derive(Debug, Parser)]
 pub struct StartWorker {
     /// Use localhost (127.0.0.1) instead of 0.0.0.0
-    #[clap(long, env = "MPS_WORKER_LOCALHOST")]
+    #[arg(long, env = "MPS_WORKER_LOCALHOST")]
     localhost: bool,
     /// The port of the worker
-    #[clap(long, default_value = "50051", env = "MPS_WORKER_PORT")]
+    #[arg(long, default_value = "50051", env = "MPS_WORKER_PORT")]
     port: u16,
     /// The type of prover that the worker will be handling
-    #[clap(long, env = "MPS_WORKER_PROVER_TYPE")]
+    #[arg(long, env = "MPS_WORKER_PROVER_TYPE")]
     prover_type: ProverType,
 }
 


### PR DESCRIPTION
Closes #1318 

`cargo check --features clap/deprecated`
Before : 
![image](https://github.com/user-attachments/assets/38942160-9817-4ea1-aa96-d85efe0c367f)


After Fix :
![check -features clapdeprecated](https://github.com/user-attachments/assets/fc335f38-4978-495c-838e-179ea67f536d)
