### PR TITLE
Implement in-kernel account delta for fungible assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
 - Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB for compiler testing (#1464).
 - [BREAKING] `TransactionExecutor` now holds plain references instead of `Arc` for its trait objects (#1469).
-- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404).
+- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460).
 - [BREAKING] Store account ID in account delta (#1493).
 - [BREAKING] Remove P2IDR and replace with P2IDE (#1483).
 - Added `Note::is_network_note()` accessor (#1485).

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -5,6 +5,7 @@ use.std::mem
 
 use.kernel::account_id
 use.kernel::asset_vault
+use.kernel::asset
 use.kernel::account_delta
 use.kernel::constants
 use.kernel::memory
@@ -760,19 +761,40 @@ export.add_asset_to_vault
     exec.memory::get_acct_vault_root_ptr movdn.4
     # => [ASSET, acct_vault_root_ptr, ASSET]
 
-    # add the asset to the account vault
-    exec.asset_vault::add_asset swapw
-    # => [ASSET, ASSET']
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET, acct_vault_root_ptr, ASSET]
 
-    dupw dup.3 movdn.3
-    # => [ASSET, amount, ASSET, ASSET']
+    # add the asset to the asset vault
+    if.true
+        # validate the fungible asset
+        exec.asset::validate_fungible_asset
+        # => [ASSET, acct_vault_root_ptr, ASSET]
 
-    exec.asset_vault::build_fungible_asset_vault_key
-    # => [ASSET_KEY, amount, ASSET, ASSET']
+        exec.asset_vault::add_fungible_asset
+        # => [ASSET', ASSET]
 
-    # dropw drop
-    exec.account_delta::add_fungible_asset_delta
-    # => [ASSET, ASSET']
+        swapw
+        # => [ASSET, ASSET']
+
+        dupw dup.3 movdn.3
+        # => [ASSET, amount, ASSET, ASSET']
+
+        exec.asset_vault::build_fungible_asset_vault_key
+        # => [ASSET_KEY, amount, ASSET, ASSET']
+
+        exec.account_delta::add_fungible_asset
+        # => [ASSET, ASSET']
+    else
+        # validate the non-fungible asset
+        exec.asset::validate_non_fungible_asset
+        # => [ASSET, acct_vault_root_ptr, ASSET]
+
+        exec.asset_vault::add_non_fungible_asset
+        # => [ASSET', ASSET]
+
+        swapw
+        # => [ASSET, ASSET']
+    end
 
     # emit event to signal that an asset is being added to the account vault
     emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
@@ -800,9 +822,26 @@ export.remove_asset_from_vault
     exec.memory::get_acct_vault_root_ptr movdn.4
     # => [ASSET, acct_vault_root_ptr]
 
-    # remove the asset from the account vault
-    exec.asset_vault::remove_asset
-    # => [ASSET]
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET, acct_vault_root_ptr]
+
+    # remove the asset from the asset vault
+    if.true
+        exec.asset_vault::remove_fungible_asset
+        # => [ASSET]
+
+        dupw dup.3 movdn.3
+        # => [ASSET, amount, ASSET]
+
+        exec.asset_vault::build_fungible_asset_vault_key
+        # => [ASSET_KEY, amount, ASSET]
+
+        exec.account_delta::remove_fungible_asset
+        # => [ASSET]
+    else
+        exec.asset_vault::remove_non_fungible_asset
+        # => [ASSET]
+    end
 
     # emit event to signal that an asset is being removed from the account vault
     emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -761,40 +761,15 @@ export.add_asset_to_vault
     exec.memory::get_acct_vault_root_ptr movdn.4
     # => [ASSET, acct_vault_root_ptr, ASSET]
 
-    exec.asset::is_fungible_asset
-    # => [is_fungible_asset, ASSET, acct_vault_root_ptr, ASSET]
+    # add the asset to the account vault
+    exec.asset_vault::add_asset
+    # => [ASSET', ASSET]
 
-    # add the asset to the asset vault
-    if.true
-        # validate the fungible asset
-        exec.asset::validate_fungible_asset
-        # => [ASSET, acct_vault_root_ptr, ASSET]
+    swapw
+    # => [ASSET, ASSET']
 
-        exec.asset_vault::add_fungible_asset
-        # => [ASSET', ASSET]
-
-        swapw
-        # => [ASSET, ASSET']
-
-        exec.asset_vault::build_fungible_asset_vault_key
-        # => [ASSET_KEY, ASSET, ASSET']
-
-        dup.7 movdn.4
-        # => [ASSET_KEY, amount, ASSET, ASSET']
-
-        exec.account_delta::add_fungible_asset
-        # => [ASSET, ASSET']
-    else
-        # validate the non-fungible asset
-        exec.asset::validate_non_fungible_asset
-        # => [ASSET, acct_vault_root_ptr, ASSET]
-
-        exec.asset_vault::add_non_fungible_asset
-        # => [ASSET', ASSET]
-
-        swapw
-        # => [ASSET, ASSET']
-    end
+    dupw exec.account_delta::add_asset
+    # => [ASSET, ASSET']
 
     # emit event to signal that an asset is being added to the account vault
     emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
@@ -822,26 +797,12 @@ export.remove_asset_from_vault
     exec.memory::get_acct_vault_root_ptr movdn.4
     # => [ASSET, acct_vault_root_ptr]
 
-    exec.asset::is_fungible_asset
-    # => [is_fungible_asset, ASSET, acct_vault_root_ptr]
+    # remove the asset from the account vault
+    exec.asset_vault::remove_asset
+    # => [ASSET]
 
-    # remove the asset from the asset vault
-    if.true
-        exec.asset_vault::remove_fungible_asset
-        # => [ASSET]
-
-        exec.asset_vault::build_fungible_asset_vault_key
-        # => [ASSET_KEY, ASSET]
-
-        dup.7 movdn.4
-        # => [ASSET_KEY, amount, ASSET]
-
-        exec.account_delta::remove_fungible_asset
-        # => [ASSET]
-    else
-        exec.asset_vault::remove_non_fungible_asset
-        # => [ASSET]
-    end
+    dupw exec.account_delta::remove_asset
+    # => [ASSET]
 
     # emit event to signal that an asset is being removed from the account vault
     emit.ACCOUNT_VAULT_AFTER_REMOVE_ASSET_EVENT

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -5,6 +5,7 @@ use.std::mem
 
 use.kernel::account_id
 use.kernel::asset_vault
+use.kernel::account_delta
 use.kernel::constants
 use.kernel::memory
 
@@ -760,11 +761,20 @@ export.add_asset_to_vault
     # => [ASSET, acct_vault_root_ptr, ASSET]
 
     # add the asset to the account vault
-    exec.asset_vault::add_asset
-    # => [ASSET', ASSET]
+    exec.asset_vault::add_asset swapw
+    # => [ASSET, ASSET']
+
+    dupw dup.3 movdn.3
+    # => [ASSET, amount, ASSET, ASSET']
+
+    exec.asset_vault::build_fungible_asset_vault_key
+    # => [ASSET_KEY, amount, ASSET, ASSET']
+
+    # dropw drop
+    exec.account_delta::add_fungible_asset_delta
+    # => [ASSET, ASSET']
 
     # emit event to signal that an asset is being added to the account vault
-    swapw
     emit.ACCOUNT_VAULT_AFTER_ADD_ASSET_EVENT dropw
     # => [ASSET']
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -776,10 +776,10 @@ export.add_asset_to_vault
         swapw
         # => [ASSET, ASSET']
 
-        dupw dup.3 movdn.3
-        # => [ASSET, amount, ASSET, ASSET']
-
         exec.asset_vault::build_fungible_asset_vault_key
+        # => [ASSET_KEY, ASSET, ASSET']
+
+        dup.7 movdn.4
         # => [ASSET_KEY, amount, ASSET, ASSET']
 
         exec.account_delta::add_fungible_asset
@@ -830,10 +830,10 @@ export.remove_asset_from_vault
         exec.asset_vault::remove_fungible_asset
         # => [ASSET]
 
-        dupw dup.3 movdn.3
-        # => [ASSET, amount, ASSET]
-
         exec.asset_vault::build_fungible_asset_vault_key
+        # => [ASSET_KEY, ASSET]
+
+        dup.7 movdn.4
         # => [ASSET_KEY, amount, ASSET]
 
         exec.account_delta::remove_fungible_asset

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -1,4 +1,5 @@
 use.kernel::memory
+use.kernel::link_map
 use.kernel::constants
 use.kernel::account
 use.std::crypto::hashes::rpo
@@ -15,6 +16,9 @@ const.DOMAIN_MAP=3
 
 # PROCEDURES
 # =================================================================================================
+
+# DELTA COMPUTATION
+# -------------------------------------------------------------------------------------------------
 
 #! Computes the commitment to the native account's delta.
 #!
@@ -182,4 +186,50 @@ proc.get_item_initial
     # get the item from storage
     swap mul.8 add padw movup.4 mem_loadw
     # => [INIT_VALUE]
+end
+
+# DELTA BOOKKEEPING
+# -------------------------------------------------------------------------------------------------
+
+#! Adds the given amount to the fungible asset delta for the asset identified by the asset key.
+#!
+#! Inputs:  [ASSET_KEY, amount]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET_KEY is the asset key of the fungible asset.
+#! - amount is the amount by which the fungible asset's amount increases.
+export.add_fungible_asset_delta
+    dupw exec.memory::get_account_delta_fungible_asset_ptr
+    # => [fungible_delta_map_ptr, ASSET_KEY, ASSET_KEY, amount]
+
+    # retrieve the current delta amount
+    # contains_key can be ignored because the default value is a delta amount of 0
+    # VALUE1 is unused so we drop it as well
+    exec.link_map::get drop swapw dropw
+    # => [delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY, amount]
+
+    movup.8 u32split
+    # => [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
+
+    exec.add_asset_amount
+    # => [delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
+
+    # pad VALUE1 of the link map
+    swapw padw movdnw.2
+    # => [ASSET_KEY, delta_amount_hi, delta_amount_lo, 0, 0, EMPTY_WORD]
+
+    exec.memory::get_account_delta_fungible_asset_ptr
+    # => [fungible_delta_map_ptr, ASSET_KEY, delta_amount_hi, delta_amount_lo, 0, 0, EMPTY_WORD]
+
+    exec.link_map::set drop
+    # => []
+end
+
+#! TODO: Document asset amount math.
+#!
+#! Inputs:  [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo]
+#! Outputs: [delta_amount_hi, delta_amount_lo]
+proc.add_asset_amount
+    exec.::std::math::u64::wrapping_add
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -2,6 +2,8 @@ use.kernel::memory
 use.kernel::link_map
 use.kernel::constants
 use.kernel::account
+use.kernel::asset
+use.kernel::asset_vault
 use.std::crypto::hashes::rpo
 use.std::math::u64
 
@@ -277,6 +279,67 @@ end
 
 # DELTA BOOKKEEPING
 # -------------------------------------------------------------------------------------------------
+
+#! Adds the given asset to the delta.
+#!
+#! Assumes the asset is valid, so it should be called after asset_vault::add_asset.
+#!
+#! Inputs:  [ASSET]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET is the asset.
+export.add_asset
+    # check if the asset is a fungible asset
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET]
+
+    if.true
+        exec.asset_vault::build_fungible_asset_vault_key swapw
+        # => [ASSET, ASSET_KEY]
+
+        drop drop drop movdn.4
+        # => [ASSET_KEY, amount]
+
+        exec.add_fungible_asset
+        # => []
+    else
+        # TODO: Handle non-fungible assets
+        dropw
+        # => []
+    end
+end
+
+#! Removes the given asset from the delta.
+#!
+#! Assumes the asset is valid, so it should be called after asset_vault::remove_asset
+#! (which would abort if the asset is invalid).
+#!
+#! Inputs:  [ASSET]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET is the asset.
+export.remove_asset
+    # check if the asset is a fungible asset
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset, ASSET, vault_root_ptr]
+
+    if.true
+        exec.asset_vault::build_fungible_asset_vault_key swapw
+        # => [ASSET, ASSET_KEY]
+
+        drop drop drop movdn.4
+        # => [ASSET_KEY, amount]
+
+        exec.remove_fungible_asset
+        # => []
+    else
+        # TODO: Handle non-fungible assets
+        dropw
+        # => []
+    end
+end
 
 #! Adds the given amount to the fungible asset delta for the asset identified by the asset key.
 #!

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -47,7 +47,8 @@ export.compute_commitment
     hperm
     # => [RATE, RATE, PERM]
 
