### PR TITLE
chore: Reduce proving service instrumentation verbosity

### DIFF
--- a/bin/proving-service/src/api/prover.rs
+++ b/bin/proving-service/src/api/prover.rs
@@ -53,10 +53,11 @@ impl ProverRpcApi {
     }
 
     #[instrument(
+        level = "debug",
         target = MIDEN_PROVING_SERVICE,
-        name = "proving_service:prove_tx",
+        name = "rpc.prove_tx",
         skip_all,
-        ret(level = "debug"),
+        ret,
         fields(id = tracing::field::Empty),
         err
     )]
@@ -83,10 +84,11 @@ impl ProverRpcApi {
     }
 
     #[instrument(
+        level = "debug",
         target = MIDEN_PROVING_SERVICE,
-        name = "proving_service:prove_batch",
+        name = "rpc.prove_batch",
         skip_all,
-        ret(level = "debug"),
+        ret,
         fields(id = tracing::field::Empty),
         err
     )]
@@ -113,10 +115,11 @@ impl ProverRpcApi {
     }
 
     #[instrument(
+        level = "debug",
         target = MIDEN_PROVING_SERVICE,
-        name = "proving_service:prove_block",
+        name = "rpc.prove_block",
         skip_all,
-        ret(level = "debug"),
+        ret,
         fields(id = tracing::field::Empty),
         err
     )]
@@ -147,8 +150,9 @@ impl ProverRpcApi {
 #[async_trait::async_trait]
 impl ProverApi for ProverRpcApi {
     #[instrument(
+        parent = None,
         target = MIDEN_PROVING_SERVICE,
-        name = "proving_service:prove",
+        name = "rpc.prove",
         skip_all,
         ret(level = "debug"),
         fields(id = tracing::field::Empty),

--- a/bin/proving-service/src/commands/mod.rs
+++ b/bin/proving-service/src/commands/mod.rs
@@ -103,7 +103,14 @@ pub enum Command {
 
 /// CLI entry point
 impl Cli {
-    #[instrument(target = MIDEN_PROVING_SERVICE, name = "cli:execute", skip_all, ret(level = "info"), err)]
+    #[instrument(
+        parent = None,
+        target = MIDEN_PROVING_SERVICE,
+        name = "cli.execute",
+        skip_all,
+        ret(level = "info"),
+        err
+    )]
     pub async fn execute(&self) -> Result<(), String> {
         match &self.action {
             // For the `StartWorker` command, we need to create a new runtime and run the worker

--- a/bin/proving-service/src/commands/worker.rs
+++ b/bin/proving-service/src/commands/worker.rs
@@ -77,7 +77,7 @@ impl StartWorker {
     /// The worker includes a health reporter that will mark the service as serving, following the
     /// [gRPC health checking protocol](
     /// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto).
-    #[instrument(target = MIDEN_PROVING_SERVICE, name = "worker:execute")]
+    #[instrument(level = "debug", target = MIDEN_PROVING_SERVICE, name = "worker.execute")]
     pub async fn execute(&self) -> Result<(), String> {
         let host = if self.localhost { "127.0.0.1" } else { "0.0.0.0" };
         let worker_addr = format!("{}:{}", host, self.port);


### PR DESCRIPTION
### Context

Relates to https://github.com/0xMiden/miden-node/issues/896.

Our instrumentation is currently extremely verbose. It is hard to to eye-ball stdout and we churn through monitoring limits at high speed.

We want to update the instrumentation so that the most meaningful, top-level spans are captured by default. And we want the ability to enable more verbose output that involves higher numbers of spans when we go to debug.

### Changes
- Add `level = "debug"` to various child spans.
- Add `parent = None` to most root spans. This is not required, but feels like a good idea to communicate intention.
- Standardize span names with format seen in miden-node
