### PR TITLE
fix: bench-tx execution

### DIFF
--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -110,8 +110,13 @@ pub fn benchmark_p2id() -> Result<TransactionMeasurements, String> {
     )
     .unwrap();
 
+    let tx_script_target =
+        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, [], TransactionKernel::assembler())
+            .unwrap();
+
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .input_notes(vec![note.clone()])
+        .tx_script(tx_script_target.clone())
         .build();
     let block_ref = tx_context.tx_inputs().block_header().block_num();
 
@@ -120,9 +125,6 @@ pub fn benchmark_p2id() -> Result<TransactionMeasurements, String> {
     let executor =
         TransactionExecutor::new(Arc::new(tx_context), Some(falcon_auth.clone())).with_tracing();
 
-    let tx_script_target =
-        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, [], TransactionKernel::assembler())
-            .unwrap();
     let tx_args_target = TransactionArgs::default().with_tx_script(tx_script_target);
 
     // execute transaction


### PR DESCRIPTION
PR fixes an error in running the `bench-tx` benchmarks for transactions. 

### Error
Running `make bench-tx` results in the following error:

```
thread 'main' panicked at bin/bench-tx/src/main.rs:133:10:
called `Result::unwrap()` on an `Err` value: TransactionProgramExecutionFailed(DynamicNodeNotFound(RpoDigest([15598073319142585341, 3746686999150019745, 15192556450201485061, 162899362230949492])))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [bench-tx] Error 101
```

This occurs when benchmarking transactions that consume P2ID notes. See specific function [here](https://github.com/0xMiden/miden-base/blob/2a4b8d18ee1942b328c30460fd1bea97f0e4da9c/bin/bench-tx/src/main.rs#L84)

The [benchmark_p2id](https://github.com/0xMiden/miden-base/blob/2a4b8d18ee1942b328c30460fd1bea97f0e4da9c/bin/bench-tx/src/main.rs#L84) function loads a transaction [script](https://github.com/0xMiden/miden-base/blob/2a4b8d18ee1942b328c30460fd1bea97f0e4da9c/bin/bench-tx/src/main.rs#L123) at some point. Seems like at some point during execution, the executor tries to call some code specific to the transaction script, but it cannot find it's digest hash because the transaction script's MAST is not available to the VM. This trigger's the following [error](https://github.com/0xMiden/miden-vm/blob/c91fa92d91532c4202cbf1ffff2f9e944747bf68/processor/src/lib.rs#L520) in the processor. 


### Solution

Just passed the transaction script loaded in the benchmark to the `TransactionContextBuilder` which eventually incorporates transaction script's digests into the MAST store. 
