### PR TITLE
Update `TokenSymbol` encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix error when creating accounts with empty storage (#1307).
 - [BREAKING] Move `MockChain` and `TransactionContext` to new `miden-testing` crate (#1309).
 - [BREAKING] Add support for private notes in `MockChain` (#1310).
-- Change Token Symbol encoding (#1334).
+- [BREAKING] Change Token Symbol encoding (#1334).
 
 ## 0.8.2 (2025-04-18) - `miden-proving-service` crate only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix error when creating accounts with empty storage (#1307).
 - [BREAKING] Move `MockChain` and `TransactionContext` to new `miden-testing` crate (#1309).
 - [BREAKING] Add support for private notes in `MockChain` (#1310).
+- Change Token Symbol encoding (#1334).
 
 ## 0.8.2 (2025-04-18) - `miden-proving-service` crate only
 

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -170,7 +170,7 @@ fn add_account_to_advice_inputs(
     let storage = account.storage();
 
     for slot in storage.slots() {
-        // if there are storage maps, we populate the merkle store and advice map
+        // if there are storage maps, populate the merkle store and advice map with them
         if let StorageSlot::Map(map) = slot {
             // extend the merkle store and map with the storage maps
             inputs.extend_merkle_store(map.inner_nodes());
@@ -179,7 +179,7 @@ fn add_account_to_advice_inputs(
         }
     }
 
-    // extend advice map with storage commitment |-> length, storage slots and types vector
+    // extend advice map with storage commitment |-> storage slots and types vector
     inputs.extend_map([(storage.commitment(), storage.as_elements())]);
 
     // --- account vault ------------------------------------------------------

--- a/crates/miden-objects/src/asset/mod.rs
+++ b/crates/miden-objects/src/asset/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    AssetError, Felt, Hasher, Word, ZERO,
+    AssetError, Felt, Hasher, TokenSymbolError, Word, ZERO,
     account::AccountType,
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };

--- a/crates/miden-objects/src/asset/token_symbol.rs
+++ b/crates/miden-objects/src/asset/token_symbol.rs
@@ -2,22 +2,43 @@ use alloc::string::{String, ToString};
 
 use super::{Felt, TokenSymbolError};
 
+/// Represents a string token symbol (e.g. "POL", "ETH") as a single [`Felt`] value.
+///
+/// Token Symbols can consists of up to 6 capital Latin characters, e.g. "C", "ETH", "MIDENC".
 #[derive(Default, Clone, Copy, Debug)]
 pub struct TokenSymbol(Felt);
 
 impl TokenSymbol {
+    /// Maximum allowed length of the token string.
     pub const MAX_SYMBOL_LENGTH: usize = 6;
+
+    /// The length of the set of characters that can be used in a token's name.
     pub const ALPHABET_LENGTH: u64 = 26;
 
-    // this value is the result of encoding "ZZZZZZ" token symbol
+    /// The maximum integer value of an encoded [`TokenSymbol`].
+    ///
+    /// This value encodes the "ZZZZZZ" token symbol.
     pub const MAX_ENCODED_VALUE: u64 = 8031810156;
 
+    /// Creates a new [`TokenSymbol`] instance from the provided token name string.
+    ///     
+    /// # Errors
+    /// Returns an error if:
+    /// - The length of the provided string is less than 1 or greater than 6.
+    /// - The provided token string contains characters that are not uppercase ASCII.
     pub fn new(symbol: &str) -> Result<Self, TokenSymbolError> {
         let felt = encode_symbol_to_felt(symbol)?;
         Ok(Self(felt))
     }
 
-    pub fn to_str(&self) -> Result<String, TokenSymbolError> {
+    /// Returns the token name string from the encoded [`TokenSymbol`] value.
+    ///     
+    /// # Errors
+    /// Returns an error if:
+    /// - The encoded value exceeds the maximum value of [`Self::MAX_ENCODED_VALUE`].
+    /// - The encoded token string length is less than 1 or greater than 6.
+    /// - The encoded token string length is less than the actual string length.
+    pub fn to_string(&self) -> Result<String, TokenSymbolError> {
         decode_felt_to_symbol(self.0)
     }
 }
@@ -42,7 +63,7 @@ impl TryFrom<Felt> for TokenSymbol {
     fn try_from(felt: Felt) -> Result<Self, Self::Error> {
         // Check if the felt value is within the valid range
         if felt.as_int() > Self::MAX_ENCODED_VALUE {
-            return Err(TokenSymbolError::ValueTooLarge(felt.as_int(), Self::MAX_ENCODED_VALUE));
+            return Err(TokenSymbolError::ValueTooLarge(felt.as_int()));
         }
         Ok(TokenSymbol(felt))
     }
@@ -50,8 +71,24 @@ impl TryFrom<Felt> for TokenSymbol {
 
 // HELPER FUNCTIONS
 // ================================================================================================
-// Utils to encode and decode the token symbol as a Felt. Token Symbols can consists of up to 6
-// characters , e.g., A = 0, ...
+
+/// Encodes the provided token symbol string into a single [`Felt`] value.
+///
+/// The alphabet used in the decoding process consists of the Latin capital letters as defined in
+/// the ASCII table, having the length of 26 characters.
+///
+/// The encoding is performed by multiplying the intermediate encrypted value by the length of the
+/// used alphabet and adding the relative index of the character to it. At the end of the encoding
+/// process the length of the initial token string is added to the encrypted value.
+///
+/// Relative character index is computed by subtracting the index of the character "A" (65) from the
+/// index of the currently processing character, e.g., `A = 65 - 65 = 0`, `B = 66 - 65 = 1`, `...` ,
+/// `Z = 90 - 65 = 25`.
+///
+/// # Errors
+/// Returns an error if:
+/// - The length of the provided string is less than 1 or greater than 6.
+/// - The provided token string contains characters that are not uppercase ASCII.
 fn encode_symbol_to_felt(s: &str) -> Result<Felt, TokenSymbolError> {
     if s.is_empty() || s.len() > TokenSymbol::MAX_SYMBOL_LENGTH {
         return Err(TokenSymbolError::InvalidLength(s.len()));
@@ -62,7 +99,7 @@ fn encode_symbol_to_felt(s: &str) -> Result<Felt, TokenSymbolError> {
     let mut encoded_value = 0;
     for char in s.chars() {
         let digit = char as u64 - b'A' as u64;
-        assert!(digit < TokenSymbol::ALPHABET_LENGTH);
+        debug_assert!(digit < TokenSymbol::ALPHABET_LENGTH);
         encoded_value = encoded_value * TokenSymbol::ALPHABET_LENGTH + digit;
     }
 
@@ -72,9 +109,34 @@ fn encode_symbol_to_felt(s: &str) -> Result<Felt, TokenSymbolError> {
     Ok(Felt::new(encoded_value))
 }
 
+/// Decodes the [`TokenSymbol`] into a token symbol string.
+///
+/// The alphabet used in the decoding process consists of the Latin capital letters as defined in
+/// the ASCII table, having the length of 26 characters.
+///
+/// The decoding is performed by getting the modulus of the intermediate encrypted value by the
+/// length of the used alphabet and then dividing the intermediate value by the length of the
+/// alphabet to shift to the next character. At the beginning of the decoding process the length of
+/// the initial token string is obtained from the encrypted value. After that the value obtained
+/// after taking the modulus represents the relative character index, which then gets converted to
+/// the ASCII index.
+///
+/// Final ASCII character idex is computed by adding the index of the character "A" (65) to the
+/// index of the currently processing character, e.g., `A = 0 + 65 = 65`, `B = 1 + 65 = 66`, `...` ,
+/// `Z = 25 + 65 = 90`.
+///
+/// # Errors
+/// Returns an error if:
+/// - The encoded value exceeds the maximum value of [`TokenSymbol::MAX_ENCODED_VALUE`].
+/// - The encoded token string length is less than 1 or greater than 6.
+/// - The encoded token string length is less than the actual string length.
 fn decode_felt_to_symbol(encoded_felt: Felt) -> Result<String, TokenSymbolError> {
     let encoded_value = encoded_felt.as_int();
-    assert!(encoded_value <= TokenSymbol::MAX_ENCODED_VALUE);
+
+    // Check if the encoded value is within the valid range
+    if encoded_value > TokenSymbol::MAX_ENCODED_VALUE {
+        return Err(TokenSymbolError::ValueTooLarge(encoded_value));
+    }
 
     let mut decoded_string = String::new();
     let mut remaining_value = encoded_value;
@@ -104,32 +166,65 @@ fn decode_felt_to_symbol(encoded_felt: Felt) -> Result<String, TokenSymbolError>
 
 // TESTS
 // ================================================================================================
-#[test]
-fn test_token_symbol_decoding_encoding() {
+
+#[cfg(test)]
+mod test {
     use assert_matches::assert_matches;
 
-    let symbols = vec!["AAAAAA", "AAAAAB", "AAAAAC", "ABC", "BC", "ZZZZZZ"];
-    for symbol in symbols {
-        let token_symbol = TokenSymbol::try_from(symbol).unwrap();
-        let decoded_symbol = TokenSymbol::to_str(&token_symbol).unwrap();
-        assert_eq!(symbol, decoded_symbol);
+    use super::{
+        Felt, TokenSymbol, TokenSymbolError, decode_felt_to_symbol, encode_symbol_to_felt,
+    };
+
+    #[test]
+    fn test_token_symbol_decoding_encoding() {
+        let symbols = vec!["AAAAAA", "AAAAB", "AAAC", "ABC", "BC", "A", "B", "ZZZZZZ"];
+        for symbol in symbols {
+            let token_symbol = TokenSymbol::try_from(symbol).unwrap();
+            let decoded_symbol = TokenSymbol::to_string(&token_symbol).unwrap();
+            assert_eq!(symbol, decoded_symbol);
+        }
+
+        let symbol = "";
+        let felt = encode_symbol_to_felt(symbol);
+        assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidLength(0));
+
+        let symbol = "ABCDEFG";
+        let felt = encode_symbol_to_felt(symbol);
+        assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidLength(7));
+
+        let symbol = "$$$";
+        let felt = encode_symbol_to_felt(symbol);
+        assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidCharacter(s) if s == *"$$$");
+
+        let symbol = "ABCDEF";
+        let token_symbol = TokenSymbol::try_from(symbol);
+        assert!(token_symbol.is_ok());
+        let token_symbol_felt: Felt = token_symbol.unwrap().into();
+        assert_eq!(token_symbol_felt, encode_symbol_to_felt(symbol).unwrap());
     }
 
-    let symbol = "";
-    let felt = encode_symbol_to_felt(symbol);
-    assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidLength(0));
+    /// Checks that if the encoded length of the token is less than the actual number of token
+    /// characters, [decode_felt_to_symbol] procedure should return the
+    /// [TokenSymbolError::DataNotFullyDecoded] error.
+    #[test]
+    fn test_invalid_token_len() {
+        // encoded value of this token has `6` as the length of the initial token string
+        let encoded_symbol = TokenSymbol::try_from("ABCDEF").unwrap();
 
-    let symbol = "ABCDEFG";
-    let felt = encode_symbol_to_felt(symbol);
-    assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidLength(7));
+        // decrease encoded length by, for example, `3`
+        let invalid_encoded_symbol_u64 = Felt::from(encoded_symbol).as_int() - 3;
 
-    let symbol = "$$$";
-    let felt = encode_symbol_to_felt(symbol);
-    assert_matches!(felt.unwrap_err(), TokenSymbolError::InvalidCharacter(s) if s == *"$$$");
+        // check that `decode_felt_to_symbol()` procedure returns an error in attempt to create a
+        // token from encoded token with invalid length
+        let err = decode_felt_to_symbol(Felt::new(invalid_encoded_symbol_u64)).unwrap_err();
+        assert_matches!(err, TokenSymbolError::DataNotFullyDecoded);
+    }
 
-    let symbol = "ABCDEF";
-    let token_symbol = TokenSymbol::try_from(symbol);
-    assert!(token_symbol.is_ok());
-    let token_symbol_felt: Felt = token_symbol.unwrap().into();
-    assert_eq!(token_symbol_felt, encode_symbol_to_felt(symbol).unwrap());
+    /// Utility test just to make sure that the [TokenSymbol::MAX_ENCODED_VALUE] constant still
+    /// represents the maximum possible encoded value.
+    #[test]
+    fn test_token_symbol_max_value() {
+        let token_symbol = TokenSymbol::try_from("ZZZZZZ").unwrap();
+        assert_eq!(Felt::from(token_symbol).as_int(), TokenSymbol::MAX_ENCODED_VALUE);
+    }
 }

--- a/crates/miden-objects/src/asset/token_symbol.rs
+++ b/crates/miden-objects/src/asset/token_symbol.rs
@@ -109,7 +109,7 @@ fn encode_symbol_to_felt(s: &str) -> Result<Felt, TokenSymbolError> {
     Ok(Felt::new(encoded_value))
 }
 
-/// Decodes the [`TokenSymbol`] into a token symbol string.
+/// Decodes a [Felt] representation of the token symbol into a string.
 ///
 /// The alphabet used in the decoding process consists of the Latin capital letters as defined in
 /// the ASCII table, having the length of 26 characters.

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -324,8 +324,23 @@ pub enum AssetError {
       expected_ty = AccountType::NonFungibleFaucet
     )]
     NonFungibleFaucetIdTypeMismatch(AccountIdPrefix),
-    #[error("{0}")]
-    TokenSymbolError(String),
+    #[error("provided token symbol invalid")]
+    TokenSymbolError(#[source] TokenSymbolError),
+}
+
+// TOKEN SYMBOL ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum TokenSymbolError {
+    #[error("token symbol value {0} cannot exceed {1}")]
+    ValueTooLarge(u64, u64),
+    #[error("token symbol should have length between 1 and 6 characters, but {0} was provided")]
+    InvalidLength(usize),
+    #[error("token symbol {0} contains characters that are not uppercase ASCII")]
+    InvalidCharacter(String),
+    #[error("after the specified number of characters were decoded there is still data left")]
+    DataNotFullyDecoded,
 }
 
 // ASSET VAULT ERROR

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -10,7 +10,7 @@ use vm_processor::DeserializationError;
 use super::{
     Digest, MAX_BATCHES_PER_BLOCK, MAX_OUTPUT_NOTES_PER_BATCH, Word,
     account::AccountId,
-    asset::{FungibleAsset, NonFungibleAsset},
+    asset::{FungibleAsset, NonFungibleAsset, TokenSymbol},
     crypto::merkle::MerkleError,
     note::NoteId,
 };
@@ -324,8 +324,6 @@ pub enum AssetError {
       expected_ty = AccountType::NonFungibleFaucet
     )]
     NonFungibleFaucetIdTypeMismatch(AccountIdPrefix),
-    #[error("provided token symbol invalid")]
-    TokenSymbolError(#[source] TokenSymbolError),
 }
 
 // TOKEN SYMBOL ERROR
@@ -333,13 +331,13 @@ pub enum AssetError {
 
 #[derive(Debug, Error)]
 pub enum TokenSymbolError {
-    #[error("token symbol value {0} cannot exceed {1}")]
-    ValueTooLarge(u64, u64),
+    #[error("token symbol value {0} cannot exceed {max}", max = TokenSymbol::MAX_ENCODED_VALUE)]
+    ValueTooLarge(u64),
     #[error("token symbol should have length between 1 and 6 characters, but {0} was provided")]
     InvalidLength(usize),
-    #[error("token symbol {0} contains characters that are not uppercase ASCII")]
+    #[error("token symbol `{0}` contains characters that are not uppercase ASCII")]
     InvalidCharacter(String),
-    #[error("after the specified number of characters were decoded there is still data left")]
+    #[error("token symbol data left after decoding the specified number of characters")]
     DataNotFullyDecoded,
 }
 

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -27,7 +27,7 @@ pub use errors::{
     AccountDeltaError, AccountError, AccountIdError, AccountTreeError, AssetError, AssetVaultError,
     BatchAccountUpdateError, NetworkIdError, NoteError, NullifierTreeError, PartialBlockchainError,
     ProposedBatchError, ProposedBlockError, ProvenBatchError, ProvenTransactionError,
-    TransactionInputError, TransactionOutputError, TransactionScriptError,
+    TokenSymbolError, TransactionInputError, TransactionOutputError, TransactionScriptError,
 };
 pub use miden_crypto::hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest};
 pub use vm_core::{


### PR DESCRIPTION
This small PR adds the token symbol length to the resulting encoded token symbol value. This is done to be able to unambiguously decode the underlying symbol string. 

Closes: #1317