### PR TITLE
fix: remove padding from output note inputs

### DIFF
--- a/crates/miden-objects/src/note/recipient.rs
+++ b/crates/miden-objects/src/note/recipient.rs
@@ -59,10 +59,11 @@ impl NoteRecipient {
 
     /// Returns the recipient encoded as [Felt]s.
     pub fn to_elements(&self) -> Vec<Felt> {
-        let mut result = Vec::with_capacity(12);
+        let mut result = Vec::with_capacity(13);
         result.extend(self.inputs.commitment());
         result.extend(self.script.root());
         result.extend(self.serial_num);
+        result.push(self.inputs.num_values().into());
         result
     }
 }


### PR DESCRIPTION
After `cargo update`ing in the client we started getting errors related to the number of note inputs. It seems like there was an error after #1327 with output notes that were then used as input notes. Specifically, the input note derived from the output note contained padding in its note inputs.
Our solution was to add the number of note inputs into the recipient's advice map entry, we're not sure if this is the correct approach though. 