### PR TITLE
Implement in-kernel account delta for non fungible assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
 - Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB for compiler testing (#1464).
 - [BREAKING] `TransactionExecutor` now holds plain references instead of `Arc` for its trait objects (#1469).
-- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460).
+- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460, #1481).
 - [BREAKING] Store account ID in account delta (#1493).
 - [BREAKING] Remove P2IDR and replace with P2IDE (#1483).
 - Added `Note::is_network_note()` accessor (#1485).

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -53,6 +53,9 @@ export.compute_commitment
     exec.update_fungible_asset_delta
     # => [RATE, RATE, PERM]
 
+    exec.update_non_fungible_asset_delta
+    # => [RATE, RATE, PERM]
+
     exec.update_storage_delta
     # => [RATE, RATE, PERM]
 
@@ -252,6 +255,74 @@ proc.update_fungible_asset_delta.2
     # => [RATE, RATE, PERM]
 end
 
+
+#! Updates the given delta hasher with the non-fungible asset vault delta.
+#!
+#! Inputs:  [RATE, RATE, PERM]
+#! Outputs: [RATE, RATE, PERM]
+proc.update_non_fungible_asset_delta.2
+    exec.memory::get_account_delta_non_fungible_asset_ptr
+    # => [account_delta_non_fungible_asset_ptr, RATE, RATE, PERM]
+
+    exec.link_map::iter
+    # => [has_next, iter, RATE, RATE, PERM]
+
+    # enter loop if the link map is not empty
+    while.true
+        exec.link_map::next
+        # => [KEY, VALUE0, VALUE1, has_next, iter, ...]
+
+        # store has_next
+        movup.12 loc_store.0
+        # => [KEY, VALUE0, VALUE1, iter, ...]
+
+        # store iter
+        movup.12 loc_store.1
+        # => [KEY, VALUE0, VALUE1, ...]
+        # this stack state is equivalent to:
+        # => [ASSET, [was_added, 0, 0, 0], EMPTY_WORD, ...]
+
+        # drop unused VALUE1 word
+        movupw.2 dropw
+        # => [ASSET, [was_added, 0, 0, 0], ...]
+
+        dup.4 neq.0
+        # => [was_added_or_removed, ASSET, [was_added, 0, 0, 0], ...]
+
+        # if the asset was added or removed (i.e. if was_added != 0), update the hasher
+        if.true
+            movup.4 movdn.6
+            # => [ASSET, [0, 0, was_added, 0], ...]
+
+            push.DOMAIN_ASSET swap.8 drop
+            # => [ASSET, [0, 0, was_added, domain], RATE, RATE, PERM]
+
+            # drop previous RATE elements
+            swapdw dropw dropw
+            # => [ASSET, [0, 0, was_added, domain], PERM]
+
+            hperm
+            # => [RATE, RATE, PERM]
+        else
+          # discard the two key and value words loaded from the map
+          dropw dropw
+          # => [RATE, RATE, PERM]
+        end
+        # => [RATE, RATE, PERM]
+
+        # load iter and has_next
+        loc_load.1
+        # => [iter, RATE, RATE, PERM]
+
+        loc_load.0
+        # => [has_next, iter, RATE, RATE, PERM]
+    end
+
+    # drop iter
+    drop
+    # => [RATE, RATE, PERM]
+end
+
 #! Returns the initial value of a storage slot from the account storage.
 #!
 #! This is the value of the slot at the beginning of the transaction.
@@ -300,8 +371,7 @@ export.add_asset
         exec.add_fungible_asset
         # => []
     else
-        # TODO: Handle non-fungible assets
-        dropw
+        exec.add_non_fungible_asset
         # => []
     end
 end
@@ -331,8 +401,7 @@ export.remove_asset
         exec.remove_fungible_asset
         # => []
     else
-        # TODO: Handle non-fungible assets
-        dropw
+        exec.remove_non_fungible_asset
         # => []
     end
 end
@@ -404,6 +473,85 @@ export.remove_fungible_asset
 
     exec.memory::get_account_delta_fungible_asset_ptr
     # => [fungible_delta_map_ptr, ASSET_KEY, delta_amount_hi, delta_amount_lo, 0, 0, EMPTY_WORD]
+
+    exec.link_map::set drop
+    # => []
+end
+
+#! Adds the given non-fungible asset to the non-fungible asset vault delta.
+#!
+#! ASSET must be a valid non-fungible asset.
+#!
+#! If the key does not exist in the delta map, the non-fungible asset's was_added value is 0.
+#! When it is added to the account vault, was_added is incremented by 1; when it is removed from
+#! the account vault, was_added is decremented by 1.
+#! Since an asset can only be added to or removed from a vault once, was_added will always have a
+#! value of -1, 0, or 1, where -1 is represented by `0 - 1` in felt operations.
+#! This means adding and removing or removing and adding the asset will correctly cancel out.
+#!
+#! The final was_added value after transaction execution is then interpreted as follows:
+#! -1 -> asset was removed
+#! 0 -> no change to the asset
+#! +1 -> asset was added
+#!
+#! Inputs:  [ASSET]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET is the non-fungible asset to be added.
+export.add_non_fungible_asset
+    dupw exec.memory::get_account_delta_non_fungible_asset_ptr
+    # => [non_fungible_delta_map_ptr, ASSET, ASSET]
+
+    # retrieve the current delta
+    # contains_key can be ignored because the default value is an empty word and the
+    # was_added value is therefore 0
+    exec.link_map::get drop
+    # => [was_added, 0, 0, 0, EMPTY_WORD, ASSET]
+
+    add.1
+    # => [was_added, 0, 0, 0, EMPTY_WORD, ASSET]
+
+    movupw.2
+    # => [ASSET, was_added, 0, 0, 0, EMPTY_WORD]
+
+    exec.memory::get_account_delta_non_fungible_asset_ptr
+    # => [non_fungible_delta_map_ptr, ASSET, was_added, 0, 0, 0, EMPTY_WORD]
+
+    exec.link_map::set drop
+    # => []
+end
+
+
+#! Removes the given non-fungible asset from the non-fungible asset vault delta.
+#!
+#! ASSET must be a valid non-fungible asset.
+#!
+#! See add_non_fungible_asset for documentation.
+#!
+#! Inputs:  [ASSET]
+#! Outputs: []
+#!
+#! Where:
+#! - ASSET is the non-fungible asset to be removed.
+export.remove_non_fungible_asset
+    dupw exec.memory::get_account_delta_non_fungible_asset_ptr
+    # => [non_fungible_delta_map_ptr, ASSET, ASSET]
+
+    # retrieve the current delta
+    # contains_key can be ignored because the default value is an empty word and the
+    # was_added value is therefore 0
+    exec.link_map::get drop
+    # => [was_added, 0, 0, 0, EMPTY_WORD, ASSET]
+
+    sub.1
+    # => [was_added, 0, 0, 0, EMPTY_WORD, ASSET]
+
+    movupw.2
+    # => [ASSET, was_added, 0, 0, 0, EMPTY_WORD]
+
+    exec.memory::get_account_delta_non_fungible_asset_ptr
+    # => [non_fungible_delta_map_ptr, ASSET, was_added, 0, 0, 0, EMPTY_WORD]
 
     exec.link_map::set drop
     # => []

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -291,7 +291,15 @@ proc.update_non_fungible_asset_delta.2
 
         # if the asset was added or removed (i.e. if was_added != 0), update the hasher
         if.true
-            movup.4 movdn.6
+            movup.4
+            # => [was_added, ASSET, [0, 0, 0], ...]
+
+            # convert was_added to a boolean
+            # was_added is 1 if the asset was added and 0 - 1 if it was removed
+            eq.1
+            # => [was_added, ASSET, [0, 0, 0], ...]
+
+            movdn.6
             # => [ASSET, [0, 0, was_added, 0], ...]
 
             push.DOMAIN_ASSET swap.8 drop

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -269,21 +269,17 @@ proc.update_non_fungible_asset_delta.2
 
     # enter loop if the link map is not empty
     while.true
-        exec.link_map::next
-        # => [KEY, VALUE0, VALUE1, has_next, iter, ...]
+        exec.link_map::next_key_value
+        # => [KEY, VALUE0, has_next, iter, ...]
 
         # store has_next
-        movup.12 loc_store.0
-        # => [KEY, VALUE0, VALUE1, iter, ...]
+        movup.8 loc_store.0
+        # => [KEY, VALUE0, iter, ...]
 
         # store iter
-        movup.12 loc_store.1
-        # => [KEY, VALUE0, VALUE1, ...]
+        movup.8 loc_store.1
+        # => [KEY, VALUE0, ...]
         # this stack state is equivalent to:
-        # => [ASSET, [was_added, 0, 0, 0], EMPTY_WORD, ...]
-
-        # drop unused VALUE1 word
-        movupw.2 dropw
         # => [ASSET, [was_added, 0, 0, 0], ...]
 
         dup.4 neq.0

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -177,6 +177,9 @@ const.ACCOUNT_DELTA_NONCE_PTR=532480
 # The link map pointer at which the delta of the fungible asset vault is stored.
 const.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+4
 
+# The link map pointer at which the delta of the non-fungible asset vault is stored.
+const.ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+8
+
 # INPUT NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -1188,6 +1191,17 @@ end
 #! - account_delta_fungible_asset_ptr is the link map pointer to the fungible asset vault delta.
 export.get_account_delta_fungible_asset_ptr
   push.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR
+end
+
+#! Returns the link map pointer to the non-fungible asset vault delta.
+#!
+#! Inputs:  []
+#! Outputs: [account_delta_non_fungible_asset_ptr]
+#!
+#! Where:
+#! - account_delta_non_fungible_asset_ptr is the link map pointer to the non-fungible asset vault delta.
+export.get_account_delta_non_fungible_asset_ptr
+    push.ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR
 end
 
 #! Increments the delta of the account's nonce.

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,15 +32,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-<<<<<<< HEAD
-    digest!("0x8f5322ba63b506cb4d624258f6c9ffab1729a661c34fd54dcd0f3120ccc05860"),
+    digest!("0x2e11ed064d99ed21fd7a91fa11bddb322ac5891df114b79b82606bed1f245ede"),
     // account_remove_asset
-    digest!("0x4598c4925aa7399dc57d2c1a125231fcbc98100a5030c9b647cb33a8791e1f20"),
-=======
-    digest!("0x27cfd8576932632b9da64bb6b6813a4b396a198a38e08e78e9139406eefa190e"),
-    // account_remove_asset
-    digest!("0x4503f44c4d1039bb8da71d1cf4f93af46e2f6e5b094189686e347fc8c8674d69"),
->>>>>>> 5cfe4bd7 (feat: Implement non-fungible asset vault delta)
+    digest!("0xa07864cba75f80e7d392c30b87d792d66d3fbc31837bddae3fbd5f43aa6f3752"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,9 +32,15 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
+<<<<<<< HEAD
     digest!("0x8f5322ba63b506cb4d624258f6c9ffab1729a661c34fd54dcd0f3120ccc05860"),
     // account_remove_asset
     digest!("0x4598c4925aa7399dc57d2c1a125231fcbc98100a5030c9b647cb33a8791e1f20"),
+=======
+    digest!("0x27cfd8576932632b9da64bb6b6813a4b396a198a38e08e78e9139406eefa190e"),
+    // account_remove_asset
+    digest!("0x4503f44c4d1039bb8da71d1cf4f93af46e2f6e5b094189686e347fc8c8674d69"),
+>>>>>>> 5cfe4bd7 (feat: Implement non-fungible asset vault delta)
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -9,9 +9,8 @@ use super::{
 };
 use crate::{
     Felt, ONE, Word, ZERO,
-    account::{AccountId, AccountType},
+    account::{AccountId, AccountType, delta::LinkMapKey},
     asset::{Asset, AssetVault, FungibleAsset, NonFungibleAsset},
-    transaction::LinkMapKey,
 };
 
 // ACCOUNT VAULT DELTA

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -396,6 +396,9 @@ impl Deserializable for FungibleAssetDelta {
 // ================================================================================================
 
 /// A binary tree map of non-fungible asset changes (addition and removal) in the account vault.
+///
+/// The [`LinkMapKey`] wrapper is necessary to order the assets in the same way as the in-kernel
+/// account delta which uses a link map.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NonFungibleAssetDelta(BTreeMap<LinkMapKey<NonFungibleAsset>, NonFungibleDeltaAction>);
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -11,11 +11,15 @@ use miden_objects::{
     },
     asset::{Asset, FungibleAsset},
     note::{Note, NoteType},
-    testing::{account_component::AccountMockComponent, account_id::AccountIdBuilder},
+    testing::{
+        account_component::AccountMockComponent, account_id::AccountIdBuilder,
+        asset::NonFungibleAssetBuilder,
+    },
     transaction::{ExecutedTransaction, TransactionScript},
     vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};
+use rand::Rng;
 
 use crate::MockChain;
 
@@ -267,6 +271,107 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that adding, removing non-fungible assets results in the correct delta.
+/// - Asset0 is added to the vault -> Delta: Add.
+/// - Asset1 is removed from the vault -> Delta: Remove.
+/// - Asset2 is added and removed -> Delta: No Change.
+/// - Asset3 is removed and added -> Delta: No Change.
+#[test]
+fn non_fungible_asset_delta() -> anyhow::Result<()> {
+    let mut rng = rand::rng();
+    // Test with random IDs to make sure the ordering in the MASM and Rust implementations
+    // matches.
+    let faucet0: AccountId = AccountIdBuilder::new()
+        .account_type(AccountType::NonFungibleFaucet)
+        .build_with_seed(rng.random());
+    let faucet1: AccountId = AccountIdBuilder::new()
+        .account_type(AccountType::NonFungibleFaucet)
+        .build_with_seed(rng.random());
+    let faucet2: AccountId = AccountIdBuilder::new()
+        .account_type(AccountType::NonFungibleFaucet)
+        .build_with_seed(rng.random());
+    let faucet3: AccountId = AccountIdBuilder::new()
+        .account_type(AccountType::NonFungibleFaucet)
+        .build_with_seed(rng.random());
+
+    let asset0 = NonFungibleAssetBuilder::new(faucet0.prefix(), &mut rng)?.build()?;
+    let asset1 = NonFungibleAssetBuilder::new(faucet1.prefix(), &mut rng)?.build()?;
+    let asset2 = NonFungibleAssetBuilder::new(faucet2.prefix(), &mut rng)?.build()?;
+    let asset3 = NonFungibleAssetBuilder::new(faucet3.prefix(), &mut rng)?.build()?;
+
+    let TestSetup { mut mock_chain, account_id } =
+        setup_asset_test([asset1, asset3].map(Asset::from));
+
+    let mut added_notes = vec![];
+    for added_asset in [asset0, asset2] {
+        let added_note = mock_chain
+            .add_pending_p2id_note(
+                account_id,
+                account_id,
+                &[Asset::from(added_asset)],
+                NoteType::Public,
+                None,
+            )
+            .context("failed to add note with asset")?;
+        added_notes.push(added_note);
+    }
+    mock_chain.prove_next_block();
+
+    let tx_script = compile_tx_script(format!(
+        "
+    begin
+        push.{asset1} exec.create_note_with_asset
+        # => []
+        push.{asset2} exec.create_note_with_asset
+        # => []
+
+        # remove and re-add asset 3
+        push.{asset3}
+        exec.remove_asset
+        # => [ASSET]
+        exec.add_asset dropw
+        # => []
+
+        # nonce must increase for state changing transactions
+        push.1 exec.incr_nonce
+    end
+    ",
+        asset1 = word_to_masm_push_string(&asset1.into()),
+        asset2 = word_to_masm_push_string(&asset2.into()),
+        asset3 = word_to_masm_push_string(&asset3.into()),
+    ))?;
+
+    let executed_tx = mock_chain
+        .build_tx_context(account_id, &added_notes.iter().map(Note::id).collect::<Vec<_>>(), &[])
+        .tx_script(tx_script)
+        .build()
+        .execute()
+        .context("failed to execute transaction")?;
+
+    let mut added_assets = executed_tx
+        .account_delta()
+        .vault()
+        .added_assets()
+        .map(|asset| (Digest::from(asset.vault_key()), asset.unwrap_non_fungible()))
+        .collect::<BTreeMap<_, _>>();
+    let mut removed_assets = executed_tx
+        .account_delta()
+        .vault()
+        .removed_assets()
+        .map(|asset| (Digest::from(asset.vault_key()), asset.unwrap_non_fungible()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(added_assets.len(), 1);
+    assert_eq!(removed_assets.len(), 1);
+
+    assert_eq!(added_assets.remove(&Digest::from(asset0.vault_key())).unwrap(), asset0);
+    assert_eq!(removed_assets.remove(&Digest::from(asset1.vault_key())).unwrap(), asset1);
+
+    validate_account_delta(&executed_tx).context("failed to validate delta")?;
+
+    Ok(())
+}
+
 /// Validates that the given host-computed account delta has the same commitment as the in-kernel
 /// computed account delta.
 ///
@@ -452,5 +557,31 @@ const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
 
           # return values are unused
           dropw dropw dropw dropw
+      end
+
+      #! Inputs:  [ASSET]
+      #! Outputs: [ASSET']
+      proc.add_asset
+          repeat.12 push.0 movdn.4 end
+          # => [ASSET, pad(12)]
+
+          call.account::add_asset
+          # => [ASSET', pad(12)]
+
+          repeat.12 movup.4 drop end
+          # => [ASSET']
+      end
+
+      #! Inputs:  [ASSET]
+      #! Outputs: [ASSET]
+      proc.remove_asset
+          repeat.12 push.0 movdn.4 end
+          # => [ASSET, pad(12)]
+
+          call.account::remove_asset
+          # => [ASSET, pad(12)]
+
+          repeat.12 movup.4 drop end
+          # => [ASSET]
       end
 ";

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -310,7 +310,6 @@ fn non_fungible_asset_delta() -> anyhow::Result<()> {
                 account_id,
                 &[Asset::from(added_asset)],
                 NoteType::Public,
-                None,
             )
             .context("failed to add note with asset")?;
         added_notes.push(added_note);


### PR DESCRIPTION
Implement in-kernel account delta for non fungible assets.

The approach is very similar to the fungible asset delta in #1460. See `account_delta::add_non_fungible_asset` for documentation on the link map layout used to bookkeep the changed assets.

part of #1198