### PR TITLE
feat: add note_args to TransactionContextBuilder

### DIFF
--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -182,6 +182,12 @@ impl TransactionContextBuilder {
         self
     }
 
+    // Set the desired note args
+    pub fn note_args(mut self, args: BTreeMap<NoteId, Word>) -> Self {
+        self.note_args = args;
+        self
+    }
+
     /// Set the desired transaction script
     pub fn tx_script(mut self, tx_script: TransactionScript) -> Self {
         self.tx_script = Some(tx_script);


### PR DESCRIPTION
This PR adds a function to set `NoteArgs` when using the `TransactionContextBuilder`. It is possible that I am missing something, but I couldn't find anywhere in the tests that use the `MockChain` where `NoteArgs` are set. 

This PR enables the ability to set `NoteArgs` for the notes that are being consumed when using the `MockChain`. 