### PR TITLE
Refactor tx benchmark to use `TransactionContext::execute`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
 name = "miden-bench-tx"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "miden-lib",
  "miden-objects",
  "miden-processor",

--- a/bin/bench-tx/Cargo.toml
+++ b/bin/bench-tx/Cargo.toml
@@ -14,6 +14,7 @@ name = "bench-tx"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = { version = "1.0", features = ["std", "backtrace"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miden-tx = { workspace = true, features = ["testing"] }

--- a/bin/bench-tx/bench-tx.json
+++ b/bin/bench-tx/bench-tx.json
@@ -1,19 +1,19 @@
 {
   "simple": {
-    "prologue": 4380,
-    "notes_processing": 2307,
+    "prologue": 4371,
+    "notes_processing": 2379,
     "note_execution": {
-      "0x21b44377de8dd01d136a70800cb66bb08f0a2e7b70f77a8781fad1719baf145a": 1487,
-      "0xa7394456a1ba2808b1d27c6f91e9830ccd9d0e3e128bc5fcb632c74cca3d487b": 779
+      "0xccc0bb4ef7e27c1fd6ada71b87574e1b48f996b328b5f5d80eb526e6c288e0a6": 803,
+      "0xd6936c529c79d21ddc287db672f07b150b8c06cd8b2b8d9c2c66b1bedb4a67fd": 1535
     },
     "tx_script_processing": 45,
-    "epilogue": 2385
+    "epilogue": 2418
   },
   "p2id": {
-    "prologue": 2655,
-    "notes_processing": 1277,
+    "prologue": 2624,
+    "notes_processing": 1288,
     "note_execution": {
-      "0xce602ae68983c400dd1fb71154e6c752174da8809e8c107a0edff6a3a96618a4": 1244
+      "0xce602ae68983c400dd1fb71154e6c752174da8809e8c107a0edff6a3a96618a4": 1255
     },
     "tx_script_processing": 60871,
     "epilogue": 432


### PR DESCRIPTION
Simplifies the benchmarks to avoid some of the awkwardness mentioned in https://github.com/0xMiden/miden-base/pull/1351/files#r2083283082, i.e. using the transaction script twice. This was due to using the transaction context as a data store, when we could've called `TransactionContext::execute` instead - which is what this PR does.