-    # TODO: Compute vault commitment
+    exec.update_fungible_asset_delta
+    # => [RATE, RATE, PERM]
 
     exec.update_storage_delta
     # => [RATE, RATE, PERM]
@@ -164,6 +165,88 @@ proc.update_value_slot_delta
       dropw dropw drop
       # => [RATE, RATE, PERM]
     end
+    # => [RATE, RATE, PERM]
+end
+
+#! Updates the given delta hasher with the fungible asset vault delta.
+#!
+#! Inputs:  [RATE, RATE, PERM]
+#! Outputs: [RATE, RATE, PERM]
+proc.update_fungible_asset_delta.2
+    exec.memory::get_account_delta_fungible_asset_ptr
+    # => [account_delta_fungible_asset_ptr, RATE, RATE, PERM]
+
+    exec.link_map::iter
+    # => [has_next, iter, RATE, RATE, PERM]
+
+    # enter loop if the link map is not empty
+    while.true
+        exec.link_map::next_key_value
+        # => [KEY, VALUE0, has_next, iter, ...]
+
+        # store has_next
+        movup.8 loc_store.0
+        # => [KEY, VALUE0, iter, ...]
+
+        # store iter
+        movup.8 loc_store.1
+        # => [KEY, VALUE0, ...]
+        # this stack state is equivalent to:
+        # => [[faucet_id_prefix, faucet_id_suffix, 0, 0], [delta_amount_hi, delta_amount_lo, 0, 0], ...]
+
+        swapw
+        # => [[delta_amount_hi, delta_amount_lo, 0, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
+
+        exec.i64_unsigned_abs not
+        # => [is_amount_unsigned, [delta_amount_abs_hi, delta_amount_abs_lo, 0, 0], ...]
+
+        # rename is_amount_unsigned to was_added
+        movdn.3
+        # => [[delta_amount_abs_hi, delta_amount_abs_lo, 0, was_added,  0], ...]
+
+        # reassemble the delta amount to a felt by multiplying the high part with 2^32 and adding the lo part
+        # this is safe to do because the delta amount is in range [-2^63 + 1, 2^63 - 1], so its
+        # absolute value will fit into a felt.
+        mul.0x0100000000 add
+        # => [[delta_amount_abs, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
+
+        dup neq.0
+        # => [is_delta_amount_non_zero, [delta_amount_abs, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
+
+        # if delta amount is non-zero, update the hasher
+        if.true
+            movup.5 movdn.2
+            # => [faucet_id_prefix, faucet_id_suffix, delta_amount_lo, 0, 0, delta_amount_hi, 0, 0, ...]
+
+            movup.5 movdn.3
+            # => [[faucet_id_prefix, faucet_id_suffix, delta_amount_lo, delta_amount_hi], 0, 0, 0, 0, ...]
+
+            push.DOMAIN_ASSET swap.8 drop
+            # => [[faucet_id_prefix, faucet_id_suffix, amount_lo, amount_hi], [0, 0, 0, domain], RATE, RATE, PERM
+
+            # drop previous RATE elements
+            swapdw dropw dropw
+            # => [[faucet_id_prefix, faucet_id_suffix, amount_lo, amount_hi], [0, 0, 0, domain], PERM]
+
+            hperm
+            # => [RATE, RATE, PERM]
+        else
+          # discard values loaded from map: KEY, VALUE0
+          dropw dropw
+          # => [RATE, RATE, PERM]
+        end
+        # => [RATE, RATE, PERM]
+
+        # load iter and has_next
+        loc_load.1
+        # => [iter, RATE, RATE, PERM]
+
+        loc_load.0
+        # => [has_next, iter, RATE, RATE, PERM]
+    end
+
+    # drop iter
+    drop
     # => [RATE, RATE, PERM]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -200,18 +200,14 @@ proc.update_fungible_asset_delta.2
         swapw
         # => [[delta_amount_hi, delta_amount_lo, 0, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
 
