### PR TITLE
Refactor Debian packages

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -34,8 +34,17 @@ runs:
             packaging/deb/$pkg/etc/opt/$pkg \
             packaging/deb/$pkg/opt/$pkg
         done
-
-    # TODO(sergerad): Enable this after our first release which includes the packaging files.
+        cp packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
+        cp packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
+        cp packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+        cp packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
+        cp packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
+        cp packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
+        chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
+        chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
+        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
+        chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
+    # TODO(sergerad): Enable this after our first release which includes the packaging files. Delete above lines after `done`.
     ## These have to be downloaded as the current repo source isn't necessarily the target git reference.
     #- name: Copy package install scripts
     #  shell: bash

--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -31,12 +31,14 @@ runs:
             packaging/deb/$pkg/DEBIAN \
             packaging/deb/$pkg/usr/bin \
             packaging/deb/$pkg/lib/systemd/system \
-            packaging/deb/$pkg/etc/opt/$pkg \
+            packaging/deb/$pkg/lib/systemd/system/${pkg}.service.d \
             packaging/deb/$pkg/opt/$pkg
         done
+        cp bin/proving-service/.env > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service.d/debian.conf
         cp packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
         cp packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
         cp packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+        cp bin/proving-service/.env > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service.d/debian.conf
         cp packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
         cp packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
         cp packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
@@ -49,9 +51,11 @@ runs:
     #- name: Copy package install scripts
     #  shell: bash
     #  run: |
+    #    git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service.d/debian.conf
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+    #    git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env   > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service.d/debian.conf
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
     #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm

--- a/bin/proving-service/.env
+++ b/bin/proving-service/.env
@@ -1,7 +1,11 @@
+# Proxy ############################
+# Port of the proxy
 MPS_PORT="8082"
+# Port to add / remove workers
 MPS_CONTROL_PORT="8083"
 # Uncomment the following line to enable Prometheus metrics on port 6192
 # MPS_METRICS_PORT="6192"
+
 MPS_TIMEOUT_SECS="100"
 MPS_CONNECTION_TIMEOUT_SECS="10"
 MPS_MAX_QUEUE_ITEMS="10"
@@ -13,8 +17,11 @@ MPS_ENABLE_METRICS="false"
 MPS_PROVER_TYPE="transaction"
 MPS_STATUS_PORT="8084"
 RUST_LOG="info"
+####################################
 
-# Worker configuration
-MPS_WORKER_LOCALHOST=true
+# Worker ###########################
+# Use 127.0.0.1 instead of 0.0.0.0
+MPS_WORKER_LOCALHOST=false
 MPS_WORKER_PORT="50051"
 MPS_WORKER_PROVER_TYPE="transaction"
+####################################

