### PR TITLE
Implement in-kernel account delta for storage maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [BREAKING] Forbid the execution of the empty transactions (#1459).
 - Temporarily bump ACCOUNT_UPDATE_MAX_SIZE to 256 KiB for compiler testing (#1464).
 - [BREAKING] `TransactionExecutor` now holds plain references instead of `Arc` for its trait objects (#1469).
-- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460, #1481).
+- [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460, #1481, #1491).
 - [BREAKING] Store account ID in account delta (#1493).
 - [BREAKING] Remove P2IDR and replace with P2IDE (#1483).
 - Added `Note::is_network_note()` accessor (#1485).

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -546,26 +546,40 @@ export.set_map_item.12
 
     # duplicate the original KEY and the NEW_VALUE to be able to emit an event after the
     # account storage item was updated
-    movdn.12 movupw.2 dupw.2 dupw.2
-    # => [KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
+    drop movupw.2 dupw.2 dupw.2
+    # => [KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE]
 
     # see hash_map_key's docs for why this is done
     exec.hash_map_key
-    # => [HASHED_KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE, index, ...]
+    # => [HASHED_KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE]
 
     # set the NEW_VALUE under HASHED_KEY in the tree
-    # note smt::set expects the stack to be [NEW_VALUE, HASHED_KEY, OLD_ROOT, ...]
+    # note smt::set expects the stack to be [NEW_VALUE, HASHED_KEY, OLD_ROOT]
     swapw exec.smt::set
-    # => [OLD_MAP_VALUE, NEW_ROOT, KEY, NEW_VALUE, index, ...]
+    # => [OLD_MAP_VALUE, NEW_ROOT, KEY, NEW_VALUE]
 
     # store OLD_MAP_VALUE and NEW_ROOT until the end of the procedure
     loc_storew.4 dropw loc_storew.8 dropw
-    # => [KEY, NEW_VALUE, index, ...]
+    # => [KEY, NEW_VALUE]
+
+    dupw.1
+    # => [NEW_VALUE, KEY, NEW_VALUE]
+
+    padw loc_loadw.4
+    # => [OLD_MAP_VALUE, NEW_VALUE, KEY, NEW_VALUE]
+
+    dupw.2
+    # => [KEY, OLD_MAP_VALUE, NEW_VALUE, KEY, NEW_VALUE]
 
     # emit event to signal that an account storage item is being updated
-    movup.8
-    emit.ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT drop
-    # => [KEY, NEW_VALUE, ...]
+    loc_load.0
+    # => [index, KEY, OLD_MAP_VALUE, NEW_VALUE, KEY, NEW_VALUE]
+
+    emit.ACCOUNT_STORAGE_AFTER_SET_MAP_ITEM_EVENT
+    # => [index, KEY, OLD_MAP_VALUE, NEW_VALUE, KEY, NEW_VALUE]
+
+    exec.account_delta::set_map_item
+    # => [KEY, NEW_VALUE]
 
     # load OLD_MAP_VALUE and NEW_ROOT on the top of the stack
     loc_loadw.8 swapw loc_loadw.4 swapw

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -533,20 +533,20 @@ export.set_map_item.12
     # => [index, KEY, NEW_VALUE, OLD_ROOT, ...]
 
     # check if storage type is map
-    dup exec.get_storage_slot_type
-    # => [slot_type, index, KEY, NEW_VALUE, OLD_ROOT]
+    exec.get_storage_slot_type
+    # => [slot_type, KEY, NEW_VALUE, OLD_ROOT]
 
     # check if slot_type == map
     exec.constants::get_storage_slot_type_map eq
     assert.err=ERR_ACCOUNT_SETTING_MAP_ITEM_ON_NON_MAP_SLOT
-    # => [index, KEY, NEW_VALUE, OLD_ROOT]
+    # => [KEY, NEW_VALUE, OLD_ROOT]
 
     emit.ACCOUNT_STORAGE_BEFORE_SET_MAP_ITEM_EVENT
-    # => [index, KEY, NEW_VALUE, OLD_ROOT]
+    # => [KEY, NEW_VALUE, OLD_ROOT]
 
     # duplicate the original KEY and the NEW_VALUE to be able to emit an event after the
     # account storage item was updated
-    drop movupw.2 dupw.2 dupw.2
+    movupw.2 dupw.2 dupw.2
     # => [KEY, NEW_VALUE, OLD_ROOT, KEY, NEW_VALUE]
 
     # see hash_map_key's docs for why this is done

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -212,19 +212,16 @@ proc.update_map_slot_delta.4
         movup.12 loc_store.2
         # => [KEY, INIT_VALUE, NEW_VALUE, ...]
 
-        movupw.2
-        # => [NEW_VALUE, KEY, INIT_VALUE, ...]
-
-        movupw.2
-        # => [INIT_VALUE, NEW_VALUE, KEY, ...]
+        swapw.2
+        # => [NEW_VALUE, INIT_VALUE, KEY, ...]
 
         eqw not
-        # => [was_changed, INIT_VALUE, NEW_VALUE, KEY, ...]
+        # => [was_changed, NEW_VALUE, INIT_VALUE, KEY, ...]
 
         # if the key-value pair has actually changed, update the hasher
         if.true
             # drop the initial value
-            dropw
+            swapw dropw
             # => [NEW_VALUE, KEY, RATE, RATE, PERM]
 
             # increment number of changed entries in local 3
@@ -662,7 +659,8 @@ export.remove_non_fungible_asset
     # => []
 end
 
-#! Updates the storage map delta of the given slot index with the given key-value pair and its previous value.
+#! Updates the storage map delta of the given slot index with the given key-value pair and its
+#! previous value.
 #!
 #! The layout of a link map entry for a given KEY is: [KEY, INIT_VALUE, NEW_VALUE] where INIT_VALUE
 #! represents the initial value for the given KEY at the beginning of transaction execution and

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -123,10 +123,9 @@ proc.update_slot_delta
     if.true
         exec.update_value_slot_delta
     else
-        # TODO: Update delta hasher with map.
-        # drop slot idx
-        drop
+        exec.update_map_slot_delta
     end
+    # => [RATE, RATE, PERM]
 end
 
 #! Updates the given delta hasher with the value storage slot at the provided index.
@@ -169,6 +168,108 @@ proc.update_value_slot_delta
     else
         # drop init value, current value and slot idx
         dropw dropw drop
+        # => [RATE, RATE, PERM]
+    end
+    # => [RATE, RATE, PERM]
+end
+
+#! Updates the given delta hasher with the map storage slot at the provided index.
+#!
+#! Inputs:  [slot_idx, RATE, RATE, PERM]
+#! Outputs: [RATE, RATE, PERM]
+#!
+#! Locals:
+#!   0: slot_idx
+#!   1: has_next
+#!   2: iter
+#!   3: num_changed_entries
+proc.update_map_slot_delta.4
+    # initialize num_changed_entries = 0
+    # this is necessary because this procedure can be called multiple times and the second
+    # invocation shouldn't reuse the first invocations value
+    push.0 loc_store.3
+    # => [slot_idx, RATE, RATE, PERM]
+
+    dup loc_store.0
+    # => [slot_idx, RATE, RATE, PERM]
+
+    exec.memory::get_account_delta_storage_map_ptr
+    # => [account_delta_storage_map_ptr, RATE, RATE, PERM]
+
+    exec.link_map::iter
+    # => [has_next, iter, RATE, RATE, PERM]
+
+    # enter loop if the link map is not empty
+    while.true
+        exec.link_map::next
+        # => [KEY, INIT_VALUE, NEW_VALUE, has_next, iter, ...]
+
+        # store has_next
+        movup.12 loc_store.1
+        # => [KEY, INIT_VALUE, NEW_VALUE, iter, ...]
+
+        # store iter
+        movup.12 loc_store.2
+        # => [KEY, INIT_VALUE, NEW_VALUE, ...]
+
+        movupw.2
+        # => [NEW_VALUE, KEY, INIT_VALUE, ...]
+
+        movupw.2
+        # => [INIT_VALUE, NEW_VALUE, KEY, ...]
+
+        eqw not
+        # => [was_changed, INIT_VALUE, NEW_VALUE, KEY, ...]
+
+        # if the key-value pair has actually changed, update the hasher
+        if.true
+            # drop the initial value
+            dropw
+            # => [NEW_VALUE, KEY, RATE, RATE, PERM]
+
+            # increment number of changed entries in local 3
+            loc_load.3 add.1 loc_store.3
+            # => [NEW_VALUE, KEY, RATE, RATE, PERM]
+
+            # drop previous RATE elements
+            swapdw dropw dropw
+            # => [NEW_VALUE, KEY, PERM]
+
+            hperm
+            # => [RATE, RATE, PERM]
+        else
+            # discard the key and init and new value words loaded from the map
+            dropw dropw dropw
+            # => [RATE, RATE, PERM]
+        end
+        # => [RATE, RATE, PERM]
+
+        # load iter and has_next
+        loc_load.2
+        # => [iter, RATE, RATE, PERM]
+
+        loc_load.1
+        # => [has_next, iter, RATE, RATE, PERM]
+    end
+
+    # drop iter
+    drop
+    # => [RATE, RATE, PERM]
+
+    # only include the map slot metadata if there were entries in the map that resulted in an
+    # update to the hasher state
+    loc_load.3 neq.0
+    # => [is_num_changed_entries_non_zero, RATE, RATE, PERM]
+
+    if.true
+        # drop the previous RATE elements
+        dropw dropw
+        # => [PERM]
+
+        push.DOMAIN_MAP loc_load.0 loc_load.3 push.0 padw
+        # => [EMPTY_WORD, [0, num_changed_entries, slot_idx, domain], PERM]
+
+        hperm
         # => [RATE, RATE, PERM]
     end
     # => [RATE, RATE, PERM]

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -561,6 +561,68 @@ export.remove_non_fungible_asset
     # => []
 end
 
+#! Updates the storage map delta of the given slot index with the given key-value pair and its previous value.
+#!
+#! The layout of a link map entry for a given KEY is: [KEY, INIT_VALUE, NEW_VALUE] where INIT_VALUE
+#! represents the initial value for the given KEY at the beginning of transaction execution and
+#! NEW_VALUE is the new value. The delta entry is a NOOP if INIT_VALUE and NEW_VALUE are equal.
+#!
+#! Inputs:  [slot_index, KEY, PREV_VALUE, NEW_VALUE]
+#! Outputs: []
+#!
+#! Where:
+#! - slot_index is the slot index of the storage map slot.
+#! - KEY is the key in the storage map that is being updated.
+#! - PREV_VALUE is the previous value of the key in the storage map that is being updated.
+#! - NEW_VALUE is the new value of the key in the storage map that is being updated.
+export.set_map_item.8
+    # retrieve the link map ptr to the storage map delta for the provided index
+    exec.memory::get_account_delta_storage_map_ptr
+    # => [account_delta_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
+
+    # store map ptr in local
+    loc_store.0
+    # => [KEY, PREV_VALUE, NEW_VALUE]
+
+    # store KEY in local
+    loc_storew.4
+    # => [KEY, PREV_VALUE, NEW_VALUE]
+
+    loc_load.0
+    # => [account_delta_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
+
+    # retrieve the current delta
+    exec.link_map::get
+    # => [contains_key, VALUE0, VALUE1, PREV_VALUE, NEW_VALUE]
+
+    movdn.12
+    # => [VALUE0, VALUE1, PREV_VALUE, contains_key, NEW_VALUE]
+
+    # VALUE1 was the previous "new value" if this key was already updated, so in any case,
+    # we can drop it since this update overwrites the previous one
+    swapw dropw
+    # => [VALUE0, PREV_VALUE, contains_key, NEW_VALUE]
+
+    movup.8
+    # => [contains_key, VALUE0, PREV_VALUE, NEW_VALUE]
+
+    # contains_key determines whether this is the first update to this KEY
+    # if this is the first update, PREV_VALUE is the *initial* value of the key-value pair
+    # if this is not the first update, VALUE0 is the initial value, so we want to store it back
+    # use cdropw to selectively keep the word that represents the initial value
+    # If contains_key VALUE0 remains.
+    # If !contains_key PREV_VALUE remains.
+    cdropw
+    # => [INITIAL_VALUE, NEW_VALUE]
+
+    # load key and index from locals
+    padw loc_loadw.4 loc_load.0
+    # => [account_delta_storage_map_ptr, KEY, INITIAL_VALUE, NEW_VALUE]
+
+    exec.link_map::set drop
+    # => []
+end
+
 # i64 MATH
 # -------------------------------------------------------------------------------------------------
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -201,7 +201,7 @@ proc.update_map_slot_delta.4
 
     # enter loop if the link map is not empty
     while.true
-        exec.link_map::next
+        exec.link_map::next_key_double_value
         # => [KEY, INIT_VALUE, NEW_VALUE, has_next, iter, ...]
 
         # store has_next

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -186,7 +186,7 @@ end
 proc.update_map_slot_delta.4
     # initialize num_changed_entries = 0
     # this is necessary because this procedure can be called multiple times and the second
-    # invocation shouldn't reuse the first invocations value
+    # invocation shouldn't reuse the first invocation's value
     push.0 loc_store.3
     # => [slot_idx, RATE, RATE, PERM]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -181,8 +181,8 @@ const.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+4
 const.ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+8
 
 # The section of link map pointers where storage map deltas are stored.
-# This section if offset by (slot index * WORD_SIZE) to get the link map ptr for the storage map
-# delta at that slot index.
+# This section is offset by `slot index` to get the link map ptr for the storage map
+# delta at that slot index. Slot indices that are not map slots are simply unused.
 const.ACCOUNT_DELTA_STORGE_MAP_SECTION=ACCOUNT_DELTA_NONCE_PTR+12
 
 # INPUT NOTES DATA
@@ -1218,7 +1218,7 @@ end
 #! - account_delta_storage_map_ptr is the link map pointer to the storage map delta for the
 #!   requested slot index.
 export.get_account_delta_storage_map_ptr
-    mul.4 add.ACCOUNT_DELTA_STORGE_MAP_SECTION
+    add.ACCOUNT_DELTA_STORGE_MAP_SECTION
 end
 
 #! Increments the delta of the account's nonce.

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -230,12 +230,12 @@ const.OUTPUT_NOTE_ASSETS_OFFSET=20
 # LINK MAP MEMORY
 # -------------------------------------------------------------------------------------------------
 
-# The inclusive start of the link map dynamic memory range.
+# The inclusive start of the link map dynamic memory region.
 # Chosen as a number greater than 2^25 such that all entry pointers are multiples of
 # LINK_MAP_ENTRY_SIZE. That enables a simpler check in assert_entry_ptr_is_valid.
 const.LINK_MAP_REGION_START_PTR=33554448
 
-# The non-inclusive end of the link map dynamic memory range.
+# The non-inclusive end of the link map dynamic memory region.
 # This happens to be 2^26, but if it is changed, it should be chosen as a number such that
 # LINK_MAP_REGION_END_PTR - LINK_MAP_REGION_START_PTR is a multiple of LINK_MAP_ENTRY_SIZE,
 # because that enables checking whether a newly allocated entry pointer is at the end of the range

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -180,6 +180,11 @@ const.ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+4
 # The link map pointer at which the delta of the non-fungible asset vault is stored.
 const.ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_NONCE_PTR+8
 
+# The section of link map pointers where storage map deltas are stored.
+# This section if offset by (slot index * WORD_SIZE) to get the link map ptr for the storage map
+# delta at that slot index.
+const.ACCOUNT_DELTA_STORGE_MAP_SECTION=ACCOUNT_DELTA_NONCE_PTR+12
+
 # INPUT NOTES DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -1202,6 +1207,18 @@ end
 #! - account_delta_non_fungible_asset_ptr is the link map pointer to the non-fungible asset vault delta.
 export.get_account_delta_non_fungible_asset_ptr
     push.ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR
+end
+
+#! Returns the link map pointer to the storage map delta of the storage map in the given slot index.
+#!
+#! Inputs:  [slot_idx]
+#! Outputs: [account_delta_storage_map_ptr]
+#!
+#! Where:
+#! - account_delta_storage_map_ptr is the link map pointer to the storage map delta for the
+#!   requested slot index.
+export.get_account_delta_storage_map_ptr
+    mul.4 add.ACCOUNT_DELTA_STORGE_MAP_SECTION
 end
 
 #! Increments the delta of the account's nonce.

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -50,15 +50,14 @@ pub type StorageSlot = u8;
 //
 // Here the "end pointer" is the last memory pointer occupied by the current data
 //
-// For now each Storage Map pointer (a link map ptr) occupies a word in anticipation of the current
-// single element map ptr storing map metadata in the future.
+// For now each Storage Map pointer (a link map ptr) occupies a single element.
 //
 // | Section                      | Start address (word pointer) | End address (word pointer) | Comment                             |
 // | ---------------------------- | :--------------------------: | :------------------------: | ----------------------------------- |
 // | Nonce                        | 0 (0)                        | 3 (0)                      |                                     |
 // | Fungible Asset Delta Ptr     | 4 (1)                        | 7 (1)                      |                                     |
 // | Non-Fungible Asset Delta Ptr | 8 (2)                        | 11 (2)                     |                                     |
-// | Storage Map Delta Ptrs       | 12 (3)                       | 1031 (257)                 | Max 255 storage map deltas          |
+// | Storage Map Delta Ptrs       | 12 (3)                       | 267 (66)                   | Max 255 storage map deltas          |
 
 // RESERVED ACCOUNT STORAGE SLOTS
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -396,25 +396,25 @@ pub const OUTPUT_NOTE_ASSETS_OFFSET: MemoryOffset = 20;
 // LINK MAP
 // ------------------------------------------------------------------------------------------------
 
-/// The inclusive start of the link map dynamic memory range.
-pub const LINK_MAP_MEMORY_START_PTR: MemoryAddress = 33_554_448;
+/// The inclusive start of the link map dynamic memory region.
+pub const LINK_MAP_REGION_START_PTR: MemoryAddress = 33_554_448;
 
-/// The non-inclusive end of the link map dynamic memory range.
-pub const LINK_MAP_MEMORY_END_PTR: MemoryAddress = 67_108_864;
+/// The non-inclusive end of the link map dynamic memory region.
+pub const LINK_MAP_REGION_END_PTR: MemoryAddress = 67_108_864;
 
-/// LINK_MAP_MEMORY_START_PTR + the offset stored at this pointer defines the next entry pointer
-/// that will be allocated.
-pub const LINK_MAP_MEMORY_CURRENT_OFFSET: MemoryAddress = 33_554_432;
+/// [`LINK_MAP_REGION_START_PTR`] + the currently used size stored at this pointer defines the next
+/// entry pointer that will be allocated.
+pub const LINK_MAP_USED_MEMORY_SIZE: MemoryAddress = 33_554_432;
 
 /// The size of each map entry, i.e. four words.
 pub const LINK_MAP_ENTRY_SIZE: MemoryOffset = 16;
 
 const _: () = assert!(
-    LINK_MAP_MEMORY_START_PTR % LINK_MAP_ENTRY_SIZE == 0,
-    "link map start ptr should be aligned to entry size"
+    LINK_MAP_REGION_START_PTR % LINK_MAP_ENTRY_SIZE == 0,
+    "link map region start ptr should be aligned to entry size"
 );
 
 const _: () = assert!(
-    (LINK_MAP_MEMORY_END_PTR - LINK_MAP_MEMORY_START_PTR) % LINK_MAP_ENTRY_SIZE == 0,
+    (LINK_MAP_REGION_END_PTR - LINK_MAP_REGION_START_PTR) % LINK_MAP_ENTRY_SIZE == 0,
     "the link map memory range should cleanly contain a multiple of the entry size"
 );

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -28,7 +28,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_map_item
     digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item
-    digest!("0x67d2cdc3425e1f179fe36ada44e6f7369e6b8feb7e19ac7cbaf59a866e3c46a4"),
+    digest!("0x90a8ab37025dc40605b930f77056b441be481526dfe4e2c568f6562da4c14bfb"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
@@ -40,9 +40,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0xd5e40814c863b7629e02bff4e57aaf45a063e23e98e1f5db757b1ae907d04da6"),
+    digest!("0x51e63646b144f7b2b161a972673a8c2f8239631683430f4021350b0d47f9ddda"),
     // faucet_burn_asset
-    digest!("0x0f04b4d601dd58a973934e9bace4d57ac5ef2569b4f482b2f0357c0ee2055703"),
+    digest!("0xd8e3f9ec798307821cd4488163c6f29fc35f9afe2a30dd32b205970cccb914d3"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -28,21 +28,21 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_map_item
     digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item
-    digest!("0x83b71c280743a6e93a210a48e777eada90e17c27b2f83c485343ddccab3c56c2"),
+    digest!("0x24051d7ebee52e507f08a25a8783450c484a7c24e0efdeeda0cda92a7ba5654f"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x2e11ed064d99ed21fd7a91fa11bddb322ac5891df114b79b82606bed1f245ede"),
+    digest!("0x3951f89f09ad96d4bf78507c1ec6b922d285a8b4a6d817c14fff1672b771a51c"),
     // account_remove_asset
-    digest!("0xa07864cba75f80e7d392c30b87d792d66d3fbc31837bddae3fbd5f43aa6f3752"),
+    digest!("0x1ee8a1d32f1ea14cd906ca137891b4923f0989b86f31c01eba73b6652d385eeb"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0x14aa1b6602681a4863cbb95d573259f18e38856b448fbdc5d77f8abf389761cb"),
+    digest!("0xe3882d3b6492bda9d789138606e5eacbf5920579abf3ef2c568b240adaa8dab9"),
     // faucet_burn_asset
-    digest!("0x7022cca81527fbb7da6849d1c256c65fef3519f849ca57b50ead8e5db05eda97"),
+    digest!("0x4251d7d17ce88053b033126ce5f257e227a819366e345c9f40f843ac5161ace2"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -28,7 +28,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_map_item
     digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item
-    digest!("0x24051d7ebee52e507f08a25a8783450c484a7c24e0efdeeda0cda92a7ba5654f"),
+    digest!("0xf80099f801e0df43ecbdc81e44475f9af4cd5ca0ae1146437bf95bb184b4bcc5"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
@@ -40,9 +40,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0xe3882d3b6492bda9d789138606e5eacbf5920579abf3ef2c568b240adaa8dab9"),
+    digest!("0xbd1c06774963eae5fdd925cc07f6824e2747f019e4e5c723dc432e66eb5697cb"),
     // faucet_burn_asset
-    digest!("0x4251d7d17ce88053b033126ce5f257e227a819366e345c9f40f843ac5161ace2"),
+    digest!("0x7d9648b071e1edcb2bd79b696f1e1171e814667b6f2b937ef0b92ed57273a640"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,15 +32,15 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    digest!("0x3951f89f09ad96d4bf78507c1ec6b922d285a8b4a6d817c14fff1672b771a51c"),
+    digest!("0x2e11ed064d99ed21fd7a91fa11bddb322ac5891df114b79b82606bed1f245ede"),
     // account_remove_asset
-    digest!("0x1ee8a1d32f1ea14cd906ca137891b4923f0989b86f31c01eba73b6652d385eeb"),
+    digest!("0xa07864cba75f80e7d392c30b87d792d66d3fbc31837bddae3fbd5f43aa6f3752"),
     // account_get_balance
     digest!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0x464692b9a7b0966d295e1093f17e66bc7121ff3b264fa022c40a09dd1bab0cb2"),
+    digest!("0xd5e40814c863b7629e02bff4e57aaf45a063e23e98e1f5db757b1ae907d04da6"),
     // faucet_burn_asset
     digest!("0x0f04b4d601dd58a973934e9bace4d57ac5ef2569b4f482b2f0357c0ee2055703"),
     // faucet_get_total_fungible_asset_issuance

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -28,7 +28,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_get_map_item
     digest!("0xf751b0762e049923d31ec6fd18512254f307f22140a7daa40e71ae7577b03f67"),
     // account_set_map_item
-    digest!("0xf80099f801e0df43ecbdc81e44475f9af4cd5ca0ae1146437bf95bb184b4bcc5"),
+    digest!("0x67d2cdc3425e1f179fe36ada44e6f7369e6b8feb7e19ac7cbaf59a866e3c46a4"),
     // account_get_vault_root
     digest!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
@@ -40,9 +40,9 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // faucet_mint_asset
-    digest!("0xbd1c06774963eae5fdd925cc07f6824e2747f019e4e5c723dc432e66eb5697cb"),
+    digest!("0x464692b9a7b0966d295e1093f17e66bc7121ff3b264fa022c40a09dd1bab0cb2"),
     // faucet_burn_asset
-    digest!("0x7d9648b071e1edcb2bd79b696f1e1171e814667b6f2b937ef0b92ed57273a640"),
+    digest!("0x0f04b4d601dd58a973934e9bace4d57ac5ef2569b4f482b2f0357c0ee2055703"),
     // faucet_get_total_fungible_asset_issuance
     digest!("0xd2ee4bd330f989165ee2be0f121a4db916f95e58f6fd2d040d57672f2f0cef63"),
     // faucet_is_non_fungible_asset_issued

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -141,9 +141,9 @@ impl AccountDelta {
     ///     - For each key-value pair, sorted by key, whose new value is different from the previous
     ///       value in the map:
     ///       - Append `[KEY, NEW_VALUE]`.
-    ///     - Append `[[domain = 3, slot_idx, num_changed_entries, 0], 0, 0, 0, 0]` where slot_idx
-    ///       is the index of the slot and `num_changed_entries` is the number of changed key-value
-    ///       pairs in the map.
+    ///     - Append `[[domain = 3, slot_idx, num_changed_entries, 0], 0, 0, 0, 0]`, except if
+    ///       `num_changed_entries` is 0, where slot_idx is the index of the slot and
+    ///       `num_changed_entries` is the number of changed key-value pairs in the map.
     ///
     /// # Rationale
     ///

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -292,6 +292,9 @@ impl Deserializable for AccountStorageDelta {
 ///
 /// The differences are represented as leaf updates: a map of updated item key ([Digest]) to
 /// value ([Word]). For cleared items the value is [EMPTY_WORD].
+///
+/// The [`LinkMapKey`] wrapper is necessary to order the keys in the same way as the in-kernel
+/// account delta which uses a link map.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StorageMapDelta(BTreeMap<LinkMapKey<Digest>, Word>);
 

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -351,6 +351,11 @@ impl StorageMapDelta {
                 .chain(updated_leaves.into_iter().map(|(key, value)| (key.into(), value))),
         ))
     }
+
+    /// Consumes self and returns the underlying map.
+    pub fn into_map(self) -> BTreeMap<Digest, Word> {
+        self.0
+    }
 }
 
 /// Converts a [StorageMap] into a [StorageMapDelta] for initial delta construction.

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -10,8 +10,7 @@ use super::{
 };
 use crate::{
     Digest, EMPTY_WORD, Felt, ZERO,
-    account::{AccountStorage, StorageMap, StorageSlot},
-    transaction::LinkMapKey,
+    account::{AccountStorage, StorageMap, StorageSlot, delta::LinkMapKey},
 };
 
 // ACCOUNT STORAGE DELTA

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::{
     Digest, EMPTY_WORD, Felt, ZERO,
     account::{AccountStorage, StorageMap, StorageSlot},
+    transaction::LinkMapKey,
 };
 
 // ACCOUNT STORAGE DELTA
@@ -157,7 +158,7 @@ impl AccountStorageDelta {
                         }
 
                         for (key, value) in map_delta.entries() {
-                            elements.extend_from_slice(key.as_elements());
+                            elements.extend_from_slice(key.inner().as_elements());
                             elements.extend_from_slice(value);
                         }
 
@@ -292,11 +293,11 @@ impl Deserializable for AccountStorageDelta {
 /// The differences are represented as leaf updates: a map of updated item key ([Digest]) to
 /// value ([Word]). For cleared items the value is [EMPTY_WORD].
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct StorageMapDelta(BTreeMap<Digest, Word>);
+pub struct StorageMapDelta(BTreeMap<LinkMapKey<Digest>, Word>);
 
 impl StorageMapDelta {
     /// Creates a new storage map delta from the provided leaves.
-    pub fn new(map: BTreeMap<Digest, Word>) -> Self {
+    pub fn new(map: BTreeMap<LinkMapKey<Digest>, Word>) -> Self {
         Self(map)
     }
 
@@ -306,13 +307,13 @@ impl StorageMapDelta {
     }
 
     /// Returns a reference to the updated entries in this storage map delta.
-    pub fn entries(&self) -> &BTreeMap<Digest, Word> {
+    pub fn entries(&self) -> &BTreeMap<LinkMapKey<Digest>, Word> {
         &self.0
     }
 
     /// Inserts an item into the storage map delta.
     pub fn insert(&mut self, key: Digest, value: Word) {
-        self.0.insert(key, value);
+        self.0.insert(LinkMapKey::new(key), value);
     }
 
     /// Returns true if storage map delta contains no updates.
@@ -328,12 +329,21 @@ impl StorageMapDelta {
 
     /// Returns an iterator of all the cleared keys in the storage map.
     fn cleared_keys(&self) -> impl Iterator<Item = &Digest> + '_ {
-        self.0.iter().filter(|&(_, value)| value == &EMPTY_WORD).map(|(key, _)| key)
+        self.0
+            .iter()
+            .filter(|&(_, value)| value == &EMPTY_WORD)
+            .map(|(key, _)| key.inner())
     }
 
     /// Returns an iterator of all the updated entries in the storage map.
     fn updated_entries(&self) -> impl Iterator<Item = (&Digest, &Word)> + '_ {
-        self.0.iter().filter(|&(_, value)| value != &EMPTY_WORD)
+        self.0.iter().filter_map(|(key, value)| {
+            if value != &EMPTY_WORD {
+                Some((key.inner(), value))
+            } else {
+                None
+            }
+        })
     }
 }
 
@@ -347,13 +357,17 @@ impl StorageMapDelta {
         Self(BTreeMap::from_iter(
             cleared_leaves
                 .into_iter()
-                .map(|key| (key.into(), EMPTY_WORD))
-                .chain(updated_leaves.into_iter().map(|(key, value)| (key.into(), value))),
+                .map(|key| (LinkMapKey::new(Digest::from(key)), EMPTY_WORD))
+                .chain(
+                    updated_leaves
+                        .into_iter()
+                        .map(|(key, value)| (LinkMapKey::new(Digest::from(key)), value)),
+                ),
         ))
     }
 
     /// Consumes self and returns the underlying map.
-    pub fn into_map(self) -> BTreeMap<Digest, Word> {
+    pub fn into_map(self) -> BTreeMap<LinkMapKey<Digest>, Word> {
         self.0
     }
 }
@@ -361,7 +375,12 @@ impl StorageMapDelta {
 /// Converts a [StorageMap] into a [StorageMapDelta] for initial delta construction.
 impl From<StorageMap> for StorageMapDelta {
     fn from(map: StorageMap) -> Self {
-        StorageMapDelta::new(map.into_entries())
+        StorageMapDelta::new(
+            map.into_entries()
+                .into_iter()
+                .map(|(key, value)| (LinkMapKey::new(key), value))
+                .collect(),
+        )
     }
 }
 
@@ -400,13 +419,13 @@ impl Deserializable for StorageMapDelta {
         let cleared_count = source.read_usize()?;
         for _ in 0..cleared_count {
             let cleared_key = source.read()?;
-            map.insert(cleared_key, EMPTY_WORD);
+            map.insert(LinkMapKey::new(cleared_key), EMPTY_WORD);
         }
 
         let updated_count = source.read_usize()?;
         for _ in 0..updated_count {
             let (updated_key, updated_value) = source.read()?;
-            map.insert(updated_key, updated_value);
+            map.insert(LinkMapKey::new(updated_key), updated_value);
         }
 
         Ok(Self::new(map))

--- a/crates/miden-objects/src/account/storage/map.rs
+++ b/crates/miden-objects/src/account/storage/map.rs
@@ -165,7 +165,7 @@ impl StorageMap {
     pub fn apply_delta(&mut self, delta: &StorageMapDelta) -> Digest {
         // apply the updated and cleared leaves to the storage map
         for (&key, &value) in delta.entries().iter() {
-            self.insert(key, value);
+            self.insert(key.into_inner(), value);
         }
 
         self.root()

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -614,7 +614,7 @@ mod tests {
         testing::account_id::{
             ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
         },
-        transaction::{ProvenTransactionBuilder, TxAccountUpdate},
+        transaction::{LinkMapKey, ProvenTransactionBuilder, TxAccountUpdate},
         utils::Serializable,
     };
 
@@ -667,7 +667,7 @@ mod tests {
         // 32 bytes in size.
         let required_entries = ACCOUNT_UPDATE_MAX_SIZE / (2 * 32);
         for _ in 0..required_entries {
-            map.insert(Digest::new(rand_array()), rand_array());
+            map.insert(LinkMapKey::new(Digest::new(rand_array())), rand_array());
         }
         let storage_delta = StorageMapDelta::new(map);
 

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -608,13 +608,14 @@ mod tests {
         ACCOUNT_UPDATE_MAX_SIZE, Digest, EMPTY_WORD, ONE, ProvenTransactionError, ZERO,
         account::{
             AccountDelta, AccountId, AccountIdVersion, AccountStorageDelta, AccountStorageMode,
-            AccountType, AccountVaultDelta, StorageMapDelta, delta::AccountUpdateDetails,
+            AccountType, AccountVaultDelta, StorageMapDelta,
+            delta::{AccountUpdateDetails, LinkMapKey},
         },
         block::BlockNumber,
         testing::account_id::{
             ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
         },
-        transaction::{LinkMapKey, ProvenTransactionBuilder, TxAccountUpdate},
+        transaction::{ProvenTransactionBuilder, TxAccountUpdate},
         utils::Serializable,
     };
 

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -609,7 +609,7 @@ mod tests {
         account::{
             AccountDelta, AccountId, AccountIdVersion, AccountStorageDelta, AccountStorageMode,
             AccountType, AccountVaultDelta, StorageMapDelta,
-            delta::{AccountUpdateDetails, LinkMapKey},
+            delta::{AccountUpdateDetails, LexicographicWord},
         },
         block::BlockNumber,
         testing::account_id::{
@@ -668,7 +668,7 @@ mod tests {
         // 32 bytes in size.
         let required_entries = ACCOUNT_UPDATE_MAX_SIZE / (2 * 32);
         for _ in 0..required_entries {
-            map.insert(LinkMapKey::new(Digest::new(rand_array())), rand_array());
+            map.insert(LexicographicWord::new(Digest::new(rand_array())), rand_array());
         }
         let storage_delta = StorageMapDelta::new(map);
 

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -9,7 +9,10 @@ use miden_lib::{
 };
 use miden_objects::{
     Felt, FieldElement, MIN_PROOF_SECURITY_LEVEL, Word,
-    account::{Account, AccountBuilder, AccountComponent, AccountId, AccountStorage, StorageSlot},
+    account::{
+        Account, AccountBuilder, AccountComponent, AccountId, AccountStorage, StorageSlot,
+        delta::LinkMapKey,
+    },
     assembly::diagnostics::{IntoDiagnostic, NamedSource, WrapErr, miette},
     asset::{Asset, AssetVault, FungibleAsset, NonFungibleAsset},
     note::{
@@ -27,7 +30,7 @@ use miden_objects::{
         note::{DEFAULT_NOTE_CODE, NoteBuilder},
         storage::{STORAGE_INDEX_0, STORAGE_INDEX_2},
     },
-    transaction::{LinkMapKey, OutputNote, ProvenTransaction, TransactionScript},
+    transaction::{OutputNote, ProvenTransaction, TransactionScript},
 };
 use miden_tx::{
     LocalTransactionProver, NoteAccountExecution, NoteConsumptionChecker, ProvingOptions,

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -1,9 +1,4 @@
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    string::String,
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
 
 use anyhow::Context;
 use assert_matches::assert_matches;
@@ -32,7 +27,7 @@ use miden_objects::{
         note::{DEFAULT_NOTE_CODE, NoteBuilder},
         storage::{STORAGE_INDEX_0, STORAGE_INDEX_2},
     },
-    transaction::{OutputNote, ProvenTransaction, TransactionScript},
+    transaction::{LinkMapKey, OutputNote, ProvenTransaction, TransactionScript},
 };
 use miden_tx::{
     LocalTransactionProver, NoteAccountExecution, NoteConsumptionChecker, ProvingOptions,
@@ -312,17 +307,16 @@ fn executed_transaction_account_delta_new() {
     );
 
     assert_eq!(executed_transaction.account_delta().storage().maps().len(), 1);
+    let map_delta = executed_transaction
+        .account_delta()
+        .storage()
+        .maps()
+        .get(&STORAGE_INDEX_2)
+        .unwrap()
+        .entries();
     assert_eq!(
-        executed_transaction
-            .account_delta()
-            .storage()
-            .maps()
-            .get(&STORAGE_INDEX_2)
-            .unwrap()
-            .entries(),
-        &Some((updated_map_key.into(), updated_map_value))
-            .into_iter()
-            .collect::<BTreeMap<Digest, _>>()
+        *map_delta.get(&LinkMapKey::new(Digest::from(updated_map_key))).unwrap(),
+        updated_map_value
     );
 
     // vault delta

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -11,7 +11,7 @@ use miden_objects::{
     Felt, FieldElement, MIN_PROOF_SECURITY_LEVEL, Word,
     account::{
         Account, AccountBuilder, AccountComponent, AccountId, AccountStorage, StorageSlot,
-        delta::LinkMapKey,
+        delta::LexicographicWord,
     },
     assembly::diagnostics::{IntoDiagnostic, NamedSource, WrapErr, miette},
     asset::{Asset, AssetVault, FungibleAsset, NonFungibleAsset},
@@ -318,7 +318,7 @@ fn executed_transaction_account_delta_new() {
         .unwrap()
         .entries();
     assert_eq!(
-        *map_delta.get(&LinkMapKey::new(Digest::from(updated_map_key))).unwrap(),
+        *map_delta.get(&LexicographicWord::new(Digest::from(updated_map_key))).unwrap(),
         updated_map_value
     );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -4,19 +4,12 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
-        AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
-        StorageSlot,
-    },
-    asset::{Asset, FungibleAsset},
-    note::{Note, NoteType},
-    testing::{
+        AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType, StorageMap, StorageSlot
+    }, asset::{Asset, FungibleAsset}, note::{Note, NoteType}, testing::{
         account_component::AccountMockComponent, account_id::AccountIdBuilder,
         asset::NonFungibleAssetBuilder,
-    },
-    transaction::{ExecutedTransaction, TransactionScript},
-    vm::AdviceMap,
+    }, transaction::{ExecutedTransaction, LinkMapKey, TransactionScript}, vm::AdviceMap, Digest, Felt, Hasher, Word, EMPTY_WORD
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};
 use rand::Rng;
@@ -138,6 +131,118 @@ fn storage_delta_for_value_slots() -> anyhow::Result<()> {
 
     // Note that slot 2 is absent because its value hasn't changed.
     assert_eq!(storage_values_delta, &[(0u8, slot_0_final_value), (1u8, slot_1_final_value)]);
+
+    validate_account_delta(&executed_tx).context("failed to validate delta")?;
+
+    Ok(())
+}
+
+/// Tests that setting new values for value storage slots results in the correct delta.
+/// - Slot 0: key0: EMPTY_WORD -> [1,2,3,4]              -> Delta: [1,2,3,4]
+/// - Slot 0: key1: EMPTY_WORD -> [1,2,3,4] -> [2,3,4,5] -> Delta: [2,3,4,5]
+/// - Slot 1: key2: [1,2,3,4]  -> [1,2,3,4]              -> Delta: None
+/// - Slot 1: key3: [1,2,3,4]  -> EMPTY_WORD             -> Delta: EMPTY_WORD
+/// - TODO (once account delta tracker is updated):
+///   - Slot 1: key4: [1,2,3,4]  -> [2,3,4,5] -> [1,2,3,4] -> Delta: None
+#[test]
+fn storage_delta_for_map_slots() -> anyhow::Result<()> {
+    // Test with random keys to make sure the ordering in the MASM and Rust implementations
+    // matches.
+    let key0 = Digest::from(word(winter_rand_utils::rand_array()));
+    let key1 = Digest::from(word(winter_rand_utils::rand_array()));
+    let key2 = Digest::from(word(winter_rand_utils::rand_array()));
+    let key3 = Digest::from(word(winter_rand_utils::rand_array()));
+
+    let key0_init_value = EMPTY_WORD;
+    let key1_init_value = EMPTY_WORD;
+    let key2_init_value = word([1, 2, 3, 4u32]);
+    let key3_init_value = word([1, 2, 3, 4u32]);
+
+    let key0_final_value = word([1, 2, 3, 4u32]);
+    let key1_tmp_value = word([1, 2, 3, 4u32]);
+    let key1_final_value = word([2, 3, 4, 5u32]);
+    let key2_final_value = key2_init_value;
+    let key3_final_value = EMPTY_WORD;
+
+    let mut map0 = StorageMap::new();
+    map0.insert(key0, key0_init_value);
+    map0.insert(key1, key1_init_value);
+
+    let mut map1 = StorageMap::new();
+    map1.insert(key2, key2_init_value);
+    map1.insert(key3, key3_init_value);
+
+    let TestSetup { mock_chain, account_id } = setup_storage_test(vec![
+        StorageSlot::Map(map0),
+        StorageSlot::Map(map1),
+        // Include an empty map which does not receive any updates, to test that the "metadata
+        // header" in the delta commitemnt is not appended if there are no updates to a map
+        // slot.
+        StorageSlot::Map(StorageMap::new()),
+    ]);
+
+    let tx_script = compile_tx_script(format!(
+        "
+      begin
+          push.{key0_value}.{key0}.0
+          # => [index, KEY, VALUE]
+          exec.set_map_item
+          # => []
+
+          push.{key1_tmp_value}.{key1}.0
+          # => [index, KEY, VALUE]
+          exec.set_map_item
+          # => []
+
+          push.{key1_value}.{key1}.0
+          # => [index, KEY, VALUE]
+          exec.set_map_item
+          # => []
+
+          push.{key2_value}.{key2}.1
+          # => [index, KEY, VALUE]
+          exec.set_map_item
+          # => []
+
+          push.{key3_value}.{key3}.1
+          # => [index, KEY, VALUE]
+          exec.set_map_item
+          # => []
+
+          # nonce must increase for state changing transactions
+          push.1 exec.incr_nonce
+      end
+      ",
+        key0 = word_to_masm_push_string(&key0),
+        key1 = word_to_masm_push_string(&key1),
+        key2 = word_to_masm_push_string(&key2),
+        key3 = word_to_masm_push_string(&key3),
+        key0_value = word_to_masm_push_string(&key0_final_value),
+        key1_tmp_value = word_to_masm_push_string(&key1_tmp_value),
+        key1_value = word_to_masm_push_string(&key1_final_value),
+        key2_value = word_to_masm_push_string(&key2_final_value),
+        key3_value = word_to_masm_push_string(&key3_final_value),
+    ))?;
+
+    let executed_tx = mock_chain
+        .build_tx_context(account_id, &[], &[])
+        .tx_script(tx_script)
+        .build()
+        .execute()
+        .context("failed to execute transaction")?;
+    let maps_delta = executed_tx.account_delta().storage().maps();
+
+    let mut map0_delta =
+        maps_delta.get(&0).expect("delta for map 0 should exist").clone().into_map();
+    let mut map1_delta =
+        maps_delta.get(&1).expect("delta for map 1 should exist").clone().into_map();
+
+    assert_eq!(map0_delta.len(), 2);
+    assert_eq!(map0_delta.remove(&LinkMapKey::new(key0)).unwrap(), key0_final_value);
+    assert_eq!(map0_delta.remove(&LinkMapKey::new(key1)).unwrap(), key1_final_value);
+
+    assert_eq!(map1_delta.len(), 1);
+    assert_eq!(map1_delta.remove(&LinkMapKey::new(key3)).unwrap(), key3_final_value);
 
     validate_account_delta(&executed_tx).context("failed to validate delta")?;
 
@@ -511,6 +616,19 @@ const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
           # => [OLD_VALUE, pad(12)]
 
           dropw dropw dropw dropw
+      end
+
+      #! Inputs:  [index, KEY, VALUE]
+      #! Outputs: []
+      proc.set_map_item
+          repeat.7 push.0 movdn.9 end
+          # => [index, KEY, VALUE, pad(7)]
+
+          call.account::set_map_item
+          # => [OLD_MAP_ROOT, OLD_MAP_VALUE, pad(8)]
+
+          dropw dropw dropw dropw
+          # => []
       end
 
       #! Inputs:  [ASSET]

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -4,12 +4,19 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
+    Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
-        AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType, StorageMap, StorageSlot
-    }, asset::{Asset, FungibleAsset}, note::{Note, NoteType}, testing::{
+        AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
+        StorageMap, StorageSlot,
+    },
+    asset::{Asset, FungibleAsset},
+    note::{Note, NoteType},
+    testing::{
         account_component::AccountMockComponent, account_id::AccountIdBuilder,
         asset::NonFungibleAssetBuilder,
-    }, transaction::{ExecutedTransaction, LinkMapKey, TransactionScript}, vm::AdviceMap, Digest, Felt, Hasher, Word, EMPTY_WORD
+    },
+    transaction::{ExecutedTransaction, LinkMapKey, TransactionScript},
+    vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};
 use rand::Rng;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
-        StorageMap, StorageSlot,
+        StorageMap, StorageSlot, delta::LinkMapKey,
     },
     asset::{Asset, FungibleAsset},
     note::{Note, NoteType},
@@ -15,7 +15,7 @@ use miden_objects::{
         account_component::AccountMockComponent, account_id::AccountIdBuilder,
         asset::NonFungibleAssetBuilder,
     },
-    transaction::{ExecutedTransaction, LinkMapKey, TransactionScript},
+    transaction::{ExecutedTransaction, TransactionScript},
     vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
-        StorageMap, StorageSlot, delta::LinkMapKey,
+        StorageMap, StorageSlot, delta::LexicographicWord,
     },
     asset::{Asset, FungibleAsset},
     note::{Note, NoteType},
@@ -245,11 +245,11 @@ fn storage_delta_for_map_slots() -> anyhow::Result<()> {
         maps_delta.get(&1).expect("delta for map 1 should exist").clone().into_map();
 
     assert_eq!(map0_delta.len(), 2);
-    assert_eq!(map0_delta.remove(&LinkMapKey::new(key0)).unwrap(), key0_final_value);
-    assert_eq!(map0_delta.remove(&LinkMapKey::new(key1)).unwrap(), key1_final_value);
+    assert_eq!(map0_delta.remove(&LexicographicWord::new(key0)).unwrap(), key0_final_value);
+    assert_eq!(map0_delta.remove(&LexicographicWord::new(key1)).unwrap(), key1_final_value);
 
     assert_eq!(map1_delta.len(), 1);
-    assert_eq!(map1_delta.remove(&LinkMapKey::new(key3)).unwrap(), key3_final_value);
+    assert_eq!(map1_delta.remove(&LexicographicWord::new(key3)).unwrap(), key3_final_value);
 
     validate_account_delta(&executed_tx).context("failed to validate delta")?;
 

--- a/crates/miden-tx/src/host/link_map.rs
+++ b/crates/miden-tx/src/host/link_map.rs
@@ -32,9 +32,7 @@ impl<'process> LinkMap<'process> {
 
     /// Creates a new link map from the provided map_ptr in the provided process.
     pub fn new(map_ptr: Felt, process: ProcessState<'process>) -> Self {
-        let map_ptr = map_ptr.try_into().expect("map_ptr must be a valid u32");
-        // This assumes map_ptr comes from a trusted source and is not user-supplied.
-        assert!(map_ptr % miden_objects::WORD_SIZE as u32 == 0, "map_ptr must be word-aligned");
+        let map_ptr: u32 = map_ptr.try_into().expect("map_ptr must be a valid u32");
 
         Self { map_ptr, process }
     }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -325,6 +325,14 @@ impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
             process.get_stack_item(1),
         ];
 
+        // get the previous VALUE of the slot
+        let prev_map_value = [
+            process.get_stack_item(8),
+            process.get_stack_item(7),
+            process.get_stack_item(6),
+            process.get_stack_item(5),
+        ];
+
         // get the VALUE to which the slot is being updated
         let new_map_value = [
             process.get_stack_item(12),
@@ -334,11 +342,13 @@ impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
         ];
 
         let slot_index = slot_index.as_int() as u8;
-        self.account_delta.storage_delta().set_map_item(
-            slot_index,
-            new_map_key.into(),
-            new_map_value,
-        );
+        if new_map_value != prev_map_value {
+            self.account_delta.storage_delta().set_map_item(
+                slot_index,
+                new_map_key.into(),
+                new_map_value,
+            );
+        }
 
         Ok(())
     }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -327,10 +327,10 @@ impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
 
         // get the VALUE to which the slot is being updated
         let new_map_value = [
-            process.get_stack_item(8),
-            process.get_stack_item(7),
-            process.get_stack_item(6),
-            process.get_stack_item(5),
+            process.get_stack_item(12),
+            process.get_stack_item(11),
+            process.get_stack_item(10),
+            process.get_stack_item(9),
         ];
 
         let slot_index = slot_index.as_int() as u8;


### PR DESCRIPTION
Implement in-kernel account delta for storage maps.

Main Changes:
- Use `LexicographicWord` in `StorageMapDelta` to sort keys in the storage map deltas in the same way in Rust and in-kernel.
- Don't insert a key-value pair into the storage map delta if prev_value == new_value, which normalizes account deltas in the simplest case. This is addressed more holistically in #1496.
- Implement storage map deltas.
- Update delta commitment hasher state with changed storage map entries.

part of #1198