-        exec.i64_unsigned_abs not
-        # => [is_amount_unsigned, [delta_amount_abs_hi, delta_amount_abs_lo, 0, 0], ...]
+        # this reassembles the delta amount into a felt, which is safe to do because the delta
+        # amount is in range [-2^63 + 1, 2^63 - 1], so its absolute value will fit into a felt.
+        exec.i64_unsigned_abs
+        # => [[is_amount_unsigned, delta_amount_abs, 0, 0], ...]
 
         # rename is_amount_unsigned to was_added
-        movdn.3
-        # => [[delta_amount_abs_hi, delta_amount_abs_lo, 0, was_added,  0], ...]
-
-        # reassemble the delta amount to a felt by multiplying the high part with 2^32 and adding the lo part
-        # this is safe to do because the delta amount is in range [-2^63 + 1, 2^63 - 1], so its
-        # absolute value will fit into a felt.
-        mul.0x0100000000 add
-        # => [[delta_amount_abs, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
+        movdn.2
+        # => [[delta_amount_abs, 0, was_added, 0], ...]
 
         dup neq.0
         # => [is_delta_amount_non_zero, [delta_amount_abs, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, 0], ...]
@@ -449,13 +445,15 @@ end
 #! Computes the absolute value of the given i64 represented by two u32 limbs and returns a
 #! boolean flag indicating whether the value is signed.
 #!
+#! Assumes that x_hi and x_lo can be safely combined into a felt.
+#!
 #! Inputs: [x_hi, x_lo]
-#! Outputs: [is_x_signed, x_abs_hi, x_abs_lo]
+#! Outputs: [is_x_unsigned, x_abs]
 #!
 #! Where:
 #! - x_{hi, lo} are the u32 limbs of an i64.
-#! - is_x_signed indicates whether x is signed.
-#! - x_abs_{hi, lo} are the absolute u32 limbs of a u64.
+#! - is_x_unsigned indicates whether the inputs were positive.
+#! - x_abs is the absolute value of the inputs as a felt.
 proc.i64_unsigned_abs
     exec.i64_is_signed
     # => [is_x_signed, x_hi, x_lo]
@@ -477,8 +475,12 @@ proc.i64_unsigned_abs
     cdropw drop drop
     # => [x_abs_hi, x_abs_lo, is_x_signed]
 
-    movup.2
-    # => [is_x_signed, x_abs_hi, x_abs_lo]
+    # reassemble the amount to a felt by multiplying the high part with 2^32 and adding the lo part
+    mul.0x0100000000 add
+    # => [x_abs, is_x_signed]
+
+    swap not
+    # => [is_x_unsigned, x_abs]
 end
 
 #! Returns 1 if the given number is signed (its most significant bit is set)

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -118,9 +118,9 @@ proc.update_slot_delta
     if.true
         exec.update_value_slot_delta
     else
-      # TODO: Update delta hasher with map.
-      # drop slot idx
-      drop
+        # TODO: Update delta hasher with map.
+        # drop slot idx
+        drop
     end
 end
 
@@ -140,31 +140,31 @@ proc.update_value_slot_delta
 
     # only include in delta if the slot's value has changed
     if.true
-      # drop init value
-      dropw
-      # => [CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
+        # drop init value
+        dropw
+        # => [CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
-      # build value slot metadata
-      push.DOMAIN_VALUE
-      # => [domain, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
+        # build value slot metadata
+        push.DOMAIN_VALUE
+        # => [domain, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
-      movup.5 push.0.0
-      # => [0, 0, slot_idx, domain, CURRENT_VALUE, RATE, RATE, PERM]
+        movup.5 push.0.0
+        # => [0, 0, slot_idx, domain, CURRENT_VALUE, RATE, RATE, PERM]
 