--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -13,6 +13,8 @@ The proxy uses [Cloudflare's Pingora crate](https://crates.io/crates/pingora), w
 ## Debian Installation
 
 #### Prover
+
+Install the Debian package:
 ```bash
 set -e
 
@@ -22,9 +24,12 @@ sudo sha256sum prover.deb | awk '{print $1}' > prover.sha256
 sudo diff prover.sha256 prover.checksum
 sudo dpkg -i prover.deb
 sudo rm prover.deb
+```
 
-sudo chown -R miden-prover /opt/miden-prover
+Edit the configuration file at `/etc/opt/miden-prover/service.conf`.
 
+Run the service:
+```bash
 sudo systemctl daemon-reload
 sudo systemctl enable miden-prover
 sudo systemctl start miden-prover
@@ -40,9 +45,12 @@ sudo sha256sum prover-proxy.deb | awk '{print $1}' > prover-proxy.sha256
 sudo diff prover-proxy.sha256 prover-proxy.checksum
 sudo dpkg -i prover-proxy.deb
 sudo rm prover-proxy.deb
+```
 
-sudo chown -R miden-prover-proxy /opt/miden-prover-proxy
+Edit the configuration file at `/etc/opt/miden-prover-proxy/service.conf`.
 
+Run the service:
+```bash
 sudo systemctl daemon-reload
 sudo systemctl enable miden-prover-proxy
 sudo systemctl start miden-prover-proxy

--- a/bin/proving-service/README.md
+++ b/bin/proving-service/README.md
@@ -26,7 +26,7 @@ sudo dpkg -i prover.deb
 sudo rm prover.deb
 ```
 
-Edit the configuration file at `/etc/opt/miden-prover/service.conf`.
+Edit the configuration file at `/lib/systemd/system/miden-prover.service.d/debian.conf`.
 
 Run the service:
 ```bash
@@ -47,7 +47,7 @@ sudo dpkg -i prover-proxy.deb
 sudo rm prover-proxy.deb
 ```
 
-Edit the configuration file at `/etc/opt/miden-prover-proxy/service.conf`.
+Edit the configuration file at `/lib/systemd/system/miden-prover-proxy.service.d/debian.conf`.
 
 Run the service:
 ```bash

--- a/packaging/prover-proxy/miden-prover-proxy.service
+++ b/packaging/prover-proxy/miden-prover-proxy.service
@@ -7,7 +7,8 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-ExecStart=/usr/bin/miden-proving-service start-proxy --port 50051 10.0.1.254:50052
+EnvironmentFile=/etc/opt/miden-prover-proxy/service.conf
+ExecStart=/usr/bin/miden-proving-service start-proxy --port ${PORT} ${PROVER_HOST}:${PROVER_PORT}
 WorkingDirectory=/opt/miden-prover-proxy
 User=miden-prover-proxy
 RestartSec=5

--- a/packaging/prover-proxy/miden-prover-proxy.service
+++ b/packaging/prover-proxy/miden-prover-proxy.service
@@ -7,8 +7,8 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-EnvironmentFile=/etc/opt/miden-prover-proxy/service.conf
-ExecStart=/usr/bin/miden-proving-service start-proxy --port ${PORT} ${PROVER_HOST}:${PROVER_PORT}
+EnvironmentFile=/lib/systemd/system/miden-prover-proxy.service.d/debian.conf
+ExecStart=/usr/bin/miden-proving-service start-proxy
 WorkingDirectory=/opt/miden-prover-proxy
 User=miden-prover-proxy
 RestartSec=5

--- a/packaging/prover-proxy/postinst
+++ b/packaging/prover-proxy/postinst
@@ -21,6 +21,11 @@ then
 else
     mkdir -p /etc/opt/miden-prover-proxy
     sudo chown -R miden-prover-proxy /etc/opt/miden-prover-proxy
+    cat << EOF | sudo tee /etc/opt/miden-prover-proxy/service.conf
+    PORT=50051
+    PROVER_HOST=127.0.0.1
+    PROVER_PORT=50052
+    EOF
 fi
 
 sudo systemctl daemon-reload

--- a/packaging/prover-proxy/postinst
+++ b/packaging/prover-proxy/postinst
@@ -6,26 +6,11 @@
 sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent miden-prover-proxy
 
 # Working folder.
-if [ -d "/opt/miden-prover-proxy" ]
-then
-    echo "Directory /opt/miden-prover-proxy exists."
-else
-    mkdir -p /opt/miden-prover-proxy
-    sudo chown -R miden-prover-proxy /opt/miden-prover-proxy
-fi
+work="/opt/miden-prover-proxy"
+sudo chown -R miden-prover-proxy "$work"
 
 # Configuration folder
-if [ -d "/etc/opt/miden-prover-proxy" ]
-then
-    echo "Directory /etc/opt/miden-prover-proxy exists."
-else
-    mkdir -p /etc/opt/miden-prover-proxy
-    sudo chown -R miden-prover-proxy /etc/opt/miden-prover-proxy
-    cat << EOF | sudo tee /etc/opt/miden-prover-proxy/service.conf
-    PORT=50051
-    PROVER_HOST=127.0.0.1
-    PROVER_PORT=50052
-    EOF
-fi
+conf="/lib/systemd/system/miden-prover-proxy.service.d"
+sudo chown -R miden-prover-proxy "$conf"
 
 sudo systemctl daemon-reload

--- a/packaging/prover-proxy/postrm
+++ b/packaging/prover-proxy/postrm
@@ -3,8 +3,8 @@
 ###############
 # Remove miden-prover-proxy installs
 ##############
-sudo rm -f /etc/systemd/system/miden-prover-proxy.service
+sudo rm -f /lib/systemd/system/miden-prover-proxy.service
+sudo rm -rf /lib/systemd/system/miden-prover-proxy.service.d/
 sudo rm -rf /opt/miden/miden-prover-proxy/
-sudo rm -rf /etc/opt/miden/miden-prover-proxy/
 sudo deluser miden-prover-proxy
 sudo systemctl daemon-reload

--- a/packaging/prover-proxy/postrm
+++ b/packaging/prover-proxy/postrm
@@ -3,7 +3,8 @@
 ###############
 # Remove miden-prover-proxy installs
 ##############
-sudo rm -f /lib/systemd/system/miden-prover-proxy.service
+sudo rm -f /etc/systemd/system/miden-prover-proxy.service
 sudo rm -rf /opt/miden/miden-prover-proxy/
+sudo rm -rf /etc/opt/miden/miden-prover-proxy/
 sudo deluser miden-prover-proxy
 sudo systemctl daemon-reload

--- a/packaging/prover/miden-prover.service
+++ b/packaging/prover/miden-prover.service
@@ -7,8 +7,8 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-EnvironmentFile=/etc/opt/miden-prover/service.conf
-ExecStart=/usr/bin/miden-proving-service start-worker --host 0.0.0.0 --port ${PORT} --${TYPE}-prover
+EnvironmentFile=/lib/systemd/system/miden-prover.service.d/debian.conf
+ExecStart=/usr/bin/miden-proving-service start-worker
 WorkingDirectory=/opt/miden-prover
 User=miden-prover
 RestartSec=5

--- a/packaging/prover/miden-prover.service
+++ b/packaging/prover/miden-prover.service
@@ -7,7 +7,8 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-ExecStart=/usr/bin/miden-proving-service start-worker --host 0.0.0.0 --port 50052 --tx-prover
+EnvironmentFile=/etc/opt/miden-prover/service.conf
+ExecStart=/usr/bin/miden-proving-service start-worker --host 0.0.0.0 --port ${PORT} --${TYPE}-prover
 WorkingDirectory=/opt/miden-prover
 User=miden-prover
 RestartSec=5

--- a/packaging/prover/postinst
+++ b/packaging/prover/postinst
@@ -6,25 +6,11 @@
 sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent miden-prover
 
 # Working folder.
-if [ -d "/opt/miden-prover" ]
-then
-    echo "Directory /opt/miden-prover exists."
-else
-    mkdir -p /opt/miden-prover
-    sudo chown -R miden-prover /opt/miden-prover
-fi
+work="/opt/miden-prover"
+sudo chown -R miden-prover "$work"
 
 # Configuration folder
-if [ -d "/etc/opt/miden-prover" ]
-then
-    echo "Directory /etc/opt/miden-prover exists."
-else
-    mkdir -p /etc/opt/miden-prover
-    sudo chown -R miden-prover /etc/opt/miden-prover
-    cat << EOF | sudo tee /etc/opt/miden-prover/service.conf
-    PORT=50052
-    TYPE=tx # [tx, batch, block]
-    EOF
-fi
+conf="/lib/systemd/system/miden-prover.service.d/debian.conf"
+sudo chown -R miden-prover "$conf"
 
 sudo systemctl daemon-reload

--- a/packaging/prover/postinst
+++ b/packaging/prover/postinst
@@ -21,6 +21,10 @@ then
 else
     mkdir -p /etc/opt/miden-prover
     sudo chown -R miden-prover /etc/opt/miden-prover
+    cat << EOF | sudo tee /etc/opt/miden-prover/service.conf
+    PORT=50052
+    TYPE=tx # [tx, batch, block]
+    EOF
 fi
 
 sudo systemctl daemon-reload

--- a/packaging/prover/postrm
+++ b/packaging/prover/postrm
@@ -3,7 +3,8 @@
 ###############
 # Remove miden-prover installs
 ##############
-sudo rm -f /lib/systemd/system/miden-prover.service
+sudo rm -f /etc/systemd/system/miden-prover.service
 sudo rm -rf /opt/miden/miden-prover/
+sudo rm -rf /etc/opt/miden/miden-prover/
 sudo deluser miden-prover
 sudo systemctl daemon-reload

--- a/packaging/prover/postrm
+++ b/packaging/prover/postrm
@@ -3,8 +3,8 @@
 ###############
 # Remove miden-prover installs
 ##############
-sudo rm -f /etc/systemd/system/miden-prover.service
+sudo rm -f /lib/systemd/system/miden-prover.service
+sudo rm -rf /lib/systemd/system/miden-prover.service.d/
 sudo rm -rf /opt/miden/miden-prover/
-sudo rm -rf /etc/opt/miden/miden-prover/
 sudo deluser miden-prover
 sudo systemctl daemon-reload


### PR DESCRIPTION
Closes #1341.

Fixes bug that was preventing service and installation files from being included into the packages.

Adds (env var) configuration files for the Debian packages.

Restructures package directories to follow systemd docs:
- `/lib/systemd/system/miden-prover.service`
- `/lib/systemd/system/miden-prover.service.d/debian.conf`
- `/opt/miden-prover/`