### PR TITLE
Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Allow list of keys in `AccountFile` (#1451).
 - Improve error message quality in `CodeExecutor::run` and `TransactionContext::execute_code` (#1458).
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
+- Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB for compiler testing.
 
 ## 0.9.1 (2025-05-30)
 

--- a/crates/miden-objects/src/constants.rs
+++ b/crates/miden-objects/src/constants.rs
@@ -1,8 +1,8 @@
 /// Depth of the account database tree.
 pub const ACCOUNT_TREE_DEPTH: u8 = 64;
 
-/// The maximum allowed size of an account update is 32 KiB.
-pub const ACCOUNT_UPDATE_MAX_SIZE: u16 = 2u16.pow(15);
+/// The maximum allowed size of an account update is 256 KiB.
+pub const ACCOUNT_UPDATE_MAX_SIZE: u32 = 2u32.pow(18);
 
 /// The maximum number of assets that can be stored in a single note.
 pub const MAX_ASSETS_PER_NOTE: usize = 255;


### PR DESCRIPTION
This PR changes the `ACCOUNT_UPDATE_MAX_SIZE` from 32 KiB to 256 KiB to allow for testing of accounts that were compiled using the Rust to Miden assembly compiler. 

This is a temporary change to allow for testing. `ACCOUNT_UPDATE_MAX_SIZE` should be set back to 32 KiB once MASM produced by the compiler becomes more optimized.

Resolves #1441