### PR TITLE
Fix outdated `account::set_item` docs

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -250,14 +250,13 @@ end
 
 #! Sets an item in the account storage.
 #!
-#! Inputs:  [index, V', pad(11)]
-#! Outputs: [R', V, pad(8)]
+#! Inputs:  [index, VALUE, pad(11)]
+#! Outputs: [OLD_VALUE, pad(12)]
 #!
 #! Where:
 #! - index is the index of the item to set.
-#! - V' is the value to set.
-#! - V is the previous value of the item.
-#! - R' is the new storage commitment.
+#! - VALUE is the value to set.
+#! - OLD_VALUE is the previous value of the item.
 #!
 #! Panics if:
 #! - the index is out of bounds.
@@ -267,30 +266,26 @@ end
 export.account_set_item
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
-    # => [index, V', pad(11)]
+    # => [index, VALUE, pad(11)]
 
     # if the transaction is being executed against a faucet account then assert
     # index != FAUCET_STORAGE_DATA_SLOT (reserved slot)
     dup exec.account::get_faucet_storage_data_slot eq
     exec.account::get_id swap drop exec.account::is_faucet
     and assertz.err=ERR_FAUCET_STORAGE_DATA_SLOT_IS_RESERVED
-    # => [index, V', pad(11)]
+    # => [index, VALUE, pad(11)]
 
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
-    # => [storage_offset, storage_size, index, V', pad(11)]
+    # => [storage_offset, storage_size, index, VALUE, pad(11)]
 
     # apply offset to storage slot index
     exec.account::apply_storage_offset
-    # => [index_with_offset, V', pad(11)]
+    # => [index_with_offset, VALUE, pad(11)]
 
     # set the account storage item
     exec.account::set_item
-    # => [R', V, pad(11)]
-
-    # truncate the stack
-    movup.8 drop movup.8 drop movup.8 drop
-    # => [R', V, pad(8)]
+    # => [OLD_VALUE, pad(12)]
 end
 
 #! Returns the VALUE located under the specified KEY within the map contained in the given

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -484,42 +484,42 @@ end
 #! Note:
 #! - We assume that index has been validated and is within bounds.
 #!
-#! Inputs:  [index, V']
-#! Outputs: [V]
+#! Inputs:  [index, VALUE]
+#! Outputs: [OLD_VALUE]
 #!
 #! Where:
 #! - index is the index of the item to set.
-#! - V' is the value to set.
-#! - V is the previous value of the item.
+#! - VALUE is the value to set.
+#! - OLD_VALUE is the previous value of the item.
 #!
 #! Panics if:
 #! - the storage slot type is not value.
 export.set_item
     emit.ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT
-    # => [index, V']
+    # => [index, VALUE]
 
     # get storage slot type
     dup exec.get_storage_slot_type
-    # => [storage_slot_type, index, V']
+    # => [storage_slot_type, index, VALUE]
 
     # check if type == slot
     exec.constants::get_storage_slot_type_value eq
     assert.err=ERR_ACCOUNT_SETTING_VALUE_ITEM_ON_NON_VALUE_SLOT
-    # => [index, V']
+    # => [index, VALUE]
 
-    # duplicate the index and the V' enabling emission of an
+    # duplicate the index and the VALUE enabling emission of an
     # event after an account storage item is being updated
     movdn.4 dupw dup.8
-    # => [index, V', V', index]
+    # => [index, VALUE, VALUE, index]
 
-    # set V' in the storage slot
+    # set VALUE in the storage slot
     exec.set_item_raw
-    # => [V, V', index]
+    # => [OLD_VALUE, VALUE, index]
 
     # emit event to signal that an account storage item is being updated
     swapw movup.8
     emit.ACCOUNT_STORAGE_AFTER_SET_ITEM_EVENT drop dropw
-    # => [V]
+    # => [OLD_VALUE]
 end
 
 #! Returns the VALUE located under the specified KEY within the map contained in the given

--- a/crates/miden-lib/asm/miden/account.masm
+++ b/crates/miden-lib/asm/miden/account.masm
@@ -171,14 +171,13 @@ end
 
 #! Sets an item in the account storage. Panics if the index is out of bounds.
 #!
-#! Inputs:  [index, V']
-#! Outputs: [R', V]
+#! Inputs:  [index, VALUE]
+#! Outputs: [OLD_VALUE]
 #!
 #! Where:
 #! - index is the index of the item to set.