-      # clear rate elements
-      swapdw dropw dropw
-      # => [0, 0, slot_idx, domain, CURRENT_VALUE, PERM]
+        # clear rate elements
+        swapdw dropw dropw
+        # => [0, 0, slot_idx, domain, CURRENT_VALUE, PERM]
 
-      # arrange rate words in correct order
-      swapw
-      # => [CURRENT_VALUE, 0, 0, slot_idx, domain, PERM]
+        # arrange rate words in correct order
+        swapw
+        # => [CURRENT_VALUE, 0, 0, slot_idx, domain, PERM]
 
-      hperm
-      # => [RATE, RATE, PERM]
+        hperm
+        # => [RATE, RATE, PERM]
     else
-      # drop init value, current value and slot idx
-      dropw dropw drop
-      # => [RATE, RATE, PERM]
+        # drop init value, current value and slot idx
+        dropw dropw drop
+        # => [RATE, RATE, PERM]
     end
     # => [RATE, RATE, PERM]
 end
@@ -235,9 +235,9 @@ proc.update_fungible_asset_delta.2
             hperm
             # => [RATE, RATE, PERM]
         else
-          # discard values loaded from map: KEY, VALUE0
-          dropw dropw
-          # => [RATE, RATE, PERM]
+            # discard values loaded from map: KEY, VALUE0
+            dropw dropw
+            # => [RATE, RATE, PERM]
         end
         # => [RATE, RATE, PERM]
 
@@ -428,9 +428,9 @@ end
 #! - x_{hi, lo} are the u32 limbs of an i64.
 #! - is_x_signed indicates whether x is signed.
 proc.i64_is_signed
-  # 0x80000000 is a u32 bitmask with highest bit set to 1 and all others to 0.
-  dup u32and.0x80000000 u32shr.31
-  # => [is_signed, x_hi, x_lo]
+    # 0x80000000 is a u32 bitmask with highest bit set to 1 and all others to 0.
+    dup u32and.0x80000000 u32shr.31
+    # => [is_signed, x_hi, x_lo]
 end
 
 #! Negates an i64 represented by two u32 limbs by computing its bitwise NOT and adding 1
@@ -442,17 +442,17 @@ end
 #! Where:
 #! - x_{hi, lo} are the u32 limbs of an i64.
 proc.i64_neg
-  u32not swap u32not swap
-  # => [x_inverted_hi, x_inverted_lo]
+    u32not swap u32not swap
+    # => [x_inverted_hi, x_inverted_lo]
 
-  # Add 1 to get negative x.
-  push.1.0
-  # => [0, 1, x_inverted_hi, x_inverted_lo]
+    # Add 1 to get negative x.
+    push.1.0
+    # => [0, 1, x_inverted_hi, x_inverted_lo]
 
-  # This should never overflow except when negating zero.
-  # (Consider this 8-bit example: 0b0000_0000 would become 0b1111_1111
-  # and adding 1 would overflow the byte resulting in 0b0000_0000 again).
-  # This is why we ignore the overflow flag.
-  exec.u64::wrapping_add
-  # => [-x_hi, -x_lo]
+    # This should never overflow except when negating zero.
+    # (Consider this 8-bit example: 0b0000_0000 would become 0b1111_1111
+    # and adding 1 would overflow the byte resulting in 0b0000_0000 again).
+    # This is why we ignore the overflow flag.
+    exec.u64::wrapping_add
+    # => [-x_hi, -x_lo]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -202,10 +202,10 @@ proc.update_fungible_asset_delta.2
 
         # this reassembles the delta amount into a felt, which is safe to do because the delta
         # amount is in range [-2^63 + 1, 2^63 - 1], so its absolute value will fit into a felt.
-        exec.i64_unsigned_abs
-        # => [[is_amount_unsigned, delta_amount_abs, 0, 0], ...]
+        exec.i64_absolute
+        # => [[is_amount_positive, delta_amount_abs, 0, 0], ...]
 
-        # rename is_amount_unsigned to was_added
+        # rename is_amount_positive to was_added
         movdn.2
         # => [[delta_amount_abs, 0, was_added, 0], ...]
 
@@ -443,19 +443,19 @@ proc.sub_asset_amount
 end
 
 #! Computes the absolute value of the given i64 represented by two u32 limbs and returns a
-#! boolean flag indicating whether the value is signed.
+#! boolean flag indicating whether the value is positive (or unsigned).
 #!
 #! Assumes that x_hi and x_lo can be safely combined into a felt.
 #!
 #! Inputs: [x_hi, x_lo]
-#! Outputs: [is_x_unsigned, x_abs]
+#! Outputs: [is_x_positive, x_abs]
 #!
 #! Where:
 #! - x_{hi, lo} are the u32 limbs of an i64.
-#! - is_x_unsigned indicates whether the inputs were positive.
+#! - is_x_positive indicates whether the inputs were positive.
 #! - x_abs is the absolute value of the inputs as a felt.
-proc.i64_unsigned_abs
-    exec.i64_is_signed
+proc.i64_absolute
+    exec.i64_is_negative
     # => [is_x_signed, x_hi, x_lo]
 
     movdn.2 push.0.0
@@ -464,7 +464,7 @@ proc.i64_unsigned_abs
     dup.3 dup.3
     # => [x_hi, x_lo, 0, 0, x_hi, x_lo, is_x_signed]
 
-    exec.i64_neg push.0.0
+    exec.i64_negate push.0.0
     # => [0, 0, x_neg_hi, x_neg_lo, 0, 0, x_hi, x_lo, is_x_signed]
 
     dup.8
@@ -483,8 +483,8 @@ proc.i64_unsigned_abs
     # => [is_x_unsigned, x_abs]
 end
 
-#! Returns 1 if the given number is signed (its most significant bit is set)
-#! without consuming its inputs, 0 otherwise.
+#! Returns 1 if the given number is negative (or signed), that is, its most significant bit is set,
+#! 0 otherwise.
 #!
 #! Inputs: [x_hi, x_lo]
 #! Outputs: [is_x_signed, x_hi, x_lo]
@@ -492,7 +492,7 @@ end
 #! Where:
 #! - x_{hi, lo} are the u32 limbs of an i64.
 #! - is_x_signed indicates whether x is signed.
-proc.i64_is_signed
+proc.i64_is_negative
     # 0x80000000 is a u32 bitmask with highest bit set to 1 and all others to 0.
     dup u32and.0x80000000 u32shr.31
     # => [is_signed, x_hi, x_lo]
