### PR TITLE
Remove `dead_code` flag

### DIFF
--- a/crates/miden-testing/src/mock_chain/account.rs
+++ b/crates/miden-testing/src/mock_chain/account.rs
@@ -28,7 +28,6 @@ impl MockAccount {
         MockAccount { account, seed, authenticator }
     }
 
-    #[allow(dead_code)]
     pub fn apply_delta(&mut self, delta: &AccountDelta) -> Result<(), AccountError> {
         self.account.apply_delta(delta)
     }


### PR DESCRIPTION
Continuation of https://github.com/0xMiden/miden-client/pull/890

The `apply_delta` method is used in `MockChain` making the `cfg` unnecessary