### PR TITLE
feat: remove Arc from tx executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Allow list of keys in `AccountFile` (#1451).
 - Improve error message quality in `CodeExecutor::run` and `TransactionContext::execute_code` (#1458).
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
+- [BREAKING] `TransactionExecutor` now holds plain references instead of `Arc` for its trait objects (#1469).
 
 ## 0.9.1 (2025-05-30)
 

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -90,7 +90,7 @@ fn transaction_executor_witness() -> miette::Result<()> {
     let mut host: TransactionHost<MemAdviceProvider> = TransactionHost::new(
         tx_inputs.account().into(),
         mem_advice_provider,
-        mast_store,
+        mast_store.as_ref(),
         scripts_mast_store,
         None,
         BTreeSet::new(),
@@ -798,7 +798,7 @@ fn prove_witness_and_verify() {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let notes = tx_context.tx_inputs().input_notes().clone();
     let tx_args = tx_context.tx_args().clone();
-    let executor = TransactionExecutor::new(Arc::new(tx_context), None);
+    let executor = TransactionExecutor::new(&tx_context, None);
     let executed_transaction = executor
         .execute_transaction(account_id, block_ref, notes, tx_args, Arc::clone(&source_manager))
         .unwrap();
@@ -1070,7 +1070,7 @@ fn test_execute_program() {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let advice_inputs = tx_context.tx_args().advice_inputs().clone();
 
-    let executor = TransactionExecutor::new(Arc::new(tx_context), None);
+    let executor = TransactionExecutor::new(&tx_context, None);
 
     let stack_outputs = executor
         .execute_tx_view_script(
@@ -1122,8 +1122,7 @@ fn test_check_note_consumability() {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let tx_args = tx_context.tx_args().clone();
 
-    let executor: TransactionExecutor =
-        TransactionExecutor::new(Arc::new(tx_context), None).with_tracing();
+    let executor: TransactionExecutor = TransactionExecutor::new(&tx_context, None).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker
@@ -1149,8 +1148,7 @@ fn test_check_note_consumability() {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let tx_args = tx_context.tx_args().clone();
 
-    let executor: TransactionExecutor =
-        TransactionExecutor::new(Arc::new(tx_context), None).with_tracing();
+    let executor: TransactionExecutor = TransactionExecutor::new(&tx_context, None).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker
@@ -1191,8 +1189,7 @@ fn test_check_note_consumability() {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let tx_args = tx_context.tx_args().clone();
 
-    let executor: TransactionExecutor =
-        TransactionExecutor::new(Arc::new(tx_context), None).with_tracing();
+    let executor: TransactionExecutor = TransactionExecutor::new(&tx_context, None).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use miden_lib::{
     errors::tx_kernel_errors::{
@@ -98,7 +98,7 @@ fn test_future_input_note_fails() -> anyhow::Result<()> {
     let tx_context = mock_chain.build_tx_context(account.id(), &[], &[]).build();
     let source_manager = tx_context.source_manager();
 
-    let tx_executor = TransactionExecutor::new(Arc::new(tx_context), None);
+    let tx_executor = TransactionExecutor::new(&tx_context, None);
     // Try to execute with block_ref==1
     let error = tx_executor.execute_transaction(
         account.id(),

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -123,7 +123,7 @@ impl TransactionContext {
             .map(|auth| Arc::new(auth) as Arc<dyn TransactionAuthenticator>);
 
         let source_manager = Arc::clone(&self.source_manager);
-        let tx_executor = TransactionExecutor::new(Arc::new(self), authenticator).with_debug_mode();
+        let tx_executor = TransactionExecutor::new(&self, authenticator).with_debug_mode();
 
         maybe_await!(tx_executor.execute_transaction(
             account_id,

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -116,11 +116,7 @@ impl TransactionContext {
         let block_num = self.tx_inputs().block_header().block_num();
         let notes = self.tx_inputs().input_notes().clone();
         let tx_args = self.tx_args().clone();
-
-        let authenticator = self
-            .authenticator()
-            .cloned()
-            .map(|auth| Arc::new(auth) as Arc<dyn TransactionAuthenticator>);
+        let authenticator = self.authenticator().map(|x| x as &dyn TransactionAuthenticator);
 
         let source_manager = Arc::clone(&self.source_manager);
         let tx_executor = TransactionExecutor::new(&self, authenticator).with_debug_mode();

--- a/crates/miden-tx/src/auth/tx_authenticator.rs
+++ b/crates/miden-tx/src/auth/tx_authenticator.rs
@@ -38,6 +38,22 @@ pub trait TransactionAuthenticator {
     ) -> Result<Vec<Felt>, AuthenticationError>;
 }
 
+/// This blanket implementation is required to allow `Option<&T>` to be mapped to `Option<&dyn
+/// TransactionAuthenticator`>.
+impl<T> TransactionAuthenticator for &T
+where
+    T: TransactionAuthenticator + ?Sized,
+{
+    fn get_signature(
+        &self,
+        pub_key: Word,
+        message: Word,
+        account_delta: &AccountDelta,
+    ) -> Result<Vec<Felt>, AuthenticationError> {
+        TransactionAuthenticator::get_signature(*self, pub_key, message, account_delta)
+    }
+}
+
 // BASIC AUTHENTICATOR
 // ================================================================================================
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -38,21 +38,21 @@ pub use notes_checker::{NoteConsumptionChecker, NoteInputsCheck};
 /// The transaction executor uses dynamic dispatch with trait objects for the [DataStore] and
 /// [TransactionAuthenticator], allowing it to be used with different backend implementations.
 /// At the moment of execution, the [DataStore] is expected to provide all required MAST nodes.
-pub struct TransactionExecutor<'a> {
-    data_store: &'a dyn DataStore,
-    authenticator: Option<Arc<dyn TransactionAuthenticator>>,
+pub struct TransactionExecutor<'store, 'auth> {
+    data_store: &'store dyn DataStore,
+    authenticator: Option<&'auth dyn TransactionAuthenticator>,
     exec_options: ExecutionOptions,
 }
 
-impl<'a> TransactionExecutor<'a> {
+impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new [TransactionExecutor] instance with the specified [DataStore] and
     /// [TransactionAuthenticator].
     pub fn new(
-        data_store: &'a dyn DataStore,
-        authenticator: Option<Arc<dyn TransactionAuthenticator>>,
+        data_store: &'store dyn DataStore,
+        authenticator: Option<&'auth dyn TransactionAuthenticator>,
     ) -> Self {
         const _: () = assert!(MIN_TX_EXECUTION_CYCLES <= MAX_TX_EXECUTION_CYCLES);
 
@@ -153,7 +153,7 @@ impl<'a> TransactionExecutor<'a> {
             advice_recorder,
             self.data_store,
             script_mast_store,
-            self.authenticator.clone(),
+            self.authenticator,
             tx_args.foreign_account_code_commitments(),
         )
         .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
@@ -228,7 +228,7 @@ impl<'a> TransactionExecutor<'a> {
             advice_recorder,
             self.data_store,
             scripts_mast_store,
-            self.authenticator.clone(),
+            self.authenticator,
             tx_args.foreign_account_code_commitments(),
         )
         .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
@@ -302,7 +302,7 @@ impl<'a> TransactionExecutor<'a> {
             advice_provider,
             self.data_store,
             scripts_mast_store,
-            self.authenticator.clone(),
+            self.authenticator,
             tx_args.foreign_account_code_commitments(),
         )
         .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -38,20 +38,20 @@ pub use notes_checker::{NoteConsumptionChecker, NoteInputsCheck};
 /// The transaction executor uses dynamic dispatch with trait objects for the [DataStore] and
 /// [TransactionAuthenticator], allowing it to be used with different backend implementations.
 /// At the moment of execution, the [DataStore] is expected to provide all required MAST nodes.
-pub struct TransactionExecutor {
-    data_store: Arc<dyn DataStore>,
+pub struct TransactionExecutor<'a> {
+    data_store: &'a dyn DataStore,
     authenticator: Option<Arc<dyn TransactionAuthenticator>>,
     exec_options: ExecutionOptions,
 }
 
-impl TransactionExecutor {
+impl<'a> TransactionExecutor<'a> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new [TransactionExecutor] instance with the specified [DataStore] and
     /// [TransactionAuthenticator].
     pub fn new(
-        data_store: Arc<dyn DataStore>,
+        data_store: &'a dyn DataStore,
         authenticator: Option<Arc<dyn TransactionAuthenticator>>,
     ) -> Self {
         const _: () = assert!(MIN_TX_EXECUTION_CYCLES <= MAX_TX_EXECUTION_CYCLES);
@@ -151,7 +151,7 @@ impl TransactionExecutor {
         let mut host = TransactionHost::new(
             tx_inputs.account().into(),
             advice_recorder,
-            self.data_store.clone(),
+            self.data_store,
             script_mast_store,
             self.authenticator.clone(),
             tx_args.foreign_account_code_commitments(),
@@ -226,7 +226,7 @@ impl TransactionExecutor {
         let mut host = TransactionHost::new(
             tx_inputs.account().into(),
             advice_recorder,
-            self.data_store.clone(),
+            self.data_store,
             scripts_mast_store,
             self.authenticator.clone(),
             tx_args.foreign_account_code_commitments(),
@@ -300,7 +300,7 @@ impl TransactionExecutor {
         let mut host = TransactionHost::new(
             tx_inputs.account().into(),
             advice_provider,
-            self.data_store.clone(),
+            self.data_store,
             scripts_mast_store,
             self.authenticator.clone(),
             tx_args.foreign_account_code_commitments(),

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -19,7 +19,7 @@ use super::{NoteAccountExecution, TransactionExecutor, TransactionExecutorError}
 /// The check is performed using the [NoteConsumptionChecker::check_notes_consumability] procedure.
 /// Essentially runs the transaction to make sure that provided input notes could be consumed by the
 /// account.
-pub struct NoteConsumptionChecker<'a>(&'a TransactionExecutor);
+pub struct NoteConsumptionChecker<'a>(&'a TransactionExecutor<'a>);
 
 impl<'a> NoteConsumptionChecker<'a> {
     /// Creates a new [`NoteConsumptionChecker`] instance with the given transaction executor.

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -19,7 +19,7 @@ use super::{NoteAccountExecution, TransactionExecutor, TransactionExecutorError}
 /// The check is performed using the [NoteConsumptionChecker::check_notes_consumability] procedure.
 /// Essentially runs the transaction to make sure that provided input notes could be consumed by the
 /// account.
-pub struct NoteConsumptionChecker<'a>(&'a TransactionExecutor<'a>);
+pub struct NoteConsumptionChecker<'a>(&'a TransactionExecutor<'a, 'a>);
 
 impl<'a> NoteConsumptionChecker<'a> {
     /// Creates a new [`NoteConsumptionChecker`] instance with the given transaction executor.

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -48,13 +48,13 @@ use crate::{auth::TransactionAuthenticator, errors::TransactionHostError};
 /// Transaction hosts are created on a per-transaction basis. That is, a transaction host is meant
 /// to support execution of a single transaction and is discarded after the transaction finishes
 /// execution.
-pub struct TransactionHost<A> {
+pub struct TransactionHost<'store, A> {
     /// Advice provider which is used to provide non-deterministic inputs to the transaction
     /// runtime.
     adv_provider: A,
 
     /// MAST store which contains the code required to execute account code functions.
-    mast_store: Arc<dyn MastForestStore>,
+    mast_store: &'store dyn MastForestStore,
 
     /// MAST store which contains the forests of all scripts involved in the transaction. These
     /// include input note scripts and the transaction script, but not account code.
@@ -90,12 +90,12 @@ pub struct TransactionHost<A> {
     tx_progress: TransactionProgress,
 }
 
-impl<A: AdviceProvider> TransactionHost<A> {
+impl<'store, A: AdviceProvider> TransactionHost<'store, A> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
         account: AccountHeader,
         adv_provider: A,
-        mast_store: Arc<dyn MastForestStore>,
+        mast_store: &'store dyn MastForestStore,
         scripts_mast_store: ScriptMastForestStore,
         authenticator: Option<Arc<dyn TransactionAuthenticator>>,
         mut foreign_account_code_commitments: BTreeSet<Digest>,
@@ -477,7 +477,7 @@ impl<A: AdviceProvider> TransactionHost<A> {
 // HOST IMPLEMENTATION FOR TRANSACTION HOST
 // ================================================================================================
 
-impl<A: AdviceProvider> Host for TransactionHost<A> {
+impl<A: AdviceProvider> Host for TransactionHost<'_, A> {
     type AdviceProvider = A;
 
     fn advice_provider(&self) -> &Self::AdviceProvider {

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -48,7 +48,7 @@ use crate::{auth::TransactionAuthenticator, errors::TransactionHostError};
 /// Transaction hosts are created on a per-transaction basis. That is, a transaction host is meant
 /// to support execution of a single transaction and is discarded after the transaction finishes
 /// execution.
-pub struct TransactionHost<'store, A> {
+pub struct TransactionHost<'store, 'auth, A> {
     /// Advice provider which is used to provide non-deterministic inputs to the transaction
     /// runtime.
     adv_provider: A,
@@ -75,7 +75,7 @@ pub struct TransactionHost<'store, A> {
 
     /// Serves signature generation requests from the transaction runtime for signatures which are
     /// not present in the `generated_signatures` field.
-    authenticator: Option<Arc<dyn TransactionAuthenticator>>,
+    authenticator: Option<&'auth dyn TransactionAuthenticator>,
 
     /// Contains previously generated signatures (as a message |-> signature map) required for
     /// transaction execution.
@@ -90,14 +90,14 @@ pub struct TransactionHost<'store, A> {
     tx_progress: TransactionProgress,
 }
 
-impl<'store, A: AdviceProvider> TransactionHost<'store, A> {
+impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
     /// Returns a new [TransactionHost] instance with the provided [AdviceProvider].
     pub fn new(
         account: AccountHeader,
         adv_provider: A,
         mast_store: &'store dyn MastForestStore,
         scripts_mast_store: ScriptMastForestStore,
-        authenticator: Option<Arc<dyn TransactionAuthenticator>>,
+        authenticator: Option<&'auth dyn TransactionAuthenticator>,
         mut foreign_account_code_commitments: BTreeSet<Digest>,
     ) -> Result<Self, TransactionHostError> {
         // currently, the executor/prover do not keep track of the code commitment of the native
@@ -477,7 +477,7 @@ impl<'store, A: AdviceProvider> TransactionHost<'store, A> {
 // HOST IMPLEMENTATION FOR TRANSACTION HOST
 // ================================================================================================
 
-impl<A: AdviceProvider> Host for TransactionHost<'_, A> {
+impl<A: AdviceProvider> Host for TransactionHost<'_, '_, A> {
     type AdviceProvider = A;
 
     fn advice_provider(&self) -> &Self::AdviceProvider {

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -106,7 +106,7 @@ impl TransactionProver for LocalTransactionProver {
         let mut host: TransactionHost<_> = TransactionHost::new(
             account.into(),
             advice_provider,
-            self.mast_store.clone(),
+            self.mast_store.as_ref(),
             script_mast_store,
             None,
             account_code_commitments,


### PR DESCRIPTION
This PR replaces `Arc<dyn DataStore` with a normal reference `&'a dyn DataStore`.

Existing `Arc<DataStore` types will somewhat automatically gain `'a = 'static` and shouldn't be inconvenienced more than doing `x.as_ref()` in the constructor (if needed at all).

I'm uncertain if this still enables the original motivation for using `Arc`. Tests and lints pass.. :shrug: 

I want this so I can use my `DataStore` in a single threaded context. Note that there is also `Option<Arc<dyn TransactionAuthenticator>>` however in my usage this is always `None`. If desired, I can also change this to a reference? --edit-- new commit makes this change as well.