### PR TITLE
chore: refresh winter-air

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,9 +5361,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7fbdcaa53d220b84811199790c1dda77c025533cdd27715cf1625af2b4027a"
+checksum = "48a9ee4b14f192be4b0f253d6cc6241844664d6d6684819b6d9b074f4b85af14"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -5416,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426be0767a25150af20a241a6ae46bad1bf2f7da86393d897e5ec9967124f760"
+checksum = "91e1ad2747c0f67f3aab25c2753cb7ee321e06722dd1f011344faeee7e2828a4"
 dependencies = [
  "tracing",
  "winter-air",
@@ -5450,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "winter-verifier"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e340716f24960b7ff3713029149fe5e52f9c0dae152101528ec5847d92d73e4"
+checksum = "1a980cd314dddc2f4c9cdbc77127e6390238bb8b7541b6f627541ca35223f8ff"
 dependencies = [
  "winter-air",
  "winter-crypto",


### PR DESCRIPTION
Client integration tests found that there is an incompatibility within `winter-air` versions `0.12.1` and `0.12.3`. 
Currently the node [has it locked to `0.12.3`](https://github.com/0xMiden/miden-node/blob/next/Cargo.lock#L5215), whereas `miden-base` had it locked to `0.12.1`. 

The client integration tests that use the remote proving service were failing at the moment of submitting the proof (execution and proving themselves were fine) to the node, which was outputting errors that looked like this:

```
2025-06-02T15:19:16.216059Z  INFO rpc.rpc/SubmitProvenTransaction:rpc.server.submit_proven_transaction:verify_program: miden_verifier: /Users/igamigo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/miden-verifier-0.14.0/src/lib.rs:55: new rpc.service: "rpc.rpc", rpc.method: "SubmitProvenTransaction"

thread 'tokio-runtime-worker' panicked at /Users/igamigp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winter-air-0.12.3/src/proof/ood_frame.rs:167:13:
assertion `left == right` failed
  left: 122
 right: 2
```

This also means that the currently proving service crate is incompatible with the current node if installed with `--locked`.
This PR updates the locked version on `next`.