### PR TITLE
Allow NOOP and state-updating transactions in the same block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.0 (TBD)
 
+- Allow NOOP transactions and state-updating transactions against the same account in the same block (#1393).
+
 ## 0.9.0 (2025-05-20)
 
 ### Features

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -674,3 +674,102 @@ fn expired_transaction() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Tests that a NOOP transaction with state commitments X -> X against account A can appear
+/// _before_ a state-updating transaction with state commitments X -> Y against account A.
+#[test]
+fn noop_tx_before_state_updating_tx_against_same_account() -> anyhow::Result<()> {
+    let TestSetup { mut chain, account1, .. } = setup_chain();
+    let block1 = chain.block_header(1);
+    let block2 = chain.prove_next_block();
+
+    let random_final_state_commitment = Digest::from([1, 2, 3, 4u32]);
+
+    let note = mock_note(40);
+    let noop_tx1 = MockProvenTxBuilder::with_account(
+        account1.id(),
+        account1.commitment(),
+        account1.commitment(),
+    )
+    .ref_block_commitment(block1.commitment())
+    .output_notes(vec![OutputNote::Full(note.clone())])
+    .build()?;
+
+    // sanity check
+    assert_eq!(
+        noop_tx1.account_update().initial_state_commitment(),
+        noop_tx1.account_update().final_state_commitment()
+    );
+
+    let tx2 = MockProvenTxBuilder::with_account(
+        account1.id(),
+        account1.commitment(),
+        random_final_state_commitment,
+    )
+    .ref_block_commitment(block1.commitment())
+    .unauthenticated_notes(vec![note.clone()])
+    .build()?;
+
+    let batch = ProposedBatch::new(
+        [noop_tx1, tx2].into_iter().map(Arc::new).collect(),
+        block2.header().clone(),
+        chain.latest_partial_blockchain(),
+        BTreeMap::default(),
+    )?;
+
+    let update = batch.account_updates().get(&account1.id()).unwrap();
+    assert_eq!(update.initial_state_commitment(), account1.commitment());
+    assert_eq!(update.final_state_commitment(), random_final_state_commitment);
+
+    Ok(())
+}
+
+/// Tests that a NOOP transaction with state commitments X -> X against account A can appear
+/// _after_ a state-updating transaction with state commitments X -> Y against account A.
+#[test]
+fn noop_tx_after_state_updating_tx_against_same_account() -> anyhow::Result<()> {
+    let TestSetup { mut chain, account1, .. } = setup_chain();
+    let block1 = chain.block_header(1);
+    let block2 = chain.prove_next_block();
+
+    let random_final_state_commitment = Digest::from([1, 2, 3, 4u32]);
+
+    let note = mock_note(40);
+
+    let tx1 = MockProvenTxBuilder::with_account(
+        account1.id(),
+        account1.commitment(),
+        random_final_state_commitment,
+    )
+    .ref_block_commitment(block1.commitment())
+    .unauthenticated_notes(vec![note.clone()])
+    .build()?;
+
+    let noop_tx2 = MockProvenTxBuilder::with_account(
+        account1.id(),
+        random_final_state_commitment,
+        random_final_state_commitment,
+    )
+    .ref_block_commitment(block1.commitment())
+    .output_notes(vec![OutputNote::Full(note.clone())])
+    .build()?;
+
+    // sanity check
+    assert_eq!(
+        noop_tx2.account_update().initial_state_commitment(),
+        noop_tx2.account_update().final_state_commitment()
+    );
+
+    let batch = ProposedBatch::new(
+        [tx1, noop_tx2].into_iter().map(Arc::new).collect(),
+        block2.header().clone(),
+        chain.latest_partial_blockchain(),
+        BTreeMap::default(),
+    )?;
+
+    let update = batch.account_updates().get(&account1.id()).unwrap();
+    assert_eq!(update.initial_state_commitment(), account1.commitment());
+    assert_eq!(update.final_state_commitment(), random_final_state_commitment);
+
+    Ok(())
+}

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -143,10 +143,19 @@ pub fn generate_tx_with_authenticated_notes(
     ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
+/// Generates a NOOP transaction, i.e. one that doesn't change the state of the account.
+pub fn generate_noop_tx(
+    chain: &mut MockChain,
+    input: impl Into<TxContextInput>,
+) -> ExecutedTransaction {
+    let tx_context = chain.build_tx_context(input, &[], &[]).build();
+    tx_context.execute().unwrap()
+}
+
 /// Generates a transaction that expires at the given block number.
 pub fn generate_tx_with_expiration(
     chain: &mut MockChain,
-    account_id: AccountId,
+    input: impl Into<TxContextInput>,
     expiration_block: BlockNumber,
 ) -> ProvenTransaction {
     let expiration_delta = expiration_block
@@ -154,7 +163,7 @@ pub fn generate_tx_with_expiration(
         .unwrap();
 
     let tx_context = chain
-        .build_tx_context(account_id, &[], &[])
+        .build_tx_context(input, &[], &[])
         .tx_script(authenticate_mock_account_tx_script(expiration_delta.as_u32() as u16))
         .build();
     let executed_tx = tx_context.execute().unwrap();


### PR DESCRIPTION
A NOOP transaction is a transaction whose initial and final state commitment are the same. Such transactions can appear in practice for UTXO-like use cases, i.e. where notes are created and consumed but the native account is unchanged.

Before this PR, a block would not be able to contain a NOOP transaction against account A in batch 0 and a state-updating transaction against account A in batch 1. This is because those are technically two transactions that update the same account from the same initial state commitment. This is how a block detects conflicts. However, NOOP transactions should be exempt from this conflict check because they do in fact not change the account, so we can safely ignore such NOOP transactions when aggregating account states. This is what this PR does.

Also adds tests to make sure that NOOP + state-updating transactions can appear within the same batch and in the same block (in different batches).

There is no corresponding issue, but I thought about this in the context of https://github.com/0xMiden/miden-base/issues/1333#issuecomment-2889322956.