### PR TITLE
Move account vault events from `api.masm` to `account.masm`

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -379,7 +379,8 @@ end
 #!
 #! Panics if:
 #! - the asset is not valid.
-#! - the total value of two fungible assets is greater than or equal to 2^63.
+#! - the total value of the fungible asset is greater than or equal to 2^63 after the new asset was 
+#!   added.
 #! - the vault already contains the same non-fungible asset.
 #! - the invocation of this procedure does not originate from the native account.
 #!
@@ -394,7 +395,7 @@ export.account_add_asset
     # => [ASSET, pad(12)]
 
     # add the specified asset to the account vault, emitting the corresponding events
-    exec.account::add_asset_to_account_vault
+    exec.account::add_asset_to_vault
     # => [ASSET', pad(12)]
 end
 
@@ -423,7 +424,7 @@ export.account_remove_asset
     # => [ASSET, pad(12)]
 
     # remove the specified asset from the account vault, emitting the corresponding events
-    exec.account::remove_asset_from_account_vault
+    exec.account::remove_asset_from_vault
     # => [ASSET, pad(12)]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -28,19 +28,6 @@ const.ERR_FAUCET_IS_NF_ASSET_ISSUED_PROC_CAN_ONLY_BE_CALLED_ON_NON_FUNGIBLE_FAUC
 
 const.ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS="provided kernel procedure offset is out of bounds"
 
-# EVENTS
-# =================================================================================================
-
-# Event emitted before an asset is added to the account vault.
-const.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=131072
-# Event emitted after an asset is added to the account vault.
-const.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT=131073
-
-# Event emitted before an asset is removed from the account vault.
-const.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT=131074
-# Event emitted after an asset is removed from the account vault.
-const.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT=131075
-
 # AUTHENTICATION
 # =================================================================================================
 
@@ -378,7 +365,7 @@ export.account_get_vault_root
     # => [VAULT_ROOT, pad(12)]
 end
 
-#! Add the specified asset to the vault.
+#! Adds the specified asset to the vault.
 #!
 #! Inputs:  [ASSET, pad(12)]
 #! Outputs: [ASSET', pad(12)]
@@ -406,28 +393,12 @@ export.account_add_asset
     exec.authenticate_account_origin drop drop
     # => [ASSET, pad(12)]
 
-    emit.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT
-    # => [ASSET, pad(12)]
-
-    # duplicate the ASSET to be able to emit an event after an asset is being added
-    dupw
-    # => [ASSET, ASSET, pad(12)]
-
-    # fetch the vault root
-    exec.memory::get_acct_vault_root_ptr movdn.4
-    # => [ASSET, acct_vault_root_ptr, ASSET, pad(12)]
-
-    # add the asset to the account vault
-    exec.asset_vault::add_asset
-    # => [ASSET', ASSET, pad(12)]
-
-    # emit event to signal that an asset is being added to the account vault
-    swapw
-    emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
+    # add the specified asset to the account vault, emitting the corresponding events
+    exec.account::add_asset_to_account_vault
     # => [ASSET', pad(12)]
 end
 
-#! Remove the specified asset from the vault.
+#! Removes the specified asset from the vault.
 #!
 #! Inputs:  [ASSET, pad(12)]
 #! Outputs: [ASSET, pad(12)]
@@ -451,19 +422,8 @@ export.account_remove_asset
     exec.authenticate_account_origin drop drop
     # => [ASSET, pad(12)]
 
-    emit.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT
-    # => [ASSET, pad(12)]
-
-    # fetch the vault root
-    exec.memory::get_acct_vault_root_ptr movdn.4
-    # => [ASSET, acct_vault_root_ptr, pad(12)]
-
-    # remove the asset from the account vault
-    exec.asset_vault::remove_asset
-    # => [ASSET, pad(12)]
-
-    # emit event to signal that an asset is being removed from the account vault
-    emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT
+    # remove the specified asset from the account vault, emitting the corresponding events
+    exec.account::remove_asset_from_account_vault
     # => [ASSET, pad(12)]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -4,6 +4,7 @@ use.std::crypto::hashes::rpo
 use.std::mem
 
 use.kernel::util::account_id
+use.kernel::asset_vault
 use.kernel::constants
 use.kernel::memory
 
@@ -114,6 +115,16 @@ const.ACCOUNT_PROCEDURE_DATA_LENGTH=8
 
 # EVENTS
 # =================================================================================================
+
+# Event emitted before an asset is added to the account vault.
+const.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=131072
+# Event emitted after an asset is added to the account vault.
+const.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT=131073
+
+# Event emitted before an asset is removed from the account vault.
+const.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT=131074
+# Event emitted after an asset is removed from the account vault.
+const.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT=131075
 
 # Event emitted before an account storage item is updated.
 const.ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT=131076