@@ -506,7 +506,7 @@ end
 #!
 #! Where:
 #! - x_{hi, lo} are the u32 limbs of an i64.
-proc.i64_neg
+proc.i64_negate
     u32not swap u32not swap
     # => [x_inverted_hi, x_inverted_lo]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -199,7 +199,7 @@ end
 #! Where:
 #! - ASSET_KEY is the asset key of the fungible asset.
 #! - amount is the amount by which the fungible asset's amount increases.
-export.add_fungible_asset_delta
+export.add_fungible_asset
     dupw exec.memory::get_account_delta_fungible_asset_ptr
     # => [fungible_delta_map_ptr, ASSET_KEY, ASSET_KEY, amount]
 
@@ -212,7 +212,44 @@ export.add_fungible_asset_delta
     movup.8 u32split
     # => [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
 
+    # compute delta + amount
     exec.add_asset_amount
+    # => [delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
+
+    # pad VALUE1 of the link map
+    swapw padw movdnw.2
+    # => [ASSET_KEY, delta_amount_hi, delta_amount_lo, 0, 0, EMPTY_WORD]
+
+    exec.memory::get_account_delta_fungible_asset_ptr
+    # => [fungible_delta_map_ptr, ASSET_KEY, delta_amount_hi, delta_amount_lo, 0, 0, EMPTY_WORD]
+
+    exec.link_map::set drop
+    # => []
+end
+
+#! Subtracts the given amount from the fungible asset delta for the asset identified by the asset key.
+#!
+#! Inputs:  [ASSET_KEY, amount]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET_KEY is the asset key of the fungible asset.
+#! - amount is the amount by which the fungible asset's amount decreases.
+export.remove_fungible_asset
+    dupw exec.memory::get_account_delta_fungible_asset_ptr
+    # => [fungible_delta_map_ptr, ASSET_KEY, ASSET_KEY, amount]
+
+    # retrieve the current delta amount
+    # contains_key can be ignored because the default value is a delta amount of 0
+    # VALUE1 is unused so we drop it as well
+    exec.link_map::get drop swapw dropw
+    # => [delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY, amount]
+
+    movup.8 u32split
+    # => [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
+
+    # compute delta - amount
+    exec.sub_asset_amount
     # => [delta_amount_hi, delta_amount_lo, 0, 0, ASSET_KEY]
 
     # pad VALUE1 of the link map
@@ -232,4 +269,12 @@ end
 #! Outputs: [delta_amount_hi, delta_amount_lo]
 proc.add_asset_amount
     exec.::std::math::u64::wrapping_add
+end
+
+#! TODO: Document asset amount math.
+#!
+#! Inputs:  [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo]
+#! Outputs: [delta_amount_hi, delta_amount_lo]
+proc.sub_asset_amount
+    exec.::std::math::u64::wrapping_sub
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -3,6 +3,7 @@ use.kernel::link_map
 use.kernel::constants
 use.kernel::account
 use.std::crypto::hashes::rpo
+use.std::math::u64
 
 # CONSTANTS
 # =================================================================================================
@@ -215,18 +216,21 @@ proc.update_fungible_asset_delta.2
 
         # if delta amount is non-zero, update the hasher
         if.true
-            movup.5 movdn.2
-            # => [faucet_id_prefix, faucet_id_suffix, delta_amount_lo, 0, 0, delta_amount_hi, 0, 0, ...]
+            swap.7
+            # => [[0, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, delta_amount_abs], ...]
 
-            movup.5 movdn.3
-            # => [[faucet_id_prefix, faucet_id_suffix, delta_amount_lo, delta_amount_hi], 0, 0, 0, 0, ...]
+            drop push.DOMAIN_ASSET
+            # => [[domain, 0, was_added, 0], [faucet_id_prefix, faucet_id_suffix, 0, delta_amount_abs], ...]
 
-            push.DOMAIN_ASSET swap.8 drop
-            # => [[faucet_id_prefix, faucet_id_suffix, amount_lo, amount_hi], [0, 0, 0, domain], RATE, RATE, PERM
+            swap.3
+            # => [[0, 0, was_added, domain], [faucet_id_prefix, faucet_id_suffix, 0, delta_amount_abs], ...]
+
+            swapw
+            # => [[faucet_id_prefix, faucet_id_suffix, 0, delta_amount_abs], [0, 0, was_added, domain], RATE, RATE, PERM]
 
             # drop previous RATE elements
             swapdw dropw dropw
-            # => [[faucet_id_prefix, faucet_id_suffix, amount_lo, amount_hi], [0, 0, 0, domain], PERM]
+            # => [[faucet_id_prefix, faucet_id_suffix, 0, delta_amount_abs], [0, 0, was_added, domain], PERM]
 
             hperm
             # => [RATE, RATE, PERM]
@@ -346,18 +350,109 @@ export.remove_fungible_asset
     # => []
 end
 
-#! TODO: Document asset amount math.
+# i64 MATH
+# -------------------------------------------------------------------------------------------------
+
+# Asset Amount Deltas can be signed or unsigned and they can be in range [-2^63 + 1, 2^63 - 1]. To make
+# math operations on deltas easy and avoid branches, they are represented using the std::math::u64
+# representation of two u32 limbs. This u64 can be interpreted as an i64 to get the asset delta.
+# In order to get the correct behavior, we use wrapping operations on u64s which ignore the overflow.
+# This means that a calculation such as 100 - 200 + 300 correctly results in an overall delta of 200.
+
+#! Adds amount to the delta.
 #!
 #! Inputs:  [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo]
 #! Outputs: [delta_amount_hi, delta_amount_lo]
+#!
+#! Where:
+#! - amount_{hi, lo} are the u32 limbs of the amount to be added.
+#! - delta_amount_{hi, lo} are the u32 limbs of the delta amount to which amount is added.
 proc.add_asset_amount
-    exec.::std::math::u64::wrapping_add
+    exec.u64::wrapping_add
 end
 
-#! TODO: Document asset amount math.
+#! Subtracts amount from the delta.
 #!
 #! Inputs:  [amount_hi, amount_lo, delta_amount_hi, delta_amount_lo]
 #! Outputs: [delta_amount_hi, delta_amount_lo]
+#!
+#! Where:
+#! - amount_{hi, lo} are the u32 limbs of the amount to be subtracted.
+#! - delta_amount_{hi, lo} are the u32 limbs of the delta amount from which amount is subtracted.
 proc.sub_asset_amount
