### PR TITLE
Forbid empty transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Remove doc update checks on CI (#1435).
 - [BREAKING] Introduce `ScriptMastForestStore` and refactor MAST forest provisioning in the `TransactionExecutor` (#1438).
 - [BREAKING] Allow list of keys in `AccountFile` (#1451).
+- [BREAKING] Forbid the execution of the empty transactions (#1459).
 
 ## 0.9.1 (2025-05-30)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -14,6 +14,8 @@ const.ERR_ACCOUNT_NONCE_DID_NOT_INCREASE_AFTER_STATE_CHANGE="account nonce did n
 
 const.ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME="total number of assets in the account and all involved notes must stay the same"
 
+const.ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY="executed transaction neither changed the account state, nor consumed any notes"
+
 # OUTPUT NOTES PROCEDURES
 # =================================================================================================
 
@@ -294,6 +296,17 @@ export.finalize_transaction
 
         # assert that initial nonce is less than current nonce
         lt assert.err=ERR_ACCOUNT_NONCE_DID_NOT_INCREASE_AFTER_STATE_CHANGE
+        # => [FINAL_ACCOUNT_COMMITMENT, INIT_ACCOUNT_COMMITMENT]
+    else
+        # assert that this transaction had input notes, otherwise this transaction is empty, which 
+        # is not allowed and will result in an error
+        exec.memory::get_input_notes_commitment padw eqw
+        # => [is_input_notes_commitment_empty, EMPTY_WORD, INPUT_NOTES_COMMITMENT, 
+        #        FINAL_ACCOUNT_COMMITMENT, INIT_ACCOUNT_COMMITMENT]
+
+        # assert that the input notes commitment is not an empty word, otherwise there were no input
+        # notes in this transaction
+        assertz.err=ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY dropw dropw
         # => [FINAL_ACCOUNT_COMMITMENT, INIT_ACCOUNT_COMMITMENT]
     end
 

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -57,6 +57,8 @@ pub const ERR_ACCOUNT_TOO_MANY_PROCEDURES: MasmError = MasmError::from_static_st
 /// Error Message: "number of account storage slots exceeds the maximum limit of 255"
 pub const ERR_ACCOUNT_TOO_MANY_STORAGE_SLOTS: MasmError = MasmError::from_static_str("number of account storage slots exceeds the maximum limit of 255");
 
+/// Error Message: "executed transaction neither changed the account state, nor consumed any notes"
+pub const ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY: MasmError = MasmError::from_static_str("executed transaction neither changed the account state, nor consumed any notes");
 /// Error Message: "total number of assets in the account and all involved notes must stay the same"
 pub const ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME: MasmError = MasmError::from_static_str("total number of assets in the account and all involved notes must stay the same");
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -566,6 +566,8 @@ pub enum ProvenTransactionError {
         account_id: AccountId,
         update_size: usize,
     },
+    #[error("proven transaction neither changed the account state, nor consumed any notes")]
+    EmptyTransaction,
 }
 
 // PROPOSED BATCH ERROR

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -18,6 +18,13 @@ use crate::{
 
 /// Result of executing and proving a transaction. Contains all the data required to verify that a
 /// transaction was executed correctly.
+///
+/// A proven transaction must not be empty. A transaction is empty if the account state is unchanged
+/// or the number of input notes is zero. This check prevents proving a transaction once and
+/// submitting it to the network many times. Output notes are not considered because they can be
+/// empty (i.e. contain no assets). Otherwise, a transaction with no account state change, no input
+/// notes and one such empty output note could be resubmitted many times to the network and fill up
+/// block space which is a form of DOS attack.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProvenTransaction {
     /// A unique identifier for the transaction, see [TransactionId] for additional details.
@@ -113,6 +120,8 @@ impl ProvenTransaction {
     ///
     /// Returns an error if:
     /// - The size of the serialized account update exceeds [`ACCOUNT_UPDATE_MAX_SIZE`].
+    /// - The transaction is empty, which is the case if the account state is unchanged or the
+    ///   number of input notes is zero.
     /// - The transaction was executed against a _new_ on-chain account and its account ID does not
     ///   match the ID in the account update.
     /// - The transaction was executed against a _new_ on-chain account and its commitment does not
@@ -337,6 +346,8 @@ impl ProvenTransactionBuilder {
     ///   [`MAX_OUTPUT_NOTES_PER_TX`](crate::constants::MAX_OUTPUT_NOTES_PER_TX).
     /// - The vector of output notes contains duplicates.
     /// - The size of the serialized account update exceeds [`ACCOUNT_UPDATE_MAX_SIZE`].
+    /// - The transaction is empty, which is the case if the account state is unchanged or the
+    ///   number of input notes is zero.
     /// - The transaction was executed against a _new_ on-chain account and its account ID does not
     ///   match the ID in the account update.
     /// - The transaction was executed against a _new_ on-chain account and its commitment does not

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_error.rs
@@ -11,7 +11,7 @@ use miden_objects::{
     batch::ProvenBatch,
     block::{BlockInputs, BlockNumber, ProposedBlock},
     testing::account_component::AccountMockComponent,
-    transaction::{ProvenTransaction, ProvenTransactionBuilder},
+    transaction::{ProvenTransaction, ProvenTransactionBuilder, TransactionScript},
     vm::ExecutionProof,
 };
 use winterfell::Proof;
@@ -298,8 +298,20 @@ fn proven_block_fails_on_creating_account_with_existing_account_id_prefix() -> a
     // Execute the account-creating transaction.
     // --------------------------------------------------------------------------------------------
 
+    // transaction code which only increases the nonce to make the transaction non-empty
+    let default_tx_code = "
+        use.miden::account 
+        
+        begin 
+            push.1 call.account::incr_nonce drop
+        end";
+    let default_tx_script =
+        TransactionScript::compile(default_tx_code, [], TransactionKernel::testing_assembler())
+            .context("failed to compile the transaction script")?;
+
     let tx_inputs = mock_chain.get_transaction_inputs(account.clone(), Some(seed), &[], &[]);
     let tx_context = TransactionContextBuilder::new(account)
+        .tx_script(default_tx_script)
         .account_seed(Some(seed))
         .tx_inputs(tx_inputs)
         .build();

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -9,7 +9,9 @@ use miden_objects::{
     batch::ProvenBatch,
     block::BlockNumber,
     note::{Note, NoteId, NoteTag, NoteType},
-    testing::{account_component::AccountMockComponent, note::NoteBuilder},
+    testing::{
+        account_component::AccountMockComponent, account_id::ACCOUNT_ID_SENDER, note::NoteBuilder,
+    },
     transaction::{ExecutedTransaction, OutputNote, ProvenTransaction, TransactionScript},
     utils::word_to_masm_push_string,
 };
@@ -144,11 +146,22 @@ pub fn generate_tx_with_authenticated_notes(
 }
 
 /// Generates a NOOP transaction, i.e. one that doesn't change the state of the account.
+///
+/// To make this transaction non-empty, it consumes one "noop note", which does nothing.
 pub fn generate_noop_tx(
     chain: &mut MockChain,
     input: impl Into<TxContextInput>,
 ) -> ExecutedTransaction {
-    let tx_context = chain.build_tx_context(input, &[], &[]).build();
+    let noop_note = NoteBuilder::new(ACCOUNT_ID_SENDER.try_into().unwrap(), &mut rand::rng())
+        .build(&TransactionKernel::assembler())
+        .expect("failed to create the noop note");
+    chain.add_pending_note(OutputNote::Full(noop_note.clone()));
+    chain.prove_next_block();
+
+    let tx_context = chain
+        .build_tx_context(input.into(), &[noop_note.id()], &[])
+        .input_notes(vec![noop_note])
+        .build();
     tx_context.execute().unwrap()
 }
 

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -823,6 +823,8 @@ fn test_tx_script_inputs() {
     let tx_script_input_value = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)];
     let tx_script_src = format!(
         "
+        use.miden::account
+
         begin
             # push the tx script input key onto the stack
             push.{key}
@@ -832,6 +834,9 @@ fn test_tx_script_inputs() {
 
             # assert that the value is correct
             push.{value} assert_eqw
+
+            # update the nonce to make the transaction non-empty
+            push.1 call.account::incr_nonce drop
         end
         ",
         key = word_to_masm_push_string(&tx_script_input_key),
@@ -861,6 +866,8 @@ fn test_tx_script_inputs() {
 #[test]
 fn test_tx_script_args() -> anyhow::Result<()> {
     let tx_script_src = r#"
+        use.miden::account
+
         begin
             # => [TX_SCRIPT_ARGS_KEY]
             # `TX_SCRIPT_ARGS_KEY` value, which is located on the stack at the beginning of 
@@ -897,6 +904,9 @@ fn test_tx_script_args() -> anyhow::Result<()> {
             # deeper on the stack, we should assert values one by one using `push.n assert_eq`.
             push.0.1.2.3
             assert_eqw.err="first three values in the transaction args array are incorrect"
+
+            # update the nonce to make the transaction non-empty
+            push.1 call.account::incr_nonce drop
         end"#;
 
     let tx_script =

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -656,6 +656,14 @@ fn test_account_component_storage_offset() {
 /// Tests that we can successfully create regular and faucet accounts with empty storage.
 #[test]
 fn create_account_with_empty_storage_slots() -> anyhow::Result<()> {
+    // transaction code which only increases the nonce to make the transaction non-empty
+    let default_tx_code = "
+        use.kernel::account 
+        
+        begin 
+            push.1 exec.account::incr_nonce 
+        end";
+
     for account_type in [AccountType::FungibleFaucet, AccountType::RegularAccountUpdatableCode] {
         let mock_chain = MockChain::new();
         let (account, seed) = AccountBuilder::new([5; 32])
@@ -673,7 +681,8 @@ fn create_account_with_empty_storage_slots() -> anyhow::Result<()> {
             .tx_inputs(tx_inputs)
             .build();
         tx_context
-            .execute()
+            .execute_code(default_tx_code)
+            .map_err(TransactionExecutorError::TransactionProgramExecutionFailed)
             .context(format!("failed to execute {account_type} account creating tx"))?;
     }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -556,6 +556,7 @@ fn test_fpi_execute_foreign_procedure() {
         use.std::sys
 
         use.miden::tx
+        use.miden::account
 
         begin
             # get the storage item at index 0
@@ -604,6 +605,9 @@ fn test_fpi_execute_foreign_procedure() {
             # assert the correctness of the obtained value
             push.1.2.3.4 assert_eqw
             # => []
+
+            # update the nonce to make the transaction non-empty
+            push.1 call.account::incr_nonce
 
             # truncate the stack
             exec.sys::truncate_stack
@@ -795,6 +799,7 @@ fn test_nested_fpi_cyclic_invocation() {
         use.std::sys
 
         use.miden::tx
+        use.miden::account
 
         begin
             # pad the stack for the `execute_foreign_procedure` execution
@@ -816,7 +821,10 @@ fn test_nested_fpi_cyclic_invocation() {
 
             # assert that the resulting value equals 18
             push.18 assert_eq.err="sum should be 18"
-            # => []
+            # => []        
+
+            # update the nonce to make the transaction non-empty
+            push.1 call.account::incr_nonce
 
             exec.sys::truncate_stack
         end

--- a/docs/src/transaction.md
+++ b/docs/src/transaction.md
@@ -45,7 +45,7 @@ A `Transaction` requires several inputs:
 3. **Transaction script processing**
    `Transaction` scripts are an optional piece of code defined by the executor which interacts with account methods after all notes have been executed. For example, `Transaction` scripts can be used to sign the `Transaction` (e.g., sign the transaction by incrementing the nonce of the account, without which, the transaction would fail), to mint tokens from a faucet, create notes, or modify account storage. `Transaction` scripts can also invoke methods of foreign accounts to read their state.
 4. **Epilogue**
-   Completes the execution, resulting in an updated account state and a generated zero-knowledge proof. The validity of the resulting state change is checked. The account's `Nonce` must have been incremented, which is how the entire transaction is authenticated. Also, the net sum of all involved assets must be `0` (if the account is not a faucet).
+   Completes the execution, resulting in an updated account state and a generated zero-knowledge proof. The validity of the resulting transaction is checked. The account's state must have changed or at least one input note must have been consumed to make the transaction non-empty. This check ensures that a transaction can only be submitted once to the network. If the account's state has changed, the `nonce` must have been incremented, which is how the entire transaction is authenticated. Additionally, the net sum of all involved assets must be `0` (if the account is not a faucet).
 
 The proof together with the corresponding data needed for verification and updates of the global state can then be submitted and processed by the network.
 


### PR DESCRIPTION
This PR adds two additional checks to make sure that the executed transaction is not empty, i.e. changes the account state or consumes at least one note. This check was added into the kernel's `epilogue` and into the `ProvenTransaction::validate`.

Closes: #1402.