### PR TITLE
Add hybrid P2ID note & tests

### DIFF
--- a/crates/miden-lib/asm/note_scripts/P2ID_RT.masm
+++ b/crates/miden-lib/asm/note_scripts/P2ID_RT.masm
@@ -1,0 +1,171 @@
+use.miden::account
+use.miden::note
+use.miden::tx
+use.miden::contracts::wallets::basic->wallet
+
+# ERRORS
+# =================================================================================================
+
+const.ERR_P2ID_WRONG_NUMBER_OF_INPUTS="P2IDH script expects exactly 4 note inputs"
+
+const.ERR_P2ID_RECLAIM_ACCT_IS_NOT_SENDER="P2IDH reclaim account != sender"
+
+const.ERR_P2ID_RECLAIM_HEIGHT_NOT_REACHED="wait until reclaim height"
+
+const.ERR_P2ID_TIMELOCK_HEIGHT_NOT_REACHED="wait until unlock"
+
+#! Helper procedure to add all assets of a note to an account.
+#!
+#! Inputs:  []
+#! Outputs: []
+proc.add_note_assets_to_account
+    push.0 exec.note::get_assets
+    # => [num_of_assets, 0 = ptr, ...]
+
+    # compute the pointer at which we should stop iterating
+    mul.4 dup.1 add
+    # => [end_ptr, ptr, ...]
+
+    # pad the stack and move the pointer to the top
+    padw movup.5
+    # => [ptr, 0, 0, 0, 0, end_ptr, ...]
+
+    # compute the loop latch
+    dup dup.6 neq
+    # => [latch, ptr, 0, 0, 0, 0, end_ptr, ...]
+
+    while.true
+        # => [ptr, 0, 0, 0, 0, end_ptr, ...]
+
+        # save the pointer so that we can use it later
+        dup movdn.5
+        # => [ptr, 0, 0, 0, 0, ptr, end_ptr, ...]
+
+        # load the asset
+        mem_loadw
+        # => [ASSET, ptr, end_ptr, ...]
+
+        # pad the stack before call
+        padw swapw padw padw swapdw
+        # => [ASSET, pad(12), ptr, end_ptr, ...]
+
+        # add asset to the account
+        call.wallet::receive_asset
+        # => [pad(16), ptr, end_ptr, ...]
+
+        # clean the stack after call
+        dropw dropw dropw
+        # => [0, 0, 0, 0, ptr, end_ptr, ...]
+
+        # increment the pointer and compare it to the end_ptr
+        movup.4 add.4 dup dup.6 neq
+        # => [latch, ptr+4, ASSET, end_ptr, ...]
+    end
+
+    # clear the stack
+    drop dropw drop
+end
+
+#! Pay to ID reclaimable: adds all assets from the note to the account, assuming ID of the account
+#! matches target account ID specified by the note inputs OR matches the sender ID if the note is
+#! consumed after the reclaim block height specified by the note inputs.
+#!
+#! Requires that the account exposes:
+#! - miden::contracts::wallets::basic::receive_asset procedure.
+#!
+#! Inputs:  []
+#! Outputs: []
+#!
+#! Note inputs are assumed to be as follows:
+#! - target_account_id is the ID of the account for which the note is intended.
+#! - reclaim_block_height is the block height at which the note can be reclaimed by the sender.
+#!
+#! Panics if:
+#! - Account does not expose miden::contracts::wallets::basic::receive_asset procedure.
+#! - Before reclaim block height: account ID of executing account is not equal to specified
+#!   account ID.
+#! - At and after reclaim block height: account ID of executing account is not equal to
+#!   specified account ID or Sender account ID.
+#! - The same non-fungible asset already exists in the account.
+#! - Adding a fungible asset would result in amount overflow, i.e., the total amount would be
+#!   greater than 2^63.
+begin
+
+    # store the note inputs to memory starting at address 0
+    push.0 exec.note::get_inputs
+    # => [num_inputs, inputs_ptr]
+
+    # step 1:
+    # get mem addr 4 (timelock)
+    # if 0, then check if can consume
+
+    # step 2:
+    # if timelock not 0, get blockheight
+    # if blockheight > timelock
+    # check if can consume
+
+    # step 3
+
+    # make sure the number of inputs is 4
+    eq.4 assert.err=ERR_P2ID_WRONG_NUMBER_OF_INPUTS
+    # => [inputs_ptr]
+
+    # read the reclaim block height and target account ID from the note inputs
+    padw movup.4 mem_loadw
+    # => [timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+    dup push.0 neq
+    # => [is_timelock_on, timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+    if.true
+        dup exec.tx::get_block_number
+        # => [current_block_height, timelock_block_height, timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+        lte
+        # => [is_unlockable, timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+        if.true
+            nop
+        else
+            push.0 assert.err=ERR_P2ID_TIMELOCK_HEIGHT_NOT_REACHED
+        end
+        # => [timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+    else
+        nop
+    end
+    # => [timelock_block_height, reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+    drop
+    # => [reclaim_block_height, target_account_id_prefix, target_account_id_suffix]
+
+    exec.account::get_id dup.1 dup.1
+    # => [account_id_prefix, account_id_suffix, account_id_prefix, account_id_suffix, reclaim_block_height, target_account_id_prefix, target_account_id_suffix, ...]
+
+    # determine if the current account is the target account
+    movup.6 movup.6 exec.account::is_id_equal
+    # => [is_target, account_id_prefix, account_id_suffix, reclaim_block_height]
+
+    if.true
+        # if current account is the target, we don't need to check anything else
+        # and so we just clear the stack
+        drop drop drop
+
+    else
+        # if current account is not the target, we need to ensure it is the sender
+        exec.note::get_sender
+        # => [sender_account_id_prefix, sender_account_id_suffix, account_id_prefix, account_id_suffix, reclaim_block_height]
+
+        # ensure current account ID = sender account ID
+        exec.account::is_id_equal assert.err=ERR_P2ID_RECLAIM_ACCT_IS_NOT_SENDER
+        # => [reclaim_block_height]
+
+        # now check that sender is allowed to reclaim, current block >= reclaim block height
+        exec.tx::get_block_number
+        # => [current_block_height, reclaim_block_height]
+
+        u32assert2 u32lte assert.err=ERR_P2ID_RECLAIM_HEIGHT_NOT_REACHED
+    end
+
+    exec.add_note_assets_to_account
+    # => []
+end

