### PR TITLE
chore: Update Debian package worfklow to work with latest packaging files

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -35,21 +35,22 @@ runs:
             packaging/deb/$pkg/opt/$pkg
         done
 
-    # These have to be downloaded as the current repo source isn't necessarily the target git reference.
-    - name: Copy package install scripts
-      shell: bash
-      run: |
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
-        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
+    # TODO(sergerad): Enable this after our first release which includes the packaging files.
+    ## These have to be downloaded as the current repo source isn't necessarily the target git reference.
+    #- name: Copy package install scripts
+    #  shell: bash
+    #  run: |
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
+    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
 
-        chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
-        chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
-        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
-        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
+    #    chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
+    #    chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
+    #    chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
+    #    chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
 
     - name: Create control files
       shell: bash


### PR DESCRIPTION
Currently the workflow assumes the tagged commit we are packaging includes the Debian packaging files. This will not be the case until we do a Github release including changes from https://github.com/0xMiden/miden-base/pull/1332.

This change will allow us to push the Debian package for v0.8.1 despite the fact that the corresponding commit does not contain the Debian packaging files.

We can revert this change after we do our next Github release.