### PR TITLE
chore: Add Debian packaging workflow

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -1,0 +1,110 @@
+name: build-package
+description: Builds miden-prover and miden-prover-proxy debian packages for the given git reference
+inputs:
+  gitref:
+    required: true
+    description: The git ref to build the packages from.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Identify target git SHA
+      id: git-sha
+      shell: bash
+      run: |
+        if git show-ref -q --verify "refs/remotes/origin/${{ inputs.gitref }}" 2>/dev/null; then
+          echo "sha=$(git show-ref --hash --verify 'refs/remotes/origin/${{ inputs.gitref }}')" >> $GITHUB_OUTPUT
+        elif git show-ref -q --verify "refs/tags/${{ inputs.gitref }}" 2>/dev/null; then
+          echo "sha=$(git show-ref --hash --verify 'refs/tags/${{ inputs.gitref }}')" >> $GITHUB_OUTPUT
+        elif git rev-parse --verify "${{ inputs.gitref }}^{commit}" >/dev/null 2>&1; then
+          echo "sha=$(git rev-parse --verify '${{ inputs.gitref }}^{commit}')" >> $GITHUB_OUTPUT
+        else
+          echo "::error::Unknown git reference type"
+          exit 1
+        fi
+
+    - name: Create package directories
+      shell: bash
+      run: |
+        for pkg in miden-prover miden-prover-proxy; do
+          mkdir -p \
+            packaging/deb/$pkg/DEBIAN \
+            packaging/deb/$pkg/usr/bin \
+            packaging/deb/$pkg/lib/systemd/system \
+            packaging/deb/$pkg/etc/opt/$pkg \
+            packaging/deb/$pkg/opt/$pkg
+        done
+
+    # These have to be downloaded as the current repo source isn't necessarily the target git reference.
+    - name: Copy package install scripts
+      shell: bash
+      run: |
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
+
+        chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
+        chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
+        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
+        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
+
+    - name: Create control files
+      shell: bash
+      run: |
+        # Map the architecture to the format required by Debian.
+        # i.e. arm64 and amd64 instead of aarch64 and x86_64.
+        arch=$(uname -m | sed "s/x86_64/amd64/" | sed "s/aarch64/arm64/")
+        # Control file's version field must be x.y.z format so strip the rest.
+        version=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]//g' )
+
+        cat > packaging/deb/miden-prover/DEBIAN/control << EOF
+        Package: miden-prover
+        Version: $version
+        Section: base
+        Priority: optional
+        Architecture: $arch
+        Maintainer: Miden <sergerad@miden.team>
+        Description: miden-prover binary package
+        Homepage: https://miden.xyz
+        Vcs-Git: git@github.com:0xMiden/miden-base.git
+        Vcs-Browser: https://github.com/0xMiden/miden-base
+        EOF
+
+        cat > packaging/deb/miden-prover-proxy/DEBIAN/control << EOF
+        Package: miden-prover-proxy
+        Version: $version
+        Section: base
+        Priority: optional
+        Architecture: $arch
+        Maintainer: Miden <sergerad@miden.team>
+        Description: miden-prover-proxy binary package
+        Homepage: https://miden.xyz
+        Vcs-Git: git@github.com:0xMiden/miden-base.git
+        Vcs-Browser: https://github.com/0xMiden/miden-base
+        EOF
+
+    - name: Build binaries
+      shell: bash
+      env:
+        repo-url: ${{ github.server_url }}/${{ github.repository }}
+      run: |
+        cargo install miden-proving-service --root . --locked --git ${{ env.repo-url }} --rev ${{ steps.git-sha.outputs.sha }}
+
+    - name: Copy binary files
+      shell: bash
+      run: |
+        cp -p ./bin/miden-proving-service   packaging/deb/miden-prover/usr/bin/
+        cp -p ./bin/miden-proving-service   packaging/deb/miden-prover-proxy/usr/bin/
+
+    - name: Build packages
+      shell: bash
+      run: |
+        dpkg-deb --build --root-owner-group packaging/deb/miden-prover
+        dpkg-deb --build --root-owner-group packaging/deb/miden-prover-proxy
+
+        # Save the .deb files, delete the rest.
+        mv packaging/deb/*.deb .
+        rm -rf packaging

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,68 @@
+name: Release packages
+run-name: Release packaging for ${{ inputs.version || github.ref }}
+
+env:
+  version: ${{ inputs.version || github.ref_name }}
+
+on:
+  release:
+    types: [released, prereleased]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  package:
+    name: ${{ inputs.version }} for ${{ matrix.arch }}
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on:
+      labels: ${{ matrix.arch == 'arm64' && 'ubuntu22-arm-4core' || 'ubuntu-latest' }}
+    steps:
+      # Note that this checkout is _not_ used as the source for the package.
+      # Instead this is required to access the workflow actions. Package source
+      # selection is handled by the packaging action.
+      - name: Checkout repo
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+
+      - name: Build packages
+        uses: ./.github/actions/build_package
+        with:
+          gitref: ${{ env.version }}
+
+      - name: Package names
+        run: |
+          echo "prover-package=miden-prover-${{ env.version }}-${{ matrix.arch }}.deb" >> $GITHUB_ENV
+          echo "prover-proxy-package=miden-prover-proxy-${{ env.version }}-${{ matrix.arch }}.deb" >> $GITHUB_ENV
+
+      - name: Rename package files
+        run: |
+          mv miden-prover.deb ${{ env.prover-package }}
+          mv miden-prover-proxy.deb ${{ env.prover-proxy-package }}
+
+      - name: shasum packages
+        run: |
+          sha256sum ${{ env.prover-package }} > ${{ env.prover-package }}.checksum
+          sha256sum ${{ env.prover-proxy-package }} > ${{ env.prover-proxy-package }}.checksum
+
+      - name: Publish packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ env.version }} \
+            ${{ env.prover-package }} \
+            ${{ env.prover-package }}.checksum \
+            ${{ env.prover-proxy-package }} \
+            ${{ env.prover-proxy-package }}.checksum \
+            --clobber

--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -1,6 +1,6 @@
 # Miden proving service
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > **Due to a transitive dependency compilation error, the only way to install the binary is using `--locked`.**
 
 A service for generating Miden proofs on-demand. The binary enables spawning workers and a proxy for Miden's remote proving service. It currently supports proving individual transactions, transaction batches, and blocks.
@@ -9,7 +9,46 @@ A worker is a gRPC service that can receive transaction witnesses, proposed batc
 
 The proxy uses [Cloudflare's Pingora crate](https://crates.io/crates/pingora), which provides features to create a modular proxy. It is meant to handle multiple workers with a queue, assigning a worker to each request and retrying if the worker is not available. Further information about Pingora and its features can be found in the [official GitHub repository](https://github.com/cloudflare/pingora).
 
-## Installation
+
+## Debian Installation
+
+#### Prover
+```bash
+set -e
+
+sudo wget https://github.com/0xMiden/miden-base/releases/download/v0.8/miden-prover-v0.8-arm64.deb -O prover.deb
+sudo wget -q -O - https://github.com/0xMiden/miden-base/releases/download/v0.8/miden-prover-v0.8-arm64.deb.checksum | awk '{print $1}' | sudo tee prover.checksum
+sudo sha256sum prover.deb | awk '{print $1}' > prover.sha256
+sudo diff prover.sha256 prover.checksum
+sudo dpkg -i prover.deb
+sudo rm prover.deb
+
+sudo chown -R miden-prover /opt/miden-prover
+
+sudo systemctl daemon-reload
+sudo systemctl enable miden-prover
+sudo systemctl start miden-prover
+```
+
+#### Prover Proxy
+```bash
+set -e
+
+sudo wget https://github.com/0xMiden/miden-base/releases/download/v0.8/miden-prover-proxy-v0.8-arm64.deb -O prover-proxy.deb
+sudo wget -q -O - https://github.com/0xMiden/miden-base/releases/download/v0.8/miden-prover-proxy-v0.8-arm64.deb.checksum | awk '{print $1}' | sudo tee prover-proxy.checksum
+sudo sha256sum prover-proxy.deb | awk '{print $1}' > prover-proxy.sha256
+sudo diff prover-proxy.sha256 prover-proxy.checksum
+sudo dpkg -i prover-proxy.deb
+sudo rm prover-proxy.deb
+
+sudo chown -R miden-prover-proxy /opt/miden-prover-proxy
+
+sudo systemctl daemon-reload
+sudo systemctl enable miden-prover-proxy
+sudo systemctl start miden-prover-proxy
+```
+
+## Source Installation
 
 To build the service from a local version, from the root of the workspace you can run:
 

--- a/packaging/prover-proxy/miden-prover-proxy.service
+++ b/packaging/prover-proxy/miden-prover-proxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Miden delegated prover proxy
+Wants=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=execExecStart=/usr/bin/miden-proving-service start-proxy --port 50051 63.176.73.108:50052 --status-port 8080
+WorkingDirectory=/opt/miden/miden-prover-proxy
+User=miden-prover-proxy
+RestartSec=5
+Restart=always

--- a/packaging/prover-proxy/postinst
+++ b/packaging/prover-proxy/postinst
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# This is a postinstallation script so the service can be configured and started when requested.
+
+# user is expected by the systemd service file and `/opt/<user>` is its working directory,
+sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent miden-prover-proxy
+
+# Working folder.
+if [ -d "/opt/miden-prover-proxy" ]
+then
+    echo "Directory /opt/miden-prover-proxy exists."
+else
+    mkdir -p /opt/miden-prover-proxy
+    sudo chown -R miden-prover-proxy /opt/miden-prover-proxy
+fi
+
+# Configuration folder
+if [ -d "/etc/opt/miden-prover-proxy" ]
+then
+    echo "Directory /etc/opt/miden-prover-proxy exists."
+else
+    mkdir -p /etc/opt/miden-prover-proxy
+    sudo chown -R miden-prover-proxy /etc/opt/miden-prover-proxy
+fi
+
+sudo systemctl daemon-reload

--- a/packaging/prover-proxy/postrm
+++ b/packaging/prover-proxy/postrm
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+###############
+# Remove miden-prover-proxy installs
+##############
+sudo rm -f /lib/systemd/system/miden-prover-proxy.service
+sudo rm -rf /opt/miden/miden-prover-proxy/
+sudo deluser miden-prover-proxy
+sudo systemctl daemon-reload

--- a/packaging/prover/miden-prover.service
+++ b/packaging/prover/miden-prover.service
@@ -1,0 +1,13 @@
+
+[Unit]
+Description=Miden delegated prover
+Wants=network-online.target
+
+[Install]WantedBy=multi-user.target
+
+[Service]
+Type=execExecStart=/usr/bin/miden-proving-service start-worker --host 0.0.0.0 --port 50052 --prover-type transaction
+WorkingDirectory=/opt/miden/prover
+User=miden-prover
+RestartSec=5
+Restart=always

--- a/packaging/prover/postinst
+++ b/packaging/prover/postinst
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# This is a postinstallation script so the service can be configured and started when requested.
+
+# user is expected by the systemd service file and `/opt/<user>` is its working directory,
+sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent miden-prover
+
+# Working folder.
+if [ -d "/opt/miden-prover" ]
+then
+    echo "Directory /opt/miden-prover exists."
+else
+    mkdir -p /opt/miden-prover
+    sudo chown -R miden-prover /opt/miden-prover
+fi
+
+# Configuration folder
+if [ -d "/etc/opt/miden-prover" ]
+then
+    echo "Directory /etc/opt/miden-prover exists."
+else
+    mkdir -p /etc/opt/miden-prover
+    sudo chown -R miden-prover /etc/opt/miden-prover
+fi
+
+sudo systemctl daemon-reload

--- a/packaging/prover/postrm
+++ b/packaging/prover/postrm
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+###############
+# Remove miden-prover installs
+##############
+sudo rm -f /lib/systemd/system/miden-prover.service
+sudo rm -rf /opt/miden/miden-prover/
+sudo deluser miden-prover
+sudo systemctl daemon-reload


### PR DESCRIPTION
Adds workflow for building Debian packages for prover and prover-proxy.

Adds systemd service file and install scripts for use in the workflow:
```
packaging
├── prover
│   ├── miden-prover.service
│   ├── postinst
│   └── postrm
└── prover-proxy
    ├── miden-prover-proxy.service
    ├── postinst
    └── postrm
```