### PR TITLE
fix(objects): export types used in public apis

### DIFF
--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -20,7 +20,7 @@ pub use builder::AccountBuilder;
 pub mod code;
 pub use code::{AccountCode, procedure::AccountProcedureInfo};
 
-mod component;
+pub mod component;
 pub use component::{
     AccountComponent, AccountComponentMetadata, AccountComponentTemplate, FeltRepresentation,
     InitStorageData, MapEntry, MapRepresentation, PlaceholderTypeRequirement, StorageEntry,


### PR DESCRIPTION
This patch fixes an issue with the 0.9.0 release where `FieldIdentifier` is not exported from `miden-objects`, even though it is present in public APIs of types which are exported, e.g. `WordRepresentation`.

I've made the `miden_objects::account::component` module public here, rather than export just `FieldIdentifier`, as it appears to me that we are largely re-exporting everything from the module anyway in `miden_objects::account`, and rather than further crowd that namespace, this allows one to simply fully-qualify the path to the `FieldIdentifier` type, i.e. `miden_objects::account::component::FieldIdentifier`. Furthermore, if any types are added in this module or its children in the future, which are marked `pub`, there is no risk that we forget to export them. We can use `pub(crate)` if there are types we wish to explicitly prevent being exported from the crate, but we should be careful about doing this unless the type is truly internal, given the use of `miden_objects` as a library in other Miden crates.