--- a/crates/miden-lib/src/errors/note_script_errors.rs
+++ b/crates/miden-lib/src/errors/note_script_errors.rs
@@ -22,6 +22,15 @@ pub const ERR_P2ID_TARGET_ACCT_MISMATCH: MasmError = MasmError::from_static_str(
 /// Error Message: "P2ID script expects exactly 2 note inputs"
 pub const ERR_P2ID_WRONG_NUMBER_OF_INPUTS: MasmError = MasmError::from_static_str("P2ID script expects exactly 2 note inputs");
 
+/// Error Message: "Hybrid P2ID script expects exactly 4 note inputs"
+pub const ERR_HYBRID_P2ID_WRONG_NUMBER_OF_INPUTS: MasmError = MasmError::from_static_str("P2ID script expects exactly 4 note inputs");
+/// Error Message: "Hybrid P2ID script reclaim account != sender"
+pub const ERR_HYBRID_P2ID_RECLAIM_ACCT_IS_NOT_SENDER: MasmError = MasmError::from_static_str("P2IDH reclaim account != sender");
+/// Error Message: "Hybrid P2ID script wait until reclaim height"
+pub const ERR_HYBRID_P2ID_RECLAIM_HEIGHT_NOT_REACHED: MasmError = MasmError::from_static_str("wait until reclaim height");
+/// Error Message: "Hybrid P2ID script wait until unlock"
+pub const ERR_HYBRID_P2ID_TIMELOCK_NOT_REACHED: MasmError = MasmError::from_static_str("wait until unlock");
+
 /// Error Message: "SWAP script requires exactly 1 note asset"
 pub const ERR_SWAP_WRONG_NUMBER_OF_ASSETS: MasmError = MasmError::from_static_str("SWAP script requires exactly 1 note asset");
 /// Error Message: "SWAP script expects exactly 10 note inputs"

--- a/crates/miden-testing/tests/integration/scripts/hybrid_p2id.rs
+++ b/crates/miden-testing/tests/integration/scripts/hybrid_p2id.rs
@@ -1,0 +1,361 @@
+use std::{fs, path::Path};
+
+use anyhow::Context;
+use miden_crypto::Word;
+use miden_lib::{
+    errors::note_script_errors::{
+        ERR_HYBRID_P2ID_RECLAIM_ACCT_IS_NOT_SENDER, ERR_HYBRID_P2ID_RECLAIM_HEIGHT_NOT_REACHED,
+        ERR_HYBRID_P2ID_TIMELOCK_NOT_REACHED, ERR_HYBRID_P2ID_WRONG_NUMBER_OF_INPUTS,
+    },
+    transaction::TransactionKernel,
+};
+use miden_objects::{
+    Felt,
+    account::{Account, AccountId, WordRepresentation},
+    asset::{Asset, AssetVault, FungibleAsset},
+    note::{
+        Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteInputs, NoteMetadata,
+        NoteRecipient, NoteScript, NoteTag, NoteType,
+    },
+    transaction::OutputNote,
+};
+use miden_testing::{Auth, MockChain};
+use rand::rngs::mock;
+
+use crate::assert_transaction_executor_error;
+
+#[test]
+fn hybrid_p2id_script_success() -> anyhow::Result<()> {
+    let mut mock_chain = MockChain::new();
+    mock_chain.prove_until_block(1u32).context("failed to prove multiple blocks")?;
+
+    // Create sender and target and malicious account
+    let sender_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+
+    let assembler = TransactionKernel::assembler().with_debug_mode(true);
+    let code = fs::read_to_string(Path::new("../miden-lib/asm/note_scripts/P2ID_RT.masm")).unwrap();
+
+    let serial_num = Word::default();
+    let note_script = NoteScript::compile(code, assembler).unwrap();
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let reclaim_block_height = Felt::new(0); // if 0, means it is not reclaimable
+    let timelock_block_height = Felt::new(0); // if 0 means it is not timelocked
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let note_inputs = NoteInputs::new(vec![
+        target_account.id().suffix(),
+        target_account.id().prefix().into(),
+        reclaim_block_height,
+        timelock_block_height,
+    ])
+    .unwrap();
+
+    let recipient = NoteRecipient::new(serial_num, note_script, note_inputs.clone());
+    let tag = NoteTag::for_public_use_case(0, 0, NoteExecutionMode::Local).unwrap();
+    let metadata = NoteMetadata::new(
+        sender_account.id(),
+        NoteType::Public,
+        tag,
+        NoteExecutionHint::always(),
+        Felt::new(0),
+    )?;
+
+    let fungible_asset: Asset = FungibleAsset::mock(100);
+    let vault = NoteAssets::new(vec![fungible_asset.into()])?;
+    let hybrid_p2id = Note::new(vault, metadata, recipient);
+
+    let output_note = OutputNote::Full(hybrid_p2id.clone());
+    mock_chain.add_pending_note(output_note);
+    mock_chain.prove_next_block();
+
+    // CONSTRUCT AND EXECUTE TX (Success - Target Account)
+    let executed_transaction_1 = mock_chain
+        .build_tx_context(target_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute()
+        .unwrap();
+
+    let target_account_after: Account = Account::from_parts(
+        target_account.id(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
+        target_account.storage().clone(),
+        target_account.code().clone(),
+        Felt::new(2),
+    );
+    assert_eq!(
+        executed_transaction_1.final_account().commitment(),
+        target_account_after.commitment()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hybrid_p2id_script_reclaim_test() -> anyhow::Result<()> {
+    let mut mock_chain = MockChain::new();
+    mock_chain.prove_until_block(1u32).context("failed to prove multiple blocks")?;
+
+    // Create sender and target and malicious account
+    let sender_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    // let malicious_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+
+    let assembler = TransactionKernel::assembler().with_debug_mode(true);
+    let code = fs::read_to_string(Path::new("../miden-lib/asm/note_scripts/P2ID_RT.masm")).unwrap();
+    let serial_num = Word::default();
+    let note_script = NoteScript::compile(code, assembler).unwrap();
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let reclaim_block_height = Felt::new(5); // if 0, means it is not reclaimable
+    let timelock_block_height = Felt::new(0); // if 0 means it is not timelocked
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let note_inputs = NoteInputs::new(vec![
+        target_account.id().suffix(),
+        target_account.id().prefix().into(),
+        reclaim_block_height,
+        timelock_block_height,
+    ])
+    .unwrap();
+
+    let recipient = NoteRecipient::new(serial_num, note_script, note_inputs.clone());
+    let tag = NoteTag::for_public_use_case(0, 0, NoteExecutionMode::Local).unwrap();
+    let metadata = NoteMetadata::new(
+        sender_account.id(),
+        NoteType::Public,
+        tag,
+        NoteExecutionHint::always(),
+        Felt::new(0),
+    )?;
+
+    let fungible_asset: Asset = FungibleAsset::mock(100);
+    let vault = NoteAssets::new(vec![fungible_asset.into()])?;
+    let hybrid_p2id = Note::new(vault, metadata, recipient);
+
+    let output_note = OutputNote::Full(hybrid_p2id.clone());
+    mock_chain.add_pending_note(output_note);
+
+    mock_chain.prove_next_block();
+
+    // CONSTRUCT AND EXECUTE TX (Failure - sender_account)
+    let executed_transaction_1 = mock_chain
+        .build_tx_context(sender_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute();
+
+    assert_transaction_executor_error!(
+        executed_transaction_1,
+        ERR_HYBRID_P2ID_RECLAIM_HEIGHT_NOT_REACHED
+    );
+
+    // fast forward to reclaim block height + 1
+    mock_chain
+        .prove_until_block((reclaim_block_height.as_int() + 1) as u32)
+        .unwrap();
+
+    // CONSTRUCT AND EXECUTE TX (Success - sender_account)
+    let executed_transaction_1 = mock_chain
+        .build_tx_context(sender_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute()
+        .unwrap();
+
+    let sender_account_after: Account = Account::from_parts(
+        sender_account.id(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
+        sender_account.storage().clone(),
+        sender_account.code().clone(),
+        Felt::new(2),
+    );
+
+    assert_eq!(
+        executed_transaction_1.final_account().commitment(),
+        sender_account_after.commitment()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hybrid_p2id_script_timelock_test() -> anyhow::Result<()> {
+    let mut mock_chain = MockChain::new();
+    mock_chain.prove_until_block(1u32).context("failed to prove multiple blocks")?;
+
+    // Create sender and target and malicious account
+    let sender_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    // let malicious_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+
+    let assembler = TransactionKernel::assembler().with_debug_mode(true);
+    let code = fs::read_to_string(Path::new("../miden-lib/asm/note_scripts/P2ID_RT.masm")).unwrap();
+    let serial_num = Word::default();
+    let note_script = NoteScript::compile(code, assembler).unwrap();
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let reclaim_block_height = Felt::new(0); // if 0, means it is not reclaimable
+    let timelock_block_height = Felt::new(7); // if 0 means it is not timelocked
+
+    // Hybrid P2ID - P2ID(RT) Pay to Id, Optional Reclaimable & Timelockable
+    let note_inputs = NoteInputs::new(vec![
+        target_account.id().suffix(),
+        target_account.id().prefix().into(),
+        reclaim_block_height,
+        timelock_block_height,
+    ])
+    .unwrap();
+
+    let recipient = NoteRecipient::new(serial_num, note_script, note_inputs.clone());
+    let tag = NoteTag::for_public_use_case(0, 0, NoteExecutionMode::Local).unwrap();
+    let metadata = NoteMetadata::new(
+        sender_account.id(),
+        NoteType::Public,
+        tag,
+        NoteExecutionHint::always(),
+        Felt::new(0),
+    )?;
+
+    let fungible_asset: Asset = FungibleAsset::mock(100);
+    let vault = NoteAssets::new(vec![fungible_asset.into()])?;
+    let hybrid_p2id = Note::new(vault, metadata, recipient);
+
+    let output_note = OutputNote::Full(hybrid_p2id.clone());
+    mock_chain.add_pending_note(output_note);
+
+    mock_chain.prove_next_block();
+
+    // CONSTRUCT AND EXECUTE TX (Failure - target_account)
+    let executed_transaction_1 = mock_chain
+        .build_tx_context(target_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute();
+
+    assert_transaction_executor_error!(
+        executed_transaction_1,
+        ERR_HYBRID_P2ID_TIMELOCK_NOT_REACHED
+    );
+
+    // fast forward to reclaim block height + 1
+    mock_chain
+        .prove_until_block((timelock_block_height.as_int() + 1) as u32)
+        .unwrap();
+
+    // CONSTRUCT AND EXECUTE TX (Success - target_account)
+    let executed_transaction_1 = mock_chain
+        .build_tx_context(target_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute()
+        .unwrap();
+
+    let target_account_after: Account = Account::from_parts(
+        target_account.id(),
+        AssetVault::new(&[fungible_asset]).unwrap(),
+        target_account.storage().clone(),
+        target_account.code().clone(),
+        Felt::new(2),
+    );
+
+    assert_eq!(
+        executed_transaction_1.final_account().commitment(),
+        target_account_after.commitment()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hybrid_p2id_script_reclaimable_timelockable() -> anyhow::Result<()> {
+    let mut mock_chain = MockChain::new();
+    mock_chain.prove_until_block(1u32).context("failed to prove multiple blocks")?;
+
+    // ── create sender & target wallets ───────────────────────────────────────
+    let sender_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+    let target_account = mock_chain.add_pending_existing_wallet(Auth::BasicAuth, vec![]);
+
+    // ── build note script ────────────────────────────────────────────────────
+    let assembler = TransactionKernel::assembler().with_debug_mode(true);
+    let code = fs::read_to_string(Path::new("../miden-lib/asm/note_scripts/P2ID_RT.masm")).unwrap();
+    let note_script = NoteScript::compile(code, assembler).unwrap();
+
+    let reclaim_block_height = Felt::new(10);
+    let timelock_block_height = Felt::new(7);
+
+    let note_inputs = NoteInputs::new(vec![
+        target_account.id().suffix(),
+        target_account.id().prefix().into(),
+        reclaim_block_height,
+        timelock_block_height,
+    ])?;
+
+    let recipient = NoteRecipient::new(Word::default(), note_script, note_inputs);
+    let tag = NoteTag::for_public_use_case(0, 0, NoteExecutionMode::Local)?;
+    let metadata = NoteMetadata::new(
+        sender_account.id(),
+        NoteType::Public,
+        tag,
+        NoteExecutionHint::always(),
+        Felt::new(0),
+    )?;
+
+    let asset: Asset = FungibleAsset::mock(100);
+    let vault = NoteAssets::new(vec![asset.into()])?;
+    let hybrid_p2id = Note::new(vault, metadata, recipient);
+
+    // push note on-chain
+    mock_chain.add_pending_note(OutputNote::Full(hybrid_p2id.clone()));
+    mock_chain.prove_next_block();
+
+    // ───────────────────── early reclaim attempt (sender) → FAIL ────────────
+    let early_reclaim = mock_chain
+        .build_tx_context(sender_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute();
+
+    assert_transaction_executor_error!(early_reclaim, ERR_HYBRID_P2ID_TIMELOCK_NOT_REACHED);
+
+    // ───────────────────── early spend attempt (target)  → FAIL ─────────────
+    let early_spend = mock_chain
+        .build_tx_context(target_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute();
+
+    assert_transaction_executor_error!(early_spend, ERR_HYBRID_P2ID_TIMELOCK_NOT_REACHED);
+
+    // ───────────────────── advance chain past height 7 ──────────────────────
+    mock_chain
+        .prove_until_block((timelock_block_height.as_int() + 1) as u32)
+        .unwrap();
+
+    // ───────────────────── early reclaim attempt (sender) → FAIL ────────────
+    let early_reclaim = mock_chain
+        .build_tx_context(sender_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute();
+
+    assert_transaction_executor_error!(early_reclaim, ERR_HYBRID_P2ID_RECLAIM_HEIGHT_NOT_REACHED);
+
+    // ───────────────────── advance chain past height 10 ──────────────────────
+    mock_chain
+        .prove_until_block((reclaim_block_height.as_int() + 1) as u32)
+        .unwrap();
+
+    // ───────────────────── target spends successfully ───────────────────────
+    let final_tx = mock_chain
+        .build_tx_context(target_account.id(), &[hybrid_p2id.id()], &[])
+        .build()
+        .execute()
+        .unwrap();
+
+    let target_after = Account::from_parts(
+        target_account.id(),
+        AssetVault::new(&[asset])?,
+        target_account.storage().clone(),
+        target_account.code().clone(),
+        Felt::new(2),
+    );
+
+    assert_eq!(final_tx.final_account().commitment(), target_after.commitment());
+
+    Ok(())
+}

--- a/crates/miden-testing/tests/integration/scripts/mod.rs
+++ b/crates/miden-testing/tests/integration/scripts/mod.rs
@@ -1,4 +1,5 @@
 mod faucet;
+mod hybrid_p2id;
 mod p2id;
 mod p2idr;
 mod send_note;


### PR DESCRIPTION
This PR introduces the initial implementation of the "hybrid P2ID" note, which combines the functionality of reclaimable and timelocked P2ID notes. This new note has optional parameters for both reclaimability and timelock, providing more flexibility.

The note is described in detail here: #1219 

The inputs for this new note are structured as follows:

```rust
let note_inputs = NoteInputs::new(vec![
    target_account.id().suffix(),
    target_account.id().prefix().into(),
    reclaim_block_height,
    timelock_block_height,
])?;
```

If both `reclaim_block_height` and `timelock_block_height` are set to 0, this note functions as a standard P2ID note. The note can be:

* Only reclaimable (`P2IDR`)
* Only timelockable (`P2IDT`)
* Both reclaimable and timelockable (`P2IDRT`)

The implementation follows the structure of the `P2IDR` note, ensuring consistency with the existing P2ID implementation.