### PR TITLE
chore: Fix Rust version in release workflow

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -33,36 +33,22 @@ runs:
             packaging/deb/$pkg/lib/systemd/system \
             packaging/deb/$pkg/opt/$pkg
         done
-        cp bin/proving-service/.env                packaging/deb/miden-prover/lib/systemd/system/miden-prover.env
-        cp packaging/prover/miden-prover.service   packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
-        cp packaging/prover/postinst               packaging/deb/miden-prover/DEBIAN/postinst
-        cp packaging/prover/postrm                 packaging/deb/miden-prover/DEBIAN/postrm
-        cp bin/proving-service/.env                          packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.env
-        cp packaging/prover-proxy/miden-prover-proxy.service packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
-        cp packaging/prover-proxy/postinst                   packaging/deb/miden-prover-proxy/DEBIAN/postinst
-        cp packaging/prover-proxy/postrm                     packaging/deb/miden-prover-proxy/DEBIAN/postrm
+
+    - name: Copy package install scripts
+      shell: bash
+      run: |
+        git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env                > packaging/deb/miden-prover/lib/systemd/system/miden-prover.env
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
+        git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env                          > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.env
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
+        git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
         chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
         chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
         chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
         chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
-    # TODO(sergerad): Enable this after our first release which includes the packaging files. Delete above lines after `done`.
-    ## These have to be downloaded as the current repo source isn't necessarily the target git reference.
-    #- name: Copy package install scripts
-    #  shell: bash
-    #  run: |
-    #    git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.env
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/miden-prover.service   > packaging/deb/miden-prover/lib/systemd/system/miden-prover.service
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postinst               > packaging/deb/miden-prover/DEBIAN/postinst
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover/postrm                 > packaging/deb/miden-prover/DEBIAN/postrm
-    #    git show ${{ steps.git-sha.outputs.sha }}:bin/proving-service/.env   > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.env
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/miden-prover-proxy.service > packaging/deb/miden-prover-proxy/lib/systemd/system/miden-prover-proxy.service
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postinst                   > packaging/deb/miden-prover-proxy/DEBIAN/postinst
-    #    git show ${{ steps.git-sha.outputs.sha }}:packaging/prover-proxy/postrm                     > packaging/deb/miden-prover-proxy/DEBIAN/postrm
-
-    #    chmod 0775 packaging/deb/miden-prover/DEBIAN/postinst
-    #    chmod 0775 packaging/deb/miden-prover/DEBIAN/postrm
-    #    chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postinst
-    #    chmod 0775 packaging/deb/miden-prover-proxy/DEBIAN/postrm
 
     - name: Create control files
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,6 +36,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Rust update
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Only update the cache on push onto the next branch. This strikes a nice balance between
+          # cache hits and cache evictions (github has a 10GB cache limit).
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Clippy no_std
+        run: |
+          rustup update --no-self-update
+
       - name: Build packages
         uses: ./.github/actions/build_package
         with:


### PR DESCRIPTION
Also reinstates previous workflow commands which depended on the released tag containing the package dir contents.