-    exec.::std::math::u64::wrapping_sub
+    exec.u64::wrapping_sub
+end
+
+#! Computes the absolute value of the given i64 represented by two u32 limbs and returns a
+#! boolean flag indicating whether the value is signed.
+#!
+#! Inputs: [x_hi, x_lo]
+#! Outputs: [is_x_signed, x_abs_hi, x_abs_lo]
+#!
+#! Where:
+#! - x_{hi, lo} are the u32 limbs of an i64.
+#! - is_x_signed indicates whether x is signed.
+#! - x_abs_{hi, lo} are the absolute u32 limbs of a u64.
+proc.i64_unsigned_abs
+    exec.i64_is_signed
+    # => [is_x_signed, x_hi, x_lo]
+
+    movdn.2 push.0.0
+    # => [0, 0, x_hi, x_lo, is_x_signed]
+
+    dup.3 dup.3
+    # => [x_hi, x_lo, 0, 0, x_hi, x_lo, is_x_signed]
+
+    exec.i64_neg push.0.0
+    # => [0, 0, x_neg_hi, x_neg_lo, 0, 0, x_hi, x_lo, is_x_signed]
+
+    dup.8
+    # => [is_x_signed, 0, 0, x_neg_hi, x_neg_lo, 0, 0, x_hi, x_lo, is_x_signed]
+
+    # If is_x_signed the word with the negated values remains.
+    # If !is_x_signed the word with the original values remains.
+    cdropw drop drop
+    # => [x_abs_hi, x_abs_lo, is_x_signed]
+
+    movup.2
+    # => [is_x_signed, x_abs_hi, x_abs_lo]
+end
+
+#! Returns 1 if the given number is signed (its most significant bit is set)
+#! without consuming its inputs, 0 otherwise.
+#!
+#! Inputs: [x_hi, x_lo]
+#! Outputs: [is_x_signed, x_hi, x_lo]
+#!
+#! Where:
+#! - x_{hi, lo} are the u32 limbs of an i64.
+#! - is_x_signed indicates whether x is signed.
+proc.i64_is_signed
+  # 0x80000000 is a u32 bitmask with highest bit set to 1 and all others to 0.
+  dup u32and.0x80000000 u32shr.31
+  # => [is_signed, x_hi, x_lo]
+end
+
+#! Negates an i64 represented by two u32 limbs by computing its bitwise NOT and adding 1
+#! according to two complements.
+#!
+#! Inputs: [x_hi, x_lo]
+#! Outputs: [x_hi, x_lo]
+#!
+#! Where:
+#! - x_{hi, lo} are the u32 limbs of an i64.
+proc.i64_neg
+  u32not swap u32not swap
+  # => [x_inverted_hi, x_inverted_lo]
+
+  # Add 1 to get negative x.
+  push.1.0
+  # => [0, 1, x_inverted_hi, x_inverted_lo]
+
+  # This should never overflow except when negating zero.
+  # (Consider this 8-bit example: 0b0000_0000 would become 0b1111_1111
+  # and adding 1 would overflow the byte resulting in 0b0000_0000 again).
+  # This is why we ignore the overflow flag.
+  exec.u64::wrapping_add
+  # => [-x_hi, -x_lo]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -126,7 +126,7 @@ export.add_fungible_asset
     # Create the asset key from the asset.
     # ---------------------------------------------------------------------------------------------
 
-    dupw exec.build_fungible_asset_vault_key
+    exec.build_fungible_asset_vault_key
     # => [ASSET_KEY, faucet_id_prefix, faucet_id_suffix, 0, amount, vault_root_ptr]
 
     movup.6 drop
@@ -447,7 +447,7 @@ end
 #! be a valid fungible asset.
 #!
 #! Inputs:  [ASSET]
-#! Outputs: [ASSET_KEY]
+#! Outputs: [ASSET_KEY, ASSET]
 #!
 #! Where:
 #! - ASSET is the fungible asset for which the vault key is built.
@@ -455,6 +455,9 @@ end
 export.build_fungible_asset_vault_key
   # => [faucet_id_prefix, faucet_id_suffix, 0, amount]
 
-  push.0 swap.4 drop
-  # => [faucet_id_prefix, faucet_id_suffix, 0, 0]
+  push.0.0
+  # => [0, 0, faucet_id_prefix, faucet_id_suffix, 0, amount]
+
+  dup.3 dup.3
+  # => [faucet_id_prefix, faucet_id_suffix, 0, 0, faucet_id_prefix, faucet_id_suffix, 0, amount]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -126,18 +126,17 @@ export.add_fungible_asset
     # Create the asset key from the asset.
     # ---------------------------------------------------------------------------------------------
 
-    # => [faucet_id_prefix, faucet_id_suffix, 0, amount, vault_root_ptr]
-    dupw
-    # => [faucet_id_prefix, faucet_id_suffix, 0, amount, faucet_id_prefix, faucet_id_suffix, 0, amount, vault_root_ptr]
-    push.0 swap.4 drop
-    # => [[faucet_id_prefix, faucet_id_suffix, 0, 0], faucet_id_prefix, faucet_id_suffix, 0, amount, vault_root_ptr]
+    dupw exec.build_fungible_asset_vault_key
+    # => [ASSET_KEY, faucet_id_prefix, faucet_id_suffix, 0, amount, vault_root_ptr]
+
     movup.6 drop
     # => [[faucet_id_prefix, faucet_id_suffix, 0, 0], faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
-    padw dup.11
-    # => [vault_root_ptr, pad(4), ASSET_KEY, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
 
     # Get the asset vault root and read the current asset using the `push_smtpeek` decorator.
     # ---------------------------------------------------------------------------------------------
+
+    padw dup.11
+    # => [vault_root_ptr, pad(4), ASSET_KEY, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
 
     # the current asset may be the empty word if it does not exist and so its faucet id would be zeroes
     # we therefore overwrite the faucet id with the faucet id from ASSET to account for this edge case
@@ -440,4 +439,22 @@ export.build_non_fungible_asset_vault_key
     # reassemble hash0 felt by multiplying the high part with 2^32 and adding the lo part
     swap push.0x0100000000 mul add
     # => [ASSET_KEY]
+end
+
+#! TODO: Add Rust <-> MASM test.
+#!
+#! Builds the vault key of a fungible asset. The asset is NOT validated and therefore must
+#! be a valid fungible asset.
+#!
+#! Inputs:  [ASSET]
+#! Outputs: [ASSET_KEY]
+#!
+#! Where:
+#! - ASSET is the fungible asset for which the vault key is built.
+#! - ASSET_KEY is the vault key of the fungible asset.
+export.build_fungible_asset_vault_key
+  # => [faucet_id_prefix, faucet_id_suffix, 0, amount]
+
+  push.0 swap.4 drop
+  # => [faucet_id_prefix, faucet_id_suffix, 0, 0]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -174,6 +174,9 @@ const.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET=4128
 # Layout: [nonce_delta, 0, 0, 0]
 const.ACCOUNT_DELTA_NONCE_PTR=532480
 
