### PR TITLE
Add the `clippy.toml` file

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -238,7 +238,6 @@ impl AccountId {
     ///
     /// The grinding process is started from the given `init_seed` which should be a random seed
     /// generated from a cryptographically secure source.
-    #[allow(clippy::too_many_arguments)]
     pub fn compute_account_seed(
         init_seed: [u8; 32],
         account_type: AccountType,

--- a/crates/miden-objects/src/account/account_id/seed.rs
+++ b/crates/miden-objects/src/account/account_id/seed.rs
@@ -17,7 +17,6 @@ use crate::{
 /// This currently always uses a single thread. This method used to either use a single- or
 /// multi-threaded implementation based on a compile-time feature flag. The multi-threaded
 /// implementation was removed in commit dab6159318832fc537bb35abf251870a9129ac8c in PR 1061.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn compute_account_seed(
     init_seed: [u8; 32],
     account_type: AccountType,
@@ -40,7 +39,6 @@ pub(super) fn compute_account_seed(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn compute_account_seed_single(
     init_seed: [u8; 32],
     account_type: AccountType,

--- a/crates/miden-objects/src/account/account_id/v0/mod.rs
+++ b/crates/miden-objects/src/account/account_id/v0/mod.rs
@@ -160,7 +160,6 @@ impl AccountIdV0 {
     }
 
     /// See [`AccountId::compute_account_seed`](super::AccountId::compute_account_seed) for details.
-    #[allow(clippy::too_many_arguments)]
     pub fn compute_account_seed(
         init_seed: [u8; 32],
         account_type: AccountType,

--- a/crates/miden-objects/src/batch/proven_batch.rs
+++ b/crates/miden-objects/src/batch/proven_batch.rs
@@ -34,7 +34,6 @@ impl ProvenBatch {
     ///
     /// Returns an error if the batch expiration block number is not greater than the reference
     /// block number.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: BatchId,
         reference_block_commitment: Digest,


### PR DESCRIPTION
Adds the `clippy.toml` file to allow fine-grained configuration of Clippy lints. For example, `disallowed-types` or `doc-valid-idents`.

This PR specifically raises the `too-many-arguments` threshold from 7 to 8, which allows the removal of many `#[allow(clippy::too_many_arguments)]` flags.