### PR TITLE
Implement script arguments for `TransactionScript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [BREAKING] Remove `AccountIdAnchor` from account ID generation process (#1391).
 - Allow NOOP transactions and state-updating transactions against the same account in the same block (#1393).
 - Implement map in transaction kernel library (#1396).
+- Implement transaction script arguments for the `TransactionScript` (#1406).
 
 ## 0.9.0 (2025-05-20)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -75,6 +75,9 @@ const.INIT_NONCE_PTR=416
 # The memory address at which the transaction script mast root is stored.
 const.TX_SCRIPT_ROOT_PTR=420
 
+# The memory address at which the commitment of the transaction script arguments is stored.
+const.TX_SCRIPT_ARGS_COMMITMENT_PTR=424
+
 # GLOBAL BLOCK DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -461,6 +464,32 @@ end
 #! - TX_SCRIPT_ROOT is the transaction script root.
 export.set_tx_script_root
     push.TX_SCRIPT_ROOT_PTR
+    mem_storew
+end
+
+#! Returns the transaction script arguments commitment.
+#!
+#! Inputs:  []
+#! Outputs: [TX_SCRIPT_ARGS_COMMITMENT]
+#!
+#! Where:
+#! - TX_SCRIPT_ARGS_COMMITMENT is the commitment of the transaction script arguments which could be
+#!   used as a key to obtain the arguments from the advice map.
+export.get_tx_script_args_commitment
+    padw push.TX_SCRIPT_ARGS_COMMITMENT_PTR
+    mem_loadw
+end
+
+#! Sets the transaction script arguments commitment.
+#!
+#! Inputs:  [TX_SCRIPT_ARGS_COMMITMENT]
+#! Outputs: [TX_SCRIPT_ARGS_COMMITMENT]
+#!
+#! Where:
+#! - TX_SCRIPT_ARGS_COMMITMENT is the commitment of the transaction script arguments which could be
+#!   used as a key to obtain the arguments from the advice map.
+export.set_tx_script_args_commitment
+    push.TX_SCRIPT_ARGS_COMMITMENT_PTR
     mem_storew
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1087,20 +1087,30 @@ end
 #!
 #! Inputs:
 #!   Operand stack: []
-#!   Advice stack: [TX_SCRIPT_ROOT]
+#!   Advice stack: [TX_SCRIPT_ROOT, TX_SCRIPT_ARGS_KEY]
 #! Outputs:
 #!   Operand stack: []
 #!   Advice stack: []
 #!
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction's script root.
-proc.process_tx_script_root
+#! - TX_SCRIPT_ARGS_KEY is the commitment of the transaction script args used to obtain them from 
+#!   the advice map.
+proc.process_tx_script_data
     # read the transaction script root from the advice stack
     adv_loadw
     # => [TX_SCRIPT_ROOT]
 
     # store the transaction script root in memory
     exec.memory::set_tx_script_root dropw
+    # => []
+
+    # read the transaction script args key from the advice stack
+    adv_loadw
+    # => [TX_SCRIPT_ARGS_KEY]
+
+    # store the transaction script args key in memory
+    exec.memory::set_tx_script_args_commitment dropw
     # => []
 end
 
@@ -1137,6 +1147,7 @@ end
 #!     ACCOUNT_CODE_COMMITMENT,
 #!     number_of_input_notes,
 #!     TX_SCRIPT_ROOT,
+#!     TX_SCRIPT_ARGS_KEY,
 #!   ]
 #!   Advice map: {
 #!      PARTIAL_BLOCKCHAIN_COMMITMENT: [MMR_PEAKS],
@@ -1195,7 +1206,7 @@ export.prepare_transaction
     exec.process_chain_data
     exec.process_account_data
     exec.process_input_notes_data
-    exec.process_tx_script_root
+    exec.process_tx_script_data
     # => []
 
     push.MAX_BLOCK_NUM exec.memory::set_expiration_block_num

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -134,6 +134,10 @@ proc.main.1
     # => [has_tx_script, tx_script_root_ptr]
 
     if.true
+        # load the transaction script arguments onto the stack
+        exec.memory::get_tx_script_args_commitment movup.4
+        # => [tx_script_root_ptr, TX_SCRIPT_ARGS_COMMITMENT]
+
         # execute the transaction script
         dyncall
         # => [OUTPUT_3, OUTPUT_2, OUTPUT_1, OUTPUT_0]

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -82,6 +82,7 @@ pub(super) fn extend_advice_inputs(
 ///     ACCOUNT_CODE_COMMITMENT,
 ///     number_of_input_notes,
 ///     TX_SCRIPT_ROOT,
+///     TX_SCRIPT_ARGS_KEY,
 /// ]
 fn build_advice_stack(
     tx_inputs: &TransactionInputs,
@@ -92,7 +93,7 @@ fn build_advice_stack(
     let header = tx_inputs.block_header();
 
     // push block header info into the stack
-    // Note: keep in sync with the process_block_data kernel procedure
+    // Note: keep in sync with the `prologue::process_block_data` kernel procedure
     inputs.extend_stack(header.prev_block_commitment());
     inputs.extend_stack(header.chain_commitment());
     inputs.extend_stack(header.account_root());
@@ -109,11 +110,11 @@ fn build_advice_stack(
     inputs.extend_stack(header.note_root());
 
     // push the version of the kernel which will be used for this transaction
-    // Note: keep in sync with the process_kernel_data kernel procedure
+    // Note: keep in sync with the `prologue::process_kernel_data` kernel procedure
     inputs.extend_stack([Felt::from(kernel_version)]);
 
     // push core account items onto the stack
-    // Note: keep in sync with the process_account_data kernel procedure
+    // Note: keep in sync with the `prologue::process_account_data` kernel procedure
     let account = tx_inputs.account();
     inputs.extend_stack([
         account.id().suffix(),
@@ -128,8 +129,12 @@ fn build_advice_stack(
     // push the number of input notes onto the stack
     inputs.extend_stack([Felt::from(tx_inputs.input_notes().num_notes() as u32)]);
 
-    // push tx_script root onto the stack
+    // push the transaction script root and transaction args commitment onto the stack
+    // Note: keep in sync with the `prologue::process_tx_script_data` kernel procedure
     inputs.extend_stack(tx_script.map_or(Word::default(), |script| *script.root()));
+    inputs.extend_stack(
+        tx_script.map_or(Word::default(), |script| *script.args_key().unwrap_or_default()),
+    );
 }
 
 // PARTIAL BLOCKCHAIN INJECTOR
@@ -149,7 +154,7 @@ fn build_advice_stack(
 /// - num_blocks, is the number of blocks in the MMR.
 /// - PEAK_1 .. PEAK_N, are the MMR peaks.
 fn add_partial_blockchain_to_advice_inputs(mmr: &PartialBlockchain, inputs: &mut AdviceInputs) {
-    // NOTE: keep this code in sync with the `process_chain_data` kernel procedure
+    // NOTE: keep this code in sync with the `prologue::process_chain_data` kernel procedure
 
     // add authentication paths from the MMR to the Merkle store
     inputs.extend_merkle_store(mmr.inner_nodes());

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -14,16 +14,16 @@ pub type StorageSlot = u8;
 //
 // Here the "end address" is the last memory address occupied by the current data
 //
-// | Section           | Start address, pointer (word pointer) | End address, pointer (word pointer) | Comment                                     |
-// | ----------------- | :-----------------------------------: | :---------------------------------: | ------------------------------------------- |
-// | Bookkeeping       | 0 (0)                                 | 287 (71)                            |                                             |
-// | Global inputs     | 400 (100)                             | 423 (105)                           |                                             |
-// | Block header      | 800 (200)                             | 835 (208)                           |                                             |
-// | Partial blockchain         | 1_200 (300)                           | 1_331? (332?)                       |                                             |
-// | Kernel data       | 1_600 (400)                           | 1_739 (434)                         | 34 procedures in total, 4 elements each     |
-// | Accounts data     | 8_192 (2048)                          | 532_479 (133_119)                   | 64 accounts max, 8192 elements each         |
-// | Input notes       | 4_194_304 (1_048_576)                 | ?                                   |                                             |
-// | Output notes      | 16_777_216 (4_194_304)                | ?                                   |                                             |
+// | Section            | Start address, pointer (word pointer) | End address, pointer (word pointer) | Comment                                     |
+// | ------------------ | :-----------------------------------: | :---------------------------------: | ------------------------------------------- |
+// | Bookkeeping        | 0 (0)                                 | 287 (71)                            |                                             |
+// | Global inputs      | 400 (100)                             | 423 (105)                           |                                             |
+// | Block header       | 800 (200)                             | 835 (208)                           |                                             |
+// | Partial blockchain | 1_200 (300)                           | 1_331? (332?)                       |                                             |
+// | Kernel data        | 1_600 (400)                           | 1_739 (434)                         | 34 procedures in total, 4 elements each     |
+// | Accounts data      | 8_192 (2048)                          | 532_479 (133_119)                   | 64 accounts max, 8192 elements each         |
+// | Input notes        | 4_194_304 (1_048_576)                 | ?                                   |                                             |
+// | Output notes       | 16_777_216 (4_194_304)                | ?                                   |                                             |
 
 // Relative layout of one account
 //
@@ -115,6 +115,9 @@ pub const INIT_NONCE_PTR: MemoryAddress = 416;
 
 /// The memory address at which the transaction script mast root is store
 pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 420;
+
+/// The memory address at which the commitment of the transaction script arguments is stored.
+pub const TX_SCRIPT_ARGS_COMMITMENT: MemoryAddress = 424;
 
 // BLOCK DATA
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -455,6 +455,8 @@ impl PartialBlockchainError {
 pub enum TransactionScriptError {
     #[error("failed to assemble transaction script:\n{}", PrintDiagnostic::new(.0))]
     AssemblyError(Report),
+    #[error("invalid script arguments key: entry with key {0} is not found in provided inputs map")]
+    InvalidScriptArgsKey(Digest),
 }
 
 // TRANSACTION INPUT ERROR

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -1,5 +1,6 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
+    string::ToString,
     sync::Arc,
     vec::Vec,
 };
@@ -9,7 +10,7 @@ use miden_crypto::merkle::InnerNodeInfo;
 
 use super::{AccountInputs, Digest, Felt, Word};
 use crate::{
-    MastForest, MastNodeId, TransactionScriptError,
+    Hasher, MastForest, MastNodeId, TransactionScriptError,
     note::{NoteId, NoteRecipient},
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     vm::{AdviceInputs, AdviceMap, Program},
@@ -205,11 +206,16 @@ impl Deserializable for TransactionArgs {
 /// - An executable program defined by a [MastForest] and an associated entrypoint.
 /// - A set of transaction script inputs defined by a map of key-value inputs that are loaded into
 ///   the advice inputs' map such that the transaction script can access them.
+/// - A script arguments key defined as an optional [`Digest`]: if presented, this key will be
+///   automatically placed to the operand stack before the transaction script execution and could be
+///   used to get the script arguments array. See [TransactionScript::with_script_args] for more
+///   info.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionScript {
     mast: Arc<MastForest>,
     entrypoint: MastNodeId,
     inputs: BTreeMap<Digest, Vec<Felt>>,
+    script_args_key: Option<Digest>,
 }
 
 impl TransactionScript {
@@ -222,6 +228,7 @@ impl TransactionScript {
             entrypoint: code.entrypoint(),
             mast: code.mast_forest().clone(),
             inputs: inputs.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+            script_args_key: None,
         }
     }
 
@@ -243,15 +250,51 @@ impl TransactionScript {
 
     /// Returns a new [TransactionScript] instantiated from the provided components.
     ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The provided `script_args_key` is not presented in the `inputs` map.
+    ///
     /// # Panics
     /// Panics if the specified entrypoint is not in the provided MAST forest.
     pub fn from_parts(
         mast: Arc<MastForest>,
         entrypoint: MastNodeId,
         inputs: BTreeMap<Digest, Vec<Felt>>,
-    ) -> Self {
+        script_args_key: Option<Digest>,
+    ) -> Result<Self, TransactionScriptError> {
         assert!(mast.get_node_by_id(entrypoint).is_some());
-        Self { mast, entrypoint, inputs }
+
+        // check that provided `script_args_key` is presented in the `inputs` map
+        if let Some(args_key) = script_args_key {
+            if !inputs.contains_key(&args_key) {
+                return Err(TransactionScriptError::InvalidScriptArgsKey(args_key));
+            }
+        }
+
+        Ok(Self {
+            mast,
+            entrypoint,
+            inputs,
+            script_args_key,
+        })
+    }
+
+    // MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Sets the `script_args_key` to the commitment of the provided arguments array and extends
+    /// the `inputs` map with the `COMPUTED_COMMITMENT -> [[script_args]]` entry.
+    ///
+    /// Script arguments is an optional array of [`Felt`]s which could be easily accessed at the
+    /// beginning of the transaction script execution. Commitment of this array (`script_args_key`)
+    /// is automatically pushed to the operand stack at the beginning of the transaction script
+    /// execution, so user can get access the underlying arguments array just using the
+    /// `adv.push_mapval` and `adv_push.n` instructions.
+    pub fn with_script_args(mut self, script_args: &[Felt]) -> Self {
+        let args_key = Hasher::hash_elements(script_args);
+        self.inputs.insert(args_key, script_args.to_vec());
+        self.script_args_key = Some(args_key);
+        self
     }
 
     // PUBLIC ACCESSORS
@@ -271,6 +314,12 @@ impl TransactionScript {
     pub fn inputs(&self) -> &BTreeMap<Digest, Vec<Felt>> {
         &self.inputs
     }
+
+    /// Returns the commitment of the transaction script arguments, or [`None`] if they were not
+    /// specified.
+    pub fn args_key(&self) -> Option<Digest> {
+        self.script_args_key
+    }
 }
 
 // SERIALIZATION
@@ -281,6 +330,7 @@ impl Serializable for TransactionScript {
         self.mast.write_into(target);
         target.write_u32(self.entrypoint.as_u32());
         self.inputs.write_into(target);
+        self.script_args_key.write_into(target);
     }
 }
 
@@ -289,8 +339,10 @@ impl Deserializable for TransactionScript {
         let mast = MastForest::read_from(source)?;
         let entrypoint = MastNodeId::from_u32_safe(source.read_u32()?, &mast)?;
         let inputs = BTreeMap::<Digest, Vec<Felt>>::read_from(source)?;
+        let script_args_key = Option::<Digest>::read_from(source)?;
 
-        Ok(Self::from_parts(Arc::new(mast), entrypoint, inputs))
+        Self::from_parts(Arc::new(mast), entrypoint, inputs, script_args_key)
+            .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
     }
 }
 

--- a/crates/miden-testing/tests/integration/scripts/faucet.rs
+++ b/crates/miden-testing/tests/integration/scripts/faucet.rs
@@ -168,7 +168,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     // is initialized with the metadata of the faucet which we don't need to check.
     assert_eq!(faucet.account().storage().get_item(1).unwrap()[0], Felt::new(200));
 
-    // Check that the faucet reserved slot has been correctly initialised.
+    // Check that the faucet reserved slot has been correctly initialized.
     // The already issued amount should be 100.
     assert_eq!(faucet.account().storage().get_item(0).unwrap()[3], Felt::new(100));
 


### PR DESCRIPTION
This PR extends the `TransactionScript`, making possible to additionally specify the transaction script arguments for it. 

These arguments have a form of `Felt`s array. During the transaction setup we compute the hash of this array and provide the resulting pair to the advice map (`COMPUTED_HASH -> [[arguments_array]]`). Right before the transaction script execution, we put this computed hash to the operand stack, making it easy to access the underlying arguments array. 

This approach allows to modify the input values placed on the stack at the beginning of the transaction execution without changing the actual tx script. 

Closes: #1262.