+# The link map pointer at which the delta of the fungible asset vault is stored.
+const.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+4
+
 # INPUT NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -1175,6 +1178,17 @@ export.get_native_account_initial_storage_slots_ptr
 end
 
 ### ACCOUNT DELTA #################################################
+
+#! Returns the link map pointer to the fungible asset vault delta.
+#!
+#! Inputs:  []
+#! Outputs: [account_delta_fungible_asset_ptr]
+#!
+#! Where:
+#! - account_delta_fungible_asset_ptr is the link map pointer to the fungible asset vault delta.
+export.get_account_delta_fungible_asset_ptr
+  push.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR
+end
 
 #! Increments the delta of the account's nonce.
 #!

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -294,6 +294,9 @@ pub const NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR: MemoryAddress =
 /// The memory address at which the nonce delta is stored.
 pub const ACCOUNT_DELTA_NONCE_PTR: MemoryAddress = 532_480;
 
+/// The link map pointer at which the delta of the fungible asset vault is stored.
+pub const ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR: MemoryAddress = ACCOUNT_DELTA_NONCE_PTR + 4;
+
 // NOTES DATA
 // ================================================================================================
 

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -294,9 +294,6 @@ pub const NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR: MemoryAddress =
 /// The memory address at which the nonce delta is stored.
 pub const ACCOUNT_DELTA_NONCE_PTR: MemoryAddress = 532_480;
 
-/// The link map pointer at which the delta of the fungible asset vault is stored.
-pub const ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR: MemoryAddress = ACCOUNT_DELTA_NONCE_PTR + 4;
-
 // NOTES DATA
 // ================================================================================================
 

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,9 +32,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x2650348398c493f7104c6c6ce682081a3a62b2bbced5c98179116a082c9fc630"),
+    digest!("0x8f5322ba63b506cb4d624258f6c9ffab1729a661c34fd54dcd0f3120ccc05860"),
     // account_remove_asset
-    digest!("0x667d5fe83620247eb5a5ff6bef85045183a8066b44ada9971ece90dfde4a46c0"),
+    digest!("0x4598c4925aa7399dc57d2c1a125231fcbc98100a5030c9b647cb33a8791e1f20"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,9 +32,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0xe4b5efe8ab5ad2ea05b76e121a1cce505323f70073588917973a296bc44c2776"),
+    digest!("0xc44dc6a11b2866fc5d56938c37eae69d23b6be937b8e290c25dc6da60c552f0e"),
     // account_remove_asset
-    digest!("0x53d62ae6f67a1d3b11184f4a2c374123ba73fe1e4e56e5a2524d6d7d1d4945aa"),
+    digest!("0x92e1362df41dcfc560d92acd7187bf843dcdd05e3769c1d27c180de22efe7444"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,15 +32,15 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0xc44dc6a11b2866fc5d56938c37eae69d23b6be937b8e290c25dc6da60c552f0e"),
+    digest!("0x2650348398c493f7104c6c6ce682081a3a62b2bbced5c98179116a082c9fc630"),
     // account_remove_asset
-    digest!("0x92e1362df41dcfc560d92acd7187bf843dcdd05e3769c1d27c180de22efe7444"),
+    digest!("0x667d5fe83620247eb5a5ff6bef85045183a8066b44ada9971ece90dfde4a46c0"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0x816b3c87726fc809c15005211d5365d66485e11ae5813e70ca1cc9d49de1cbf6"),
+    digest!("0x14aa1b6602681a4863cbb95d573259f18e38856b448fbdc5d77f8abf389761cb"),
     // faucet_burn_asset
     digest!("0x7022cca81527fbb7da6849d1c256c65fef3519f849ca57b50ead8e5db05eda97"),
     // faucet_get_total_fungible_asset_issuance

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,7 +32,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x50a19d31b2434024ae16146948d0903eb3755760e83118216c73008f53f0834a"),
+    digest!("0xa2be189aa283792110060f17d3c885021e47b3da2e918ec06c116d5ea319542d"),
     // account_remove_asset
     digest!("0x7378a9d10a2b92e9576ae61ebc117603e49c41f5e7f3b6ff4122fab8c7ece3e5"),
     // account_get_balance

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,7 +32,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x3ea434357a79698550fcb07f887665ba48ebc9c99b19cde20dc8aa170ed65ea8"),
+    digest!("0x50a19d31b2434024ae16146948d0903eb3755760e83118216c73008f53f0834a"),
     // account_remove_asset
     digest!("0x7378a9d10a2b92e9576ae61ebc117603e49c41f5e7f3b6ff4122fab8c7ece3e5"),
     // account_get_balance

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,9 +32,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0xa2be189aa283792110060f17d3c885021e47b3da2e918ec06c116d5ea319542d"),
+    digest!("0xe4b5efe8ab5ad2ea05b76e121a1cce505323f70073588917973a296bc44c2776"),
     // account_remove_asset
-    digest!("0x7378a9d10a2b92e9576ae61ebc117603e49c41f5e7f3b6ff4122fab8c7ece3e5"),
+    digest!("0x53d62ae6f67a1d3b11184f4a2c374123ba73fe1e4e56e5a2524d6d7d1d4945aa"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -122,10 +122,10 @@ impl AccountDelta {
     /// - Fungible Asset Delta
     ///   - For each **updated** fungible asset, sorted by its vault key, whose amount delta is
     ///     **non-zero**:
-    ///     - Append `[domain = 1, 0, 0, 0]`.
-    ///     - Append `[amount_hi, amount_lo, faucet_id_suffix, faucet_id_prefix]` where amount_hi
-    ///       and amount_lo are the u32 limbs of the amount delta by which the fungible asset's
-    ///       amount has changed.
+    ///     - Append `[domain = 1, was_added, 0, 0]`.
+    ///     - Append `[amount, 0, faucet_id_suffix, faucet_id_prefix]` where amount is the delta by
+    ///       which the fungible asset's amount has changed and was_added is a boolean flag
+    ///       indicating whether the amount was added (1) or subtracted (0).
     /// - Non-Fungible Asset Delta
     ///   - For each **updated** non-fungible asset, sorted by its vault key:
     ///     - Append `[domain = 1, was_added, 0, 0]` where was_added is a boolean flag indicating

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -344,17 +344,19 @@ impl FungibleAssetDelta {
     /// link map key ordering, however this is subtle and fragile.
     pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
         for (faucet_id, amount_delta) in self.iter() {
-            let amount_delta = *amount_delta as u64;
-            let amount_hi = (amount_delta / (1 << 32)) as u32;
-            let amount_lo = (amount_delta % (1 << 32)) as u32;
+            // Note that this iterator is guaranteed to never yield zero amounts, so we don't have
+            // to exclude those explicitly.
+            debug_assert_ne!(
+                *amount_delta, 0,
+                "fungible asset iterator should never yield amount deltas of 0"
+            );
 
-            elements.extend_from_slice(&[DOMAIN_ASSET, ZERO, ZERO, ZERO]);
-            elements.extend_from_slice(&[
-                Felt::from(amount_hi),
-                Felt::from(amount_lo),
-                faucet_id.suffix(),
-                faucet_id.prefix().as_felt(),
-            ]);
+            let asset = FungibleAsset::new(*faucet_id, amount_delta.unsigned_abs())
+                .expect("absolute amount delta should be less than i64::MAX");
+            let was_added = if *amount_delta > 0 { ONE } else { ZERO };
+
+            elements.extend_from_slice(&[DOMAIN_ASSET, was_added, ZERO, ZERO]);
+            elements.extend_from_slice(&Word::from(asset));
         }
     }
 }
@@ -494,12 +496,12 @@ impl NonFungibleAssetDelta {
     /// commitment will be computed.
     pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
         for (asset, action) in self.iter() {
-            let action_felt = match action {
+            let was_added = match action {
                 NonFungibleDeltaAction::Remove => ZERO,
                 NonFungibleDeltaAction::Add => ONE,
             };
 
-            elements.extend_from_slice(&[DOMAIN_ASSET, action_felt, ZERO, ZERO]);
+            elements.extend_from_slice(&[DOMAIN_ASSET, was_added, ZERO, ZERO]);
             elements.extend_from_slice(&Word::from(*asset));
         }
     }

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -334,6 +334,14 @@ impl FungibleAssetDelta {
 
     /// Appends the fungible asset vault delta to the given `elements` from which the delta
     /// commitment will be computed.
+    ///
+    /// Note that the order in which elements are appended should be the link map key ordering. This
+    /// is fulfilled here because the link map key's most significant element takes precedence over
+    /// less significant ones. The most significant element in the fungible asset delta is the
+    /// account ID prefix and the delta happens to be sorted by account IDs. Since the account ID
+    /// prefix is unique, it will always decide on the ordering of a link map key, so less
+    /// significant elements are unimportant. This implicit sort should therefore always match the
+    /// link map key ordering, however this is subtle and fragile.
     pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
         for (faucet_id, amount_delta) in self.iter() {
             let amount_delta = *amount_delta as u64;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, StorageSlot,
     }, asset::{Asset, FungibleAsset}, note::{Note, NoteType}, testing::{
-        account_component::AccountMockComponent, account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+        account_component::AccountMockComponent, account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2},
     }, transaction::{ExecutedTransaction, TransactionScript}, vm::AdviceMap, Digest, Felt, Hasher, Word, EMPTY_WORD
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};
@@ -147,8 +147,8 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
     // FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?, 100)?;
 
     let added_asset0 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into()?, 100)?;
-    // let added_asset1 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?, 100)?;
-    // let added_asset2 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?, 200)?;
+    let added_asset1 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?, 100)?;
+    let added_asset2 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?, 200)?;
 
     // let removed_asset0 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into()?, 200)?;
     // let removed_asset1 = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?,
@@ -165,7 +165,7 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
     );
 
     let mut added_notes = vec![];
