### PR TITLE
chore: re-export `MastForestStore`

### DIFF
--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -12,6 +12,7 @@ use miden_objects::{
     },
     vm::StackOutputs,
 };
+pub use vm_processor::MastForestStore;
 use vm_processor::{AdviceInputs, ExecutionOptions, MemAdviceProvider, Process, RecAdviceProvider};
 use winter_maybe_async::{maybe_async, maybe_await};
 

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -10,7 +10,8 @@ pub use miden_objects::transaction::TransactionInputs;
 
 mod executor;
 pub use executor::{
-    DataStore, NoteAccountExecution, NoteConsumptionChecker, NoteInputsCheck, TransactionExecutor,
+    DataStore, MastForestStore, NoteAccountExecution, NoteConsumptionChecker, NoteInputsCheck,
+    TransactionExecutor,
 };
 
 pub mod host;


### PR DESCRIPTION
It seems the re-export was accidentally removed from `miden-tx`. We were using it in `miden-client` to implement the `DataStore` trait (which also needs `MastForestStore`) for our `ClientDataStore`.