### PR TITLE
fix: load account and input notes advice maps into the advice provider before executing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 - [BREAKING] Allow list of keys in `AccountFile` (#1451).
 - Improve error message quality in `CodeExecutor::run` and `TransactionContext::execute_code` (#1458).
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
-- [BREAKING] `TransactionHost::new` now expects `&Account` instead `AccountHeader`.
-- Load account and input notes advice maps into the advice provider before executing them (#1452)
+- [BREAKING] `TransactionHost::new` now expects `&PartialAccount` instead `AccountHeader` (#1452).
+- Load account and input notes advice maps into the advice provider before executing them (#1452).
 - Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB for compiler testing (#1464).
 
 ## 0.9.1 (2025-05-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - [BREAKING] Allow list of keys in `AccountFile` (#1451).
 - Improve error message quality in `CodeExecutor::run` and `TransactionContext::execute_code` (#1458).
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
+- [BREAKING] `TransactionHost::new` now expects `&Account` instead `AccountHeader`.
+- Load account and input notes advice maps into the advice provider before executing them (#1452)
 
 ## 0.9.1 (2025-05-30)
 

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -88,7 +88,7 @@ fn transaction_executor_witness() -> miette::Result<()> {
     mast_store.load_account_code(tx_inputs.account().code());
 
     let mut host: TransactionHost<MemAdviceProvider> = TransactionHost::new(
-        tx_inputs.account(),
+        &tx_inputs.account().into(),
         mem_advice_provider,
         mast_store,
         scripts_mast_store,

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -88,7 +88,7 @@ fn transaction_executor_witness() -> miette::Result<()> {
     mast_store.load_account_code(tx_inputs.account().code());
 
     let mut host: TransactionHost<MemAdviceProvider> = TransactionHost::new(
-        tx_inputs.account().into(),
+        tx_inputs.account(),
         mem_advice_provider,
         mast_store,
         scripts_mast_store,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -149,7 +149,7 @@ impl TransactionExecutor {
         );
 
         let mut host = TransactionHost::new(
-            tx_inputs.account().into(),
+            tx_inputs.account(),
             advice_recorder,
             self.data_store.clone(),
             script_mast_store,
@@ -224,7 +224,7 @@ impl TransactionExecutor {
             ScriptMastForestStore::new(Some(&tx_script), core::iter::empty::<&NoteScript>());
 
         let mut host = TransactionHost::new(
-            tx_inputs.account().into(),
+            tx_inputs.account(),
             advice_recorder,
             self.data_store.clone(),
             scripts_mast_store,
@@ -298,7 +298,7 @@ impl TransactionExecutor {
         );
 
         let mut host = TransactionHost::new(
-            tx_inputs.account().into(),
+            tx_inputs.account(),
             advice_provider,
             self.data_store.clone(),
             scripts_mast_store,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -149,7 +149,7 @@ impl TransactionExecutor {
         );
 
         let mut host = TransactionHost::new(
-            tx_inputs.account(),
+            &tx_inputs.account().into(),
             advice_recorder,
             self.data_store.clone(),
             script_mast_store,
@@ -224,7 +224,7 @@ impl TransactionExecutor {
             ScriptMastForestStore::new(Some(&tx_script), core::iter::empty::<&NoteScript>());
 
         let mut host = TransactionHost::new(
-            tx_inputs.account(),
+            &tx_inputs.account().into(),
             advice_recorder,
             self.data_store.clone(),
             scripts_mast_store,
@@ -298,7 +298,7 @@ impl TransactionExecutor {
         );
 
         let mut host = TransactionHost::new(
-            tx_inputs.account(),
+            &tx_inputs.account().into(),
             advice_provider,
             self.data_store.clone(),
             scripts_mast_store,

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -112,13 +112,10 @@ impl<A: AdviceProvider> TransactionHost<A> {
             adv_provider.insert_into_map(*key, values);
         }
 
-        // Iterate over all MAST forests in scripts_mast_store and add their advice_map to the
-        // adv_provider This ensures the advice provider has all the necessary data for
-        // script execution
-        for forest in scripts_mast_store.forests() {
-            for (key, values) in forest.advice_map().clone() {
-                adv_provider.insert_into_map(*key, values);
-            }
+        // Add all advice data from scripts_mast_store to the adv_provider. This ensures the
+        // advice provider has all the necessary data for script execution
+        for (key, values) in scripts_mast_store.advice_data().clone() {
+            adv_provider.insert_into_map(*key, values);
         }
 
         let proc_index_map =

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -11,7 +11,7 @@ use miden_lib::transaction::{
 };
 use miden_objects::{
     Digest, Hasher,
-    account::{Account, AccountDelta},
+    account::{AccountDelta, PartialAccount},
     assembly::mast::MastNodeExt,
     asset::Asset,
     note::NoteId,
@@ -93,7 +93,7 @@ pub struct TransactionHost<A> {
 impl<A: AdviceProvider> TransactionHost<A> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
-        account: &Account,
+        account: &PartialAccount,
         mut adv_provider: A,
         mast_store: Arc<dyn MastForestStore>,
         scripts_mast_store: ScriptMastForestStore,

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -11,7 +11,7 @@ use miden_lib::transaction::{
 };
 use miden_objects::{
     Digest, Hasher,
-    account::{AccountDelta, AccountHeader},
+    account::{Account, AccountDelta},
     assembly::mast::MastNodeExt,
     asset::Asset,
     note::NoteId,
@@ -93,8 +93,8 @@ pub struct TransactionHost<A> {
 impl<A: AdviceProvider> TransactionHost<A> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
-        account: AccountHeader,
-        adv_provider: A,
+        account: &Account,
+        mut adv_provider: A,
         mast_store: Arc<dyn MastForestStore>,
         scripts_mast_store: ScriptMastForestStore,
         authenticator: Option<Arc<dyn TransactionAuthenticator>>,
@@ -102,7 +102,24 @@ impl<A: AdviceProvider> TransactionHost<A> {
     ) -> Result<Self, TransactionHostError> {
         // currently, the executor/prover do not keep track of the code commitment of the native
         // account, so we add it to the set here
-        foreign_account_code_commitments.insert(account.code_commitment());
+        foreign_account_code_commitments.insert(account.code().commitment());
+
+        // Insert the account advice map into the advice recorder.
+        // This ensures that the advice map is available during the note script execution when it
+        // calls the account's code that relies on the it's advice map data (data segments) loaded
+        // into the advice provider
+        for (key, values) in account.code().mast().advice_map().clone() {
+            adv_provider.insert_into_map(*key, values);
+        }
+
+        // Iterate over all MAST forests in scripts_mast_store and add their advice_map to the
+        // adv_provider This ensures the advice provider has all the necessary data for
+        // script execution
+        for forest in scripts_mast_store.forests() {
+            for (key, values) in forest.advice_map().clone() {
+                adv_provider.insert_into_map(*key, values);
+            }
+        }
 
         let proc_index_map =
             AccountProcedureIndexMap::new(foreign_account_code_commitments, &adv_provider)?;
@@ -111,7 +128,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
             adv_provider,
             mast_store,
             scripts_mast_store,
-            account_delta: AccountDeltaTracker::new(&account),
+            account_delta: AccountDeltaTracker::new(&account.into()),
             acct_procedure_index_map: proc_index_map,
             output_notes: BTreeMap::default(),
             authenticator,

--- a/crates/miden-tx/src/host/script_mast_forest_store.rs
+++ b/crates/miden-tx/src/host/script_mast_forest_store.rs
@@ -38,6 +38,17 @@ impl ScriptMastForestStore {
             self.mast_forests.insert(proc_digest, mast_forest.clone());
         }
     }
+
+    /// Returns an iterator over unique MAST forests stored in this store.
+    pub fn forests(&self) -> impl Iterator<Item = &Arc<MastForest>> {
+        // Deduplicate forests since multiple procedure digests can point to the same forest
+        let mut seen = alloc::collections::BTreeSet::new();
+        self.mast_forests.values().filter(move |forest| {
+            // Use pointer address for deduplication since we're dealing with Arc<MastForest>
+            let ptr = Arc::as_ptr(forest) as usize;
+            seen.insert(ptr)
+        })
+    }
 }
 
 // MAST FOREST STORE IMPLEMENTATION

--- a/crates/miden-tx/src/host/script_mast_forest_store.rs
+++ b/crates/miden-tx/src/host/script_mast_forest_store.rs
@@ -2,6 +2,7 @@ use alloc::{collections::BTreeMap, sync::Arc};
 
 use miden_objects::{
     Digest, assembly::mast::MastForest, note::NoteScript, transaction::TransactionScript,
+    vm::AdviceMap,
 };
 use vm_processor::MastForestStore;
 
@@ -11,6 +12,7 @@ use vm_processor::MastForestStore;
 /// transaction and input note scripts.
 pub struct ScriptMastForestStore {
     mast_forests: BTreeMap<Digest, Arc<MastForest>>,
+    adv_data: AdviceMap,
 }
 
 impl ScriptMastForestStore {
@@ -19,7 +21,10 @@ impl ScriptMastForestStore {
         tx_script: Option<&TransactionScript>,
         note_scripts: impl Iterator<Item = impl AsRef<NoteScript>>,
     ) -> Self {
-        let mut mast_store = ScriptMastForestStore { mast_forests: BTreeMap::new() };
+        let mut mast_store = ScriptMastForestStore {
+            mast_forests: BTreeMap::new(),
+            adv_data: AdviceMap::new(),
+        };
 
         for note_script in note_scripts {
             mast_store.insert(note_script.as_ref().mast());
@@ -37,17 +42,16 @@ impl ScriptMastForestStore {
         for proc_digest in mast_forest.local_procedure_digests() {
             self.mast_forests.insert(proc_digest, mast_forest.clone());
         }
+
+        // collect advice data from the forest
+        for (key, values) in mast_forest.advice_map().clone() {
+            self.adv_data.insert((*key).into(), values);
+        }
     }
 
-    /// Returns an iterator over unique MAST forests stored in this store.
-    pub fn forests(&self) -> impl Iterator<Item = &Arc<MastForest>> {
-        // Deduplicate forests since multiple procedure digests can point to the same forest
-        let mut seen = alloc::collections::BTreeSet::new();
-        self.mast_forests.values().filter(move |forest| {
-            // Use pointer address for deduplication since we're dealing with Arc<MastForest>
-            let ptr = Arc::as_ptr(forest) as usize;
-            seen.insert(ptr)
-        })
+    /// Returns a reference to the advice data collected from all forests.
+    pub fn advice_data(&self) -> &AdviceMap {
+        &self.adv_data
     }
 }
 

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -104,7 +104,7 @@ impl TransactionProver for LocalTransactionProver {
         );
 
         let mut host: TransactionHost<_> = TransactionHost::new(
-            account.into(),
+            account,
             advice_provider,
             self.mast_store.clone(),
             script_mast_store,

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -104,7 +104,7 @@ impl TransactionProver for LocalTransactionProver {
         );
 
         let mut host: TransactionHost<_> = TransactionHost::new(
-            account,
+            &account.into(),
             advice_provider,
             self.mast_store.clone(),
             script_mast_store,


### PR DESCRIPTION
Close #1452 

This PR introduces the following changes:
- Load account and input notes advice maps into the advice provider before executing them;
- `TransactionHost::new` now expects `&Account` instead `AccountHeader`.

### Testing

I tried to test these changes by pulling them through the `miden-client` (next branch, `v0.10`) and patching numerous deps along the way to try it in the test reproduced in #1452 but stumbled upon testnet node rejecting my request because my client is not `v0.9`. So, no luck. 

Next, I looked into `miden-testing` to introduce a test there, but found that it'd take quite a lot of efforts to construct a proper test case (a note script, loading the data from the advice provider and calling an account that is also loads another data from the advice provider). OTOH, the code changes are quite straightforward, so I'd assume they should work. Please let me know if you want me to build one.
