### PR TITLE
Implement conversion from `Account` for `BasicFungibleFaucet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [BREAKING] Change Token Symbol encoding (#1334).
 - [BREAKING] Upgrade VM to 0.14 and refactor transaction kernel error extraction (#1353).
 - Add iterators over concrete asset types in `NoteAssets` (#1346).
+- Add the ability to create `BasicFungibleFaucet` from `Account` (#1375).
 
 ## 0.8.3 (2025-04-22) - `miden-proving-service` crate only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ dependencies = [
 name = "miden-lib"
 version = "0.9.0"
 dependencies = [
+ "assert_matches",
  "miden-assembly",
  "miden-objects",
  "miden-processor",

--- a/crates/miden-lib/Cargo.toml
+++ b/crates/miden-lib/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 miden-objects = { workspace = true, features = ["testing"] }
 vm-processor = { workspace = true, features = ["testing"] }
+assert_matches = { workspace = true }
 
 [build-dependencies]
 assembly = { workspace = true }

--- a/crates/miden-lib/src/account/interface/component.rs
+++ b/crates/miden-lib/src/account/interface/component.rs
@@ -26,7 +26,10 @@ pub enum AccountComponentInterface {
     BasicWallet,
     /// Exposes procedures from the
     /// [`BasicFungibleFaucet`][crate::account::faucets::BasicFungibleFaucet] module.
-    BasicFungibleFaucet,
+    ///
+    /// Internal value holds the storage index where faucet metadata is stored. This metadata slot
+    /// has a format of `max_supply || faucet_decimals || token_symbol || 0`
+    BasicFungibleFaucet(u8),
     /// Exposes procedures from the
     /// [`RpoFalcon512`][crate::account::auth::RpoFalcon512] module.
     ///
@@ -49,7 +52,9 @@ impl AccountComponentInterface {
     pub fn name(&self) -> String {
         match self {
             AccountComponentInterface::BasicWallet => "Basic Wallet".to_string(),
-            AccountComponentInterface::BasicFungibleFaucet => "Basic Fungible Faucet".to_string(),
+            AccountComponentInterface::BasicFungibleFaucet(_) => {
+                "Basic Fungible Faucet".to_string()
+            },
             AccountComponentInterface::RpoFalcon512(_) => "RPO Falcon512".to_string(),
             AccountComponentInterface::Custom(proc_info_vec) => {
                 let result = proc_info_vec
@@ -97,13 +102,17 @@ impl AccountComponentInterface {
             .procedure_digests()
             .all(|proc_digest| procedures.contains_key(&proc_digest))
         {
+            let mut storage_offset = Default::default();
             basic_fungible_faucet_library().mast_forest().procedure_digests().for_each(
                 |component_procedure| {
-                    procedures.remove(&component_procedure);
+                    if let Some(proc_info) = procedures.remove(&component_procedure) {
+                        storage_offset = proc_info.storage_offset();
+                    }
                 },
             );
 
-            component_interface_vec.push(AccountComponentInterface::BasicFungibleFaucet);
+            component_interface_vec
+                .push(AccountComponentInterface::BasicFungibleFaucet(storage_offset));
         }
 
         // RPO Falcon 512
@@ -209,7 +218,7 @@ impl AccountComponentInterface {
             // stack => [tag, aux, note_type, execution_hint, RECIPIENT]
 
             match self {
-                AccountComponentInterface::BasicFungibleFaucet => {
+                AccountComponentInterface::BasicFungibleFaucet(_) => {
                     if partial_note.assets().num_assets() != 1 {
                         return Err(AccountInterfaceError::FaucetNoteWithoutAsset);
                     }

--- a/crates/miden-lib/src/account/interface/mod.rs
+++ b/crates/miden-lib/src/account/interface/mod.rs
@@ -131,7 +131,7 @@ impl AccountInterface {
                     component_proc_digests
                         .extend(basic_wallet_library().mast_forest().procedure_digests());
                 },
-                AccountComponentInterface::BasicFungibleFaucet => {
+                AccountComponentInterface::BasicFungibleFaucet(_) => {
                     component_proc_digests
                         .extend(basic_fungible_faucet_library().mast_forest().procedure_digests());
                 },
@@ -271,8 +271,10 @@ impl AccountInterface {
         &self,
         output_notes: &[PartialNote],
     ) -> Result<String, AccountInterfaceError> {
-        if self.components().contains(&AccountComponentInterface::BasicFungibleFaucet) {
-            AccountComponentInterface::BasicFungibleFaucet.send_note_body(*self.id(), output_notes)
+        if let Some(basic_fungible_faucet) = self.components().iter().find(|component_interface| {
+            matches!(component_interface, AccountComponentInterface::BasicFungibleFaucet(_))
+        }) {
+            basic_fungible_faucet.send_note_body(*self.id(), output_notes)
         } else if self.components().contains(&AccountComponentInterface::BasicWallet) {
             AccountComponentInterface::BasicWallet.send_note_body(*self.id(), output_notes)
         } else {

--- a/crates/miden-objects/src/asset/token_symbol.rs
+++ b/crates/miden-objects/src/asset/token_symbol.rs
@@ -5,7 +5,7 @@ use super::{Felt, TokenSymbolError};
 /// Represents a string token symbol (e.g. "POL", "ETH") as a single [`Felt`] value.
 ///
 /// Token Symbols can consists of up to 6 capital Latin characters, e.g. "C", "ETH", "MIDENC".
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct TokenSymbol(Felt);
 
 impl TokenSymbol {

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -95,10 +95,8 @@ pub enum AccountError {
     AssetVaultUpdateError(#[source] AssetVaultError),
     #[error("account build error: {0}")]
     BuildError(String, #[source] Option<Box<AccountError>>),
-    #[error("faucet metadata decimals is {actual} which exceeds max value of {max}")]
-    FungibleFaucetTooManyDecimals { actual: u8, max: u8 },
-    #[error("faucet metadata max supply is {actual} which exceeds max value of {max}")]
-    FungibleFaucetMaxSupplyTooLarge { actual: u64, max: u64 },
+    #[error("failed to create basic fungible faucet")]
+    BasicFungibleFaucetError(#[source] BasicFungibleFaucetError),
     #[error("account header data has length {actual} but it must be of length {expected}")]
     HeaderDataIncorrectLength { actual: usize, expected: usize },
     #[error("new account nonce {new} is less than the current nonce {current}")]
@@ -136,6 +134,22 @@ pub enum AccountError {
     /// this error type.
     #[error("assumption violated: {0}")]
     AssumptionViolated(String),
+}
+
+#[derive(Debug, Error)]
+pub enum BasicFungibleFaucetError {
+    #[error("faucet metadata decimals is {actual} which exceeds max value of {max}")]
+    TooManyDecimals { actual: u64, max: u8 },
+    #[error("faucet metadata max supply is {actual} which exceeds max value of {max}")]
+    MaxSupplyTooLarge { actual: u64, max: u64 },
+    #[error(
+        "account interface provided for faucet creation does not have basic fungible faucet component"
+    )]
+    NoAvailableInterface,
+    #[error("storage offset `{0}` is invalid")]
+    InvalidStorageOffset(u8),
+    #[error("invalid token symbol")]
+    InvalidTokenSymbol(#[source] TokenSymbolError),
 }
 
 // ACCOUNT ID ERROR

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -25,9 +25,10 @@ mod errors;
 pub use constants::*;
 pub use errors::{
     AccountDeltaError, AccountError, AccountIdError, AccountTreeError, AssetError, AssetVaultError,
-    BatchAccountUpdateError, NetworkIdError, NoteError, NullifierTreeError, PartialBlockchainError,
-    ProposedBatchError, ProposedBlockError, ProvenBatchError, ProvenTransactionError,
-    TokenSymbolError, TransactionInputError, TransactionOutputError, TransactionScriptError,
+    BasicFungibleFaucetError, BatchAccountUpdateError, NetworkIdError, NoteError,
+    NullifierTreeError, PartialBlockchainError, ProposedBatchError, ProposedBlockError,
+    ProvenBatchError, ProvenTransactionError, TokenSymbolError, TransactionInputError,
+    TransactionOutputError, TransactionScriptError,
 };
 pub use miden_crypto::hash::rpo::{Rpo256 as Hasher, RpoDigest as Digest};
 pub use vm_core::{


### PR DESCRIPTION
This small PR implements ability to:
- Obtain the storage offset of the `BasicFungibleFaucet` component using corresponding enum variant.
- Create the `BasicFungibleFaucet` struct instance from `Account`.

Closes: #1325 