@@ -785,6 +796,75 @@ export.validate_seed
     # assert the account ID matches the account ID of the new account
     exec.is_id_equal assert.err=ERR_ACCOUNT_SEED_AND_COMMITMENT_DIGEST_MISMATCH
     # => []
+end
+
+#! Adds the specified asset to the account vault.
+#!
+#! Inputs:  [ASSET]
+#! Outputs: [ASSET']
+#!
+#! Where:
+#! - ASSET is the asset that is added to the vault.
+#! - ASSET' final asset in the account vault defined as follows:
+#!   - If ASSET is a non-fungible asset, then ASSET' is the same as ASSET.
+#!   - If ASSET is a fungible asset, then ASSET' is the total fungible asset in the account vault
+#!     after ASSET was added to it.
+#!
+#! Panics if:
+#! - the asset is not valid.
+#! - the total value of two fungible assets is greater than or equal to 2^63.
+#! - the vault already contains the same non-fungible asset.
+export.add_asset_to_account_vault
+    # emit event to signal that an asset is going to be added to the account vault
+    emit.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT
+    # => [ASSET]
+
+    # duplicate the ASSET to be able to emit an event after an asset is being added
+    dupw
+    # => [ASSET, ASSET]
+
+    # fetch the account vault root
+    exec.memory::get_acct_vault_root_ptr movdn.4
+    # => [ASSET, acct_vault_root_ptr, ASSET]
+
+    # add the asset to the account vault
+    exec.asset_vault::add_asset
+    # => [ASSET', ASSET]
+
+    # emit event to signal that an asset is being added to the account vault
+    swapw
+    emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
+    # => [ASSET']
+end
+
+#! Removes the specified asset from the vault.
+#!
+#! Inputs:  [ASSET]
+#! Outputs: [ASSET]
+#!
+#! Where:
+#! - ASSET is the asset to remove from the vault.
+#!
+#! Panics if:
+#! - the fungible asset is not found in the vault.
+#! - the amount of the fungible asset in the vault is less than the amount to be removed.
+#! - the non-fungible asset is not found in the vault.
+export.remove_asset_from_account_vault
+    # emit event to signal that an asset is going to be removed from the account vault
+    emit.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT
+    # => [ASSET]
+
+    # fetch the vault root
+    exec.memory::get_acct_vault_root_ptr movdn.4
+    # => [ASSET, acct_vault_root_ptr]
+
+    # remove the asset from the account vault
+    exec.asset_vault::remove_asset
+    # => [ASSET]
+
+    # emit event to signal that an asset is being removed from the account vault
+    emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT
+    # => [ASSET]
 end
 
 # DATA LOADERS

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -812,9 +812,10 @@ end
 #!
 #! Panics if:
 #! - the asset is not valid.
-#! - the total value of two fungible assets is greater than or equal to 2^63.
+#! - the total value of the fungible asset is greater than or equal to 2^63 after the new asset was 
+#!   added.
 #! - the vault already contains the same non-fungible asset.
-export.add_asset_to_account_vault
+export.add_asset_to_vault
     # emit event to signal that an asset is going to be added to the account vault
     emit.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT
     # => [ASSET]
@@ -837,7 +838,7 @@ export.add_asset_to_account_vault
     # => [ASSET']
 end
 
-#! Removes the specified asset from the vault.
+#! Removes the specified asset from the account vault.
 #!
 #! Inputs:  [ASSET]
 #! Outputs: [ASSET]
@@ -849,7 +850,7 @@ end
 #! - the fungible asset is not found in the vault.
 #! - the amount of the fungible asset in the vault is less than the amount to be removed.
 #! - the non-fungible asset is not found in the vault.
-export.remove_asset_from_account_vault
+export.remove_asset_from_vault
     # emit event to signal that an asset is going to be removed from the account vault
     emit.ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_EVENT
     # => [ASSET]

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,9 +32,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x355dfcd3adfaca5bc5819182bf4982eb7363ec9a62b7f7173b48476cb0cfd28b"),
+    digest!("0x3ea434357a79698550fcb07f887665ba48ebc9c99b19cde20dc8aa170ed65ea8"),
     // account_remove_asset
-    digest!("0x50935b368b7843258ae86f6392df9346721b60dd9563d77a2d548da8ab81e44c"),
+    digest!("0x7378a9d10a2b92e9576ae61ebc117603e49c41f5e7f3b6ff4122fab8c7ece3e5"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset


### PR DESCRIPTION
This small PR implements two new procedures in the `account.masm`: `add_asset_to_account_vault` and `remove_asset_from_account_vault`. These procedures are wrappers around `add_asset` and `remove_asset` asset vault procedures — this will allow us to maintain the account vault exclusively, making possible to move the corresponding events from the `api.masm` to `account.masm` file.

Closes: #1089.