-#! - V' is the value to set.
-#! - V is the previous value of the item.
-#! - R' is the new storage commitment.
+#! - VALUE is the value to set.
+#! - OLD_VALUE is the previous value of the item.
 #!
 #! Panics if:
 #! - the index of the item is out of bounds.
@@ -186,18 +185,18 @@ end
 #! Invocation: exec
 export.set_item
     exec.kernel_proc_offsets::account_set_item_offset
-    # => [offset, index, V']
+    # => [offset, index, VALUE]
 
     # pad the stack
     push.0.0 movdn.7 movdn.7 padw padw swapdw
-    # => [offset, index, V', pad(10)]
+    # => [offset, index, VALUE, pad(10)]
 
     syscall.exec_kernel_proc
-    # => [R', V, pad(8)]
+    # => [OLD_VALUE, pad(12)]
 
     # clean the stack
-    swapdw dropw dropw
-    # => [R', V]
+    swapw.3 dropw dropw dropw
+    # => [OLD_VALUE]
 end
 
 #! Gets a map item from the account storage.

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -24,7 +24,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_item
     digest!("0xdd8f439cb6f7f3edcda15c9c339e7c2b2dada2fc94952a8199081a197aeebb7a"),
     // account_set_item
-    digest!("0x61104ec016c3ed9b49aee53650ddde9e984a72e4c4e13001cbf98b9cef426758"),
+    digest!("0x0d1820e4d87588381ab45e74635ad542e4a25180cd66b40601d9c4c593ee1daf"),
     // account_get_map_item
     digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item

--- a/crates/miden-objects/src/note/assets.rs
+++ b/crates/miden-objects/src/note/assets.rs
@@ -11,8 +11,8 @@ use crate::{
 // ================================================================================================
 /// An asset container for a note.
 ///
-/// A note must contain at least 1 asset and can contain up to 256 assets. No duplicates are
-/// allowed, but the order of assets is unspecified.
+/// A note can contain between 0 and 256 assets. No duplicates are allowed, but the order of assets
+/// is unspecified.
 ///
 /// All the assets in a note can be reduced to a single commitment which is computed by
 /// sequentially hashing the assets. Note that the same list of assets can result in two different

--- a/crates/miden-objects/src/testing/account_code.rs
+++ b/crates/miden-objects/src/testing/account_code.rs
@@ -38,14 +38,10 @@ pub(crate) const MOCK_ACCOUNT_CODE: &str = "
     end
 
     # Stack:  [index, VALUE_TO_SET, pad(11)]
-    # Output: [NEW_STORAGE_ROOT, PREVIOUS_STORAGE_VALUE, pad(8)]
+    # Output: [PREVIOUS_STORAGE_VALUE, pad(12)]
     export.set_item
         exec.account::set_item
-        # => [R', V, pad(11)]
-
-        # truncate the stack
-        movup.8 drop movup.8 drop movup.8 drop
-        # => [R', V, pad(8)]
+        # => [V, pad(12)]
     end
 
     # Stack:  [index, pad(15)]

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -229,7 +229,7 @@ fn executed_transaction_account_delta_new() {
             push.{STORAGE_INDEX_0}
             # => [idx, 13, 11, 9, 7]
             # update the storage value
-            call.account::set_item dropw dropw
+            call.account::set_item dropw
             # => []
 
             ## Update account storage map

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -404,7 +404,6 @@ fn test_set_item() {
     let code = format!(
         "
         use.kernel::account
-        use.kernel::memory
         use.kernel::prologue
 
         begin
@@ -526,7 +525,7 @@ fn test_account_component_storage_offset() {
             push.1.2.3.4.0
             exec.account::set_item
 
-            dropw dropw
+            dropw
         end
 
         export.foo_read
@@ -545,7 +544,7 @@ fn test_account_component_storage_offset() {
             push.5.6.7.8.0
             exec.account::set_item
 
-            dropw dropw
+            dropw
         end
 
         export.bar_read


### PR DESCRIPTION
- Fixes outdated `account::set_item` docs, removing the reference to the "new storage commitment" which is no longer returned.
- Uses proper variable names instead of single-letter names. (Could needs a larger refactor to do this everywhere).
- Fixes outdated docs that at least one asset is required in a note.