-    for added_asset in [added_asset0] {
+    for added_asset in [added_asset0, added_asset1, added_asset2] {
         let added_note = mock_chain
             .add_pending_p2id_note(
                 account_id,

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -4,11 +4,21 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
+    Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, StorageSlot,
-    }, asset::{Asset, FungibleAsset}, note::{Note, NoteType}, testing::{
-        account_component::AccountMockComponent, account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2},
-    }, transaction::{ExecutedTransaction, TransactionScript}, vm::AdviceMap, Digest, Felt, Hasher, Word, EMPTY_WORD
+    },
+    asset::{Asset, FungibleAsset},
+    note::{Note, NoteType},
+    testing::{
+        account_component::AccountMockComponent,
+        account_id::{
+            ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
+            ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
+        },
+    },
+    transaction::{ExecutedTransaction, TransactionScript},
+    vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};
 
@@ -221,6 +231,8 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
         removed_asset0.amount() - added_asset0.amount()
     );
 
+    validate_account_delta(&executed_tx)?;
+
     Ok(())
 }
 
@@ -304,6 +316,7 @@ fn setup_storage_test(storage_slots: Vec<StorageSlot>) -> TestSetup {
 
 fn setup_asset_test(assets: impl IntoIterator<Item = Asset>) -> TestSetup {
     let account = AccountBuilder::new([3; 32])
+        .storage_mode(AccountStorageMode::Public)
         .with_component(
             AccountMockComponent::new_with_slots(TransactionKernel::testing_assembler(), vec![])
                 .unwrap(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -334,17 +334,17 @@ fn compile_tx_script(code: impl AsRef<str>) -> anyhow::Result<TransactionScript>
     .context("failed to compile tx script")
 }
 
-fn default_tx_script() -> TransactionScript {
-    compile_tx_script(
-        "
-  begin
-      # nonce must increase for state changing transactions
-      push.1 exec.incr_nonce
-  end
-  ",
-    )
-    .expect("tx script should be valid")
-}
+// fn default_tx_script() -> TransactionScript {
+//     compile_tx_script(
+//         "
+//   begin
+//       # nonce must increase for state changing transactions
+//       push.1 exec.incr_nonce
+//   end
+//   ",
+//     )
+//     .expect("tx script should be valid")
+// }
 
 fn word(data: [u32; 4]) -> Word {
     Word::from(Digest::from(data))


### PR DESCRIPTION
Implement fungible asset vault in-kernel account delta.

The high-level approach is that the fungible asset delta is kept track of using the following layout of a value in a link map: `[amount_hi, amount_lo, faucet_id_suffix, faucet_id_prefix]` where `amount_hi` and `amount_lo` are the u32 limbs of the amount delta by which the fungible asset's amount has changed.

In the `account::add_fungible_asset` and `account::remove_fungible_asset` procedures, we call analogous functions in `account_delta` that update the link map. When computing the delta, all entries that zero out (e.g. asset amount 100 added and 100 removed) are ignored and not hashed into the delta commitment.

When the delta is computed, the above representation is converted to the regular fungible asset representation prepended by "metadata": `[domain, was_added, 0, 0, amount, 0, faucet_id_suffix, faucet_id_prefix]`, where `was_added` indicates whether the amount is unsigned or not. This required a few i64 helper functions.

This PR is technically ready for review, but builds on top of https://github.com/0xMiden/miden-base/pull/1404 and #1428 and https://github.com/0xMiden/miden-base/pull/1478 were merged in because the link map and its iterator was needed. So it should probably only be reviewed after merging the link map PRs into next.

part of #1198 