### PR TITLE
Refactor account delta nonce from `Option<Felt>` to `Felt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [BREAKING] Implemented in-kernel account delta tracking (#1471, #1404, #1460, #1481, #1491).
 - [BREAKING] Store account ID in account delta (#1493).
 - [BREAKING] Remove P2IDR and replace with P2IDE (#1483).
+- [BREAKING] Refactor nonce in delta from `Option<Felt>` to `Felt` (#1492).
 - Added `Note::is_network_note()` accessor (#1485).
 - [BREAKING] Update handling of the shared modules (#1490).
 - Added a new constructor for `TransactionExecutor` that accepts `ExecutionOptions` (#1502).

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -22,7 +22,7 @@ pub type StorageSlot = u8;
 // | Partial blockchain | 1_200 (300)                           | 1_331? (332?)                       |                                             |
 // | Kernel data        | 1_600 (400)                           | 1_739 (434)                         | 34 procedures in total, 4 elements each     |
 // | Accounts data      | 8_192 (2048)                          | 532_479 (133_119)                   | 64 accounts max, 8192 elements each         |
-// | Account delta      | 532_480 (133_120)                     | 533_511 (133_377)                   |                                             |
+// | Account delta      | 532_480 (133_120)                     | 532_746 (133_186)                   |                                             |
 // | Input notes        | 4_194_304 (1_048_576)                 | ?                                   |                                             |
 // | Output notes       | 16_777_216 (4_194_304)                | ?                                   |                                             |
 // | Link Map Memory    | 33_554_432 (8_388_608)                | 67_108_863 (16_777_215)               | Enough for 2_097_151 key-value pairs        |

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -22,7 +22,7 @@ pub type StorageSlot = u8;
 // | Partial blockchain | 1_200 (300)                           | 1_331? (332?)                       |                                             |
 // | Kernel data        | 1_600 (400)                           | 1_739 (434)                         | 34 procedures in total, 4 elements each     |
 // | Accounts data      | 8_192 (2048)                          | 532_479 (133_119)                   | 64 accounts max, 8192 elements each         |
-// | Account delta      | 532_480 (133_120)                     | TODO (TODO)                         |                                             |
+// | Account delta      | 532_480 (133_120)                     | 533_511 (133_377)                   |                                             |
 // | Input notes        | 4_194_304 (1_048_576)                 | ?                                   |                                             |
 // | Output notes       | 16_777_216 (4_194_304)                | ?                                   |                                             |
 // | Link Map Memory    | 33_554_432 (8_388_608)                | 67_108_863 (16_777_215)               | Enough for 2_097_151 key-value pairs        |

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -4,7 +4,7 @@ use super::{
     Account, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Serializable,
     Word, ZERO,
 };
-use crate::{AccountDeltaError, Digest, EMPTY_WORD, Hasher, ONE, account::AccountId};
+use crate::{AccountDeltaError, Digest, EMPTY_WORD, Hasher, account::AccountId};
 
 mod lexicographic_word;
 pub use lexicographic_word::LexicographicWord;
@@ -331,31 +331,6 @@ impl AccountUpdateDetails {
             AccountUpdateDetails::Private => "private",
             AccountUpdateDetails::New(_) => "new",
             AccountUpdateDetails::Delta(_) => "delta",
-        }
-    }
-}
-
-/// Converts an [Account] into an [AccountDelta] for initial delta construction.
-///
-/// TODO: This is unused; should we remove it?
-impl From<Account> for AccountDelta {
-    fn from(account: Account) -> Self {
-        let (_id, vault, storage, _code, _nonce) = account.into_parts();
-
-        let storage_delta = AccountStorageDelta::from(storage);
-        let vault_delta = AccountVaultDelta::from(&vault);
-
-        let nonce_increment = if !storage_delta.is_empty() || !vault_delta.is_empty() {
-            ONE
-        } else {
-            ZERO
-        };
-
-        AccountDelta {
-            account_id: _id,
-            storage: storage_delta,
-            vault: vault_delta,
-            nonce_increment,
         }
     }
 }

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -420,11 +420,11 @@ impl Deserializable for AccountUpdateDetails {
 /// Returns an error if:
 /// - storage or vault were updated, but the nonce_increment was set to 0.
 fn validate_nonce(
-    nonce: Felt,
+    nonce_increment: Felt,
     storage: &AccountStorageDelta,
     vault: &AccountVaultDelta,
 ) -> Result<(), AccountDeltaError> {
-    if (!storage.is_empty() || !vault.is_empty()) && nonce == ZERO {
+    if (!storage.is_empty() || !vault.is_empty()) && nonce_increment == ZERO {
         return Err(AccountDeltaError::InconsistentNonceUpdate(
             "nonce not updated for non-empty account delta".into(),
         ));

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -61,7 +61,12 @@ impl AccountDelta {
         // nonce must be updated if either account storage or vault were updated
         validate_nonce(nonce_increment, &storage, &vault)?;
 
-        Ok(Self {account_id, storage, vault, nonce_increment })
+        Ok(Self {
+            account_id,
+            storage,
+            vault,
+            nonce_increment,
+        })
     }
 
     /// Merge another [AccountDelta] into this one.
@@ -362,7 +367,12 @@ impl Deserializable for AccountDelta {
         validate_nonce(nonce_increment, &storage, &vault)
             .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
 
-        Ok(Self { account_id, storage, vault, nonce_increment })
+        Ok(Self {
+            account_id,
+            storage,
+            vault,
+            nonce_increment,
+        })
     }
 }
 
@@ -459,8 +469,8 @@ mod tests {
         let storage_delta = AccountStorageDelta::new();
         let vault_delta = AccountVaultDelta::default();
 
-        AccountDelta::new(account_id,storage_delta.clone(), vault_delta.clone(), ZERO).unwrap();
-        AccountDelta::new(account_id,storage_delta.clone(), vault_delta.clone(), ONE).unwrap();
+        AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ZERO).unwrap();
+        AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ONE).unwrap();
 
         // non-empty delta
         let storage_delta = AccountStorageDelta::from_iters([1], [], []);
@@ -511,7 +521,8 @@ mod tests {
         assert_eq!(storage_delta.to_bytes().len(), storage_delta.get_size_hint());
         assert_eq!(vault_delta.to_bytes().len(), vault_delta.get_size_hint());
 
-        let account_delta = AccountDelta::new(account_id, storage_delta, vault_delta, ZERO).unwrap();
+        let account_delta =
+            AccountDelta::new(account_id, storage_delta, vault_delta, ZERO).unwrap();
         assert_eq!(account_delta.to_bytes().len(), account_delta.get_size_hint());
 
         let storage_delta = AccountStorageDelta::from_iters(

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -8,7 +8,8 @@ use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError,
     LexicographicWord, Serializable, Word,
 };
-use crate::{Digest, EMPTY_WORD, Felt, ZERO, account::StorageMap, transaction::LinkMapKey};
+use crate::{Digest, EMPTY_WORD, Felt, ZERO, account::StorageMap};
+
 // ACCOUNT STORAGE DELTA
 // ================================================================================================
 

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -10,7 +10,8 @@ use super::{
 };
 use crate::{
     Digest, EMPTY_WORD, Felt, ZERO,
-    account::{AccountStorage, StorageMap, StorageSlot},
+    account::StorageMap,
+    transaction::LinkMapKey,
 };
 
 // ACCOUNT STORAGE DELTA
@@ -199,27 +200,6 @@ impl AccountStorageDelta {
             ),
             maps: BTreeMap::from_iter(updated_maps),
         }
-    }
-}
-
-/// Converts an [AccountStorage] into an [AccountStorageDelta] for initial delta construction.
-impl From<AccountStorage> for AccountStorageDelta {
-    fn from(storage: AccountStorage) -> Self {
-        let mut values = BTreeMap::new();
-        let mut maps = BTreeMap::new();
-        for (slot_idx, slot) in storage.into_iter().enumerate() {
-            let slot_idx: u8 = slot_idx.try_into().expect("slot index must fit into `u8`");
-            match slot {
-                StorageSlot::Value(value) => {
-                    values.insert(slot_idx, value);
-                },
-                StorageSlot::Map(map) => {
-                    maps.insert(slot_idx, map.into());
-                },
-            }
-        }
-
-        Self { values, maps }
     }
 }
 

--- a/crates/miden-objects/src/account/delta/storage.rs
+++ b/crates/miden-objects/src/account/delta/storage.rs
@@ -8,12 +8,7 @@ use super::{
     AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError,
     LexicographicWord, Serializable, Word,
 };
-use crate::{
-    Digest, EMPTY_WORD, Felt, ZERO,
-    account::StorageMap,
-    transaction::LinkMapKey,
-};
-
+use crate::{Digest, EMPTY_WORD, Felt, ZERO, account::StorageMap, transaction::LinkMapKey};
 // ACCOUNT STORAGE DELTA
 // ================================================================================================
 

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -5,13 +5,13 @@ use alloc::{
 };
 
 use super::{
-    AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError,
+    LexicographicWord, Serializable,
 };
 use crate::{
     Felt, ONE, Word, ZERO,
     account::{AccountId, AccountType},
     asset::{Asset, FungibleAsset, NonFungibleAsset},
-    transaction::LinkMapKey,
 };
 
 // ACCOUNT VAULT DELTA

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -9,8 +9,9 @@ use super::{
 };
 use crate::{
     Felt, ONE, Word, ZERO,
-    account::{AccountId, AccountType, delta::LexicographicWord},
-    asset::{Asset, AssetVault, FungibleAsset, NonFungibleAsset},
+    account::{AccountId, AccountType},
+    asset::{Asset, FungibleAsset, NonFungibleAsset},
+    transaction::LinkMapKey,
 };
 
 // ACCOUNT VAULT DELTA
@@ -156,35 +157,6 @@ impl AccountVaultDelta {
             .chain(self.non_fungible.filter_by_action(NonFungibleDeltaAction::Remove).map(|key| {
                 Asset::NonFungible(unsafe { NonFungibleAsset::new_unchecked(key.into()) })
             }))
-    }
-}
-
-impl From<&AssetVault> for AccountVaultDelta {
-    fn from(vault: &AssetVault) -> Self {
-        let mut fungible = BTreeMap::new();
-        let mut non_fungible = BTreeMap::new();
-
-        for asset in vault.assets() {
-            match asset {
-                Asset::Fungible(asset) => {
-                    fungible.insert(
-                        asset.faucet_id(),
-                        asset
-                            .amount()
-                            .try_into()
-                            .expect("asset amount should be at most i64::MAX by construction"),
-                    );
-                },
-                Asset::NonFungible(asset) => {
-                    non_fungible.insert(LexicographicWord::new(asset), NonFungibleDeltaAction::Add);
-                },
-            }
-        }
-
-        Self {
-            fungible: FungibleAssetDelta(fungible),
-            non_fungible: NonFungibleAssetDelta::new(non_fungible),
-        }
     }
 }
 

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -285,7 +285,7 @@ impl Account {
         Ok(())
     }
 
-    /// Sets the nonce of this account to the specified nonce value.
+    /// Increments the nonce of this account by the provided increment.
     ///
     /// # Errors
     ///

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -280,9 +280,7 @@ impl Account {
         self.storage.apply_delta(delta.storage())?;
 
         // update nonce
-        if let Some(nonce_delta) = delta.nonce() {
-            self.set_nonce(self.nonce() + nonce_delta)?;
-        }
+        self.increment_nonce(delta.nonce_increment())?;
 
         Ok(())
     }
@@ -290,18 +288,21 @@ impl Account {
     /// Sets the nonce of this account to the specified nonce value.
     ///
     /// # Errors
+    ///
     /// Returns an error if:
-    /// - The new nonce is smaller than the actual account nonce
-    /// - The new nonce is equal to the actual account nonce
-    pub fn set_nonce(&mut self, nonce: Felt) -> Result<(), AccountError> {
-        if self.nonce.as_int() >= nonce.as_int() {
-            return Err(AccountError::NonceNotMonotonicallyIncreasing {
-                current: self.nonce.as_int(),
-                new: nonce.as_int(),
+    /// - The new nonce is smaller than the current account nonce.
+    fn increment_nonce(&mut self, nonce_increment: Felt) -> Result<(), AccountError> {
+        let new_nonce = self.nonce + nonce_increment;
+
+        if new_nonce.as_int() < self.nonce.as_int() {
+            return Err(AccountError::NonceOverflow {
+                current: self.nonce,
+                increment: nonce_increment,
+                new: new_nonce,
             });
         }
 
-        self.nonce = nonce;
+        self.nonce = new_nonce;
 
         Ok(())
     }
@@ -448,7 +449,7 @@ mod tests {
     #[test]
     fn test_serde_account_delta() {
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-        let final_nonce = Felt::new(2);
+        let nonce_increment = Felt::new(2);
         let asset_0 = FungibleAsset::mock(15);
         let asset_1 = NonFungibleAsset::mock(&[5, 5, 5]);
         let storage_delta = AccountStorageDeltaBuilder::new()
@@ -460,7 +461,7 @@ mod tests {
             account_id,
             vec![asset_1],
             vec![asset_0],
-            final_nonce,
+            nonce_increment,
             storage_delta,
         );
 
@@ -601,12 +602,12 @@ mod tests {
         let mut account = build_account(vec![], init_nonce, vec![storage_slot]);
 
         // build account delta
-        let final_nonce = Felt::new(2);
+        let nonce_increment = Felt::new(1);
         let account_delta = AccountDelta::new(
             account_id,
             AccountStorageDelta::new(),
             AccountVaultDelta::default(),
-            Some(final_nonce),
+            nonce_increment,
         )
         .unwrap();
 
@@ -618,11 +619,11 @@ mod tests {
         account_id: AccountId,
         added_assets: Vec<Asset>,
         removed_assets: Vec<Asset>,
-        nonce: Felt,
+        nonce_increment: Felt,
         storage_delta: AccountStorageDelta,
     ) -> AccountDelta {
         let vault_delta = AccountVaultDelta::from_iters(added_assets, removed_assets);
-        AccountDelta::new(account_id, storage_delta, vault_delta, Some(nonce)).unwrap()
+        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_increment).unwrap()
     }
 
     pub fn build_account(assets: Vec<Asset>, nonce: Felt, slots: Vec<StorageSlot>) -> Account {

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -290,7 +290,7 @@ impl Account {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - The new nonce is smaller than the current account nonce.
+    /// - Incrementing the nonce overflows a [`Felt`].
     fn increment_nonce(&mut self, nonce_increment: Felt) -> Result<(), AccountError> {
         let new_nonce = self.nonce + nonce_increment;
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -245,8 +245,16 @@ pub enum AccountDeltaError {
         account_id: AccountId,
         source: AccountError,
     },
-    #[error("inconsistent nonce update: {0}")]
-    InconsistentNonceUpdate(Box<str>),
+    #[error("zero nonce is not allowed for non-empty account deltas")]
+    ZeroNonceForNonEmptyDelta,
+    #[error(
+        "current account nonce increment {current} plus the other nonce increment {increment} overflows a felt to {new}"
+    )]
+    NonceOverflow {
+        current: Felt,
+        increment: Felt,
+        new: Felt,
+    },
     #[error("account ID {0} in fungible asset delta is not of type fungible faucet")]
     NotAFungibleFaucetId(AccountId),
 }

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -248,9 +248,9 @@ pub enum AccountDeltaError {
     #[error("zero nonce is not allowed for non-empty account deltas")]
     ZeroNonceForNonEmptyDelta,
     #[error(
-        "current account nonce increment {current} plus the other nonce increment {increment} overflows a felt to {new}"
+        "account nonce increment {current} plus the other nonce increment {increment} overflows a felt to {new}"
     )]
-    NonceOverflow {
+    NonceIncrementOverflow {
         current: Felt,
         increment: Felt,
         new: Felt,

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -99,8 +99,12 @@ pub enum AccountError {
     FinalAccountHeaderIdParsingFailed(#[source] AccountIdError),
     #[error("account header data has length {actual} but it must be of length {expected}")]
     HeaderDataIncorrectLength { actual: usize, expected: usize },
-    #[error("new account nonce {new} is less than the current nonce {current}")]
-    NonceNotMonotonicallyIncreasing { current: u64, new: u64 },
+    #[error("current account nonce {current} plus increment {increment} overflows a felt to {new}")]
+    NonceOverflow {
+        current: Felt,
+        increment: Felt,
+        new: Felt,
+    },
     #[error(
         "digest of the seed has {actual} trailing zeroes but must have at least {expected} trailing zeroes"
     )]
@@ -242,7 +246,7 @@ pub enum AccountDeltaError {
         source: AccountError,
     },
     #[error("inconsistent nonce update: {0}")]
-    InconsistentNonceUpdate(String),
+    InconsistentNonceUpdate(Box<str>),
     #[error("account ID {0} in fungible asset delta is not of type fungible faucet")]
     NotAFungibleFaucetId(AccountId),
 }

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -645,9 +645,8 @@ mod tests {
             [(2, [ONE, ONE, ONE, ONE]), (3, [ONE, ONE, ZERO, ONE])],
             [],
         );
-        let delta =
-            AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), Some(ONE))
-                .unwrap();
+        let delta = AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), ONE)
+            .unwrap();
         let details = AccountUpdateDetails::Delta(delta);
         TxAccountUpdate::new(
             AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap(),
@@ -674,9 +673,8 @@ mod tests {
 
         // A delta that exceeds the limit returns an error.
         let storage_delta = AccountStorageDelta::from_iters([], [], [(4, storage_delta)]);
-        let delta =
-            AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), Some(ONE))
-                .unwrap();
+        let delta = AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), ONE)
+            .unwrap();
         let details = AccountUpdateDetails::Delta(delta);
         let details_size = details.get_size_hint();
 

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -298,7 +298,7 @@ fn executed_transaction_account_delta_new() {
     // --------------------------------------------------------------------------------------------
 
     // nonce was incremented by 1
-    assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(1)));
+    assert_eq!(executed_transaction.account_delta().nonce_increment(), ONE);
 
     // storage delta
     // --------------------------------------------------------------------------------------------
@@ -385,7 +385,7 @@ fn test_empty_delta_nonce_update() {
     // --------------------------------------------------------------------------------------------
 
     // nonce was incremented by 1
-    assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(1)));
+    assert_eq!(executed_transaction.account_delta().nonce_increment(), ONE);
 
     // storage delta
     // --------------------------------------------------------------------------------------------
@@ -507,7 +507,7 @@ fn test_send_note_proc() -> miette::Result<()> {
         // --------------------------------------------------------------------------------------------
 
         // nonce was incremented by 1
-        assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(1)));
+        assert_eq!(executed_transaction.account_delta().nonce_increment(), ONE);
 
         // vault delta
         // --------------------------------------------------------------------------------------------
@@ -975,7 +975,7 @@ fn transaction_executor_account_code_using_custom_library() {
     let executed_tx = tx_context.execute().unwrap();
 
     // Account's initial nonce of 1 should have been incremented by 4.
-    assert_eq!(executed_tx.account_delta().nonce().unwrap(), Felt::new(4));
+    assert_eq!(executed_tx.account_delta().nonce_increment(), Felt::new(4));
 }
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
-        StorageMap, StorageSlot,
+        StorageMap, StorageSlot, delta::LexicographicWord,
     },
     asset::{Asset, FungibleAsset},
     note::{Note, NoteType},
@@ -15,7 +15,7 @@ use miden_objects::{
         account_component::AccountMockComponent, account_id::AccountIdBuilder,
         asset::NonFungibleAssetBuilder,
     },
-    transaction::{ExecutedTransaction, LinkMapKey, TransactionScript},
+    transaction::{ExecutedTransaction, TransactionScript},
     vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     Digest, EMPTY_WORD, Felt, Hasher, Word,
     account::{
         AccountBuilder, AccountDelta, AccountHeader, AccountId, AccountStorageMode, AccountType,
-        StorageMap, StorageSlot, delta::LexicographicWord,
+        StorageMap, StorageSlot,
     },
     asset::{Asset, FungibleAsset},
     note::{Note, NoteType},
@@ -15,7 +15,7 @@ use miden_objects::{
         account_component::AccountMockComponent, account_id::AccountIdBuilder,
         asset::NonFungibleAssetBuilder,
     },
-    transaction::{ExecutedTransaction, TransactionScript},
+    transaction::{ExecutedTransaction, LinkMapKey, TransactionScript},
     vm::AdviceMap,
 };
 use miden_tx::{TransactionExecutorError, utils::word_to_masm_push_string};

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -55,7 +55,7 @@ fn delta_nonce() -> anyhow::Result<()> {
         .execute()
         .context("failed to execute transaction")?;
 
-    assert_eq!(executed_tx.account_delta().nonce(), Some(Felt::new(5)));
+    assert_eq!(executed_tx.account_delta().nonce_increment(), Felt::new(5));
 
     validate_account_delta(&executed_tx).context("failed to validate delta")?;
 

--- a/crates/miden-testing/tests/integration/scripts/faucet.rs
+++ b/crates/miden-testing/tests/integration/scripts/faucet.rs
@@ -209,6 +209,6 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     prove_and_verify_transaction(executed_transaction.clone()).unwrap();
 
     // nonce was incremented by 2 (once by the call to burn, once by the auth script)
-    assert_eq!(executed_transaction.account_delta().nonce(), Some(Felt::new(2)));
+    assert_eq!(executed_transaction.account_delta().nonce_increment(), Felt::new(2));
     assert_eq!(executed_transaction.input_notes().get_note(0).id(), note.id());
 }

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -43,14 +43,8 @@ pub enum TransactionExecutorError {
         input_id: AccountId,
         output_id: AccountId,
     },
-    #[error("expected account nonce delta to be {}, found {}",
-        expected.as_ref().map(Felt::as_int).unwrap_or(0),
-        actual.as_ref().map(Felt::as_int).unwrap_or(0)
-    )]
-    InconsistentAccountNonceDelta {
-        expected: Option<Felt>,
-        actual: Option<Felt>,
-    },
+    #[error("expected account nonce delta to be {expected}, found {actual}")]
+    InconsistentAccountNonceDelta { expected: Felt, actual: Felt },
     #[error("account witness provided for account ID {0} is invalid")]
     InvalidAccountWitness(AccountId, #[source] SmtProofError),
     #[error(

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES, ZERO,
+    Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES,
     account::AccountId,
     assembly::SourceManager,
     block::{BlockHeader, BlockNumber},
@@ -403,18 +403,11 @@ fn build_executed_transaction(
     }
 
     // make sure nonce delta was computed correctly
-    let nonce_delta = final_account.nonce() - initial_account.nonce();
-    if nonce_delta == ZERO {
-        if account_delta.nonce().is_some() {
-            return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
-                expected: None,
-                actual: account_delta.nonce(),
-            });
-        }
-    } else if nonce_delta != account_delta.nonce().unwrap_or_default() {
+    let nonce_increment = final_account.nonce() - initial_account.nonce();
+    if nonce_increment != account_delta.nonce_increment() {
         return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
-            expected: Some(nonce_delta),
-            actual: account_delta.nonce(),
+            expected: nonce_increment,
+            actual: account_delta.nonce_increment(),
         });
     }
 

--- a/crates/miden-tx/src/host/account_delta_tracker.rs
+++ b/crates/miden-tx/src/host/account_delta_tracker.rs
@@ -20,7 +20,7 @@ pub struct AccountDeltaTracker {
     account_id: AccountId,
     storage: AccountStorageDelta,
     vault: AccountVaultDelta,
-    nonce_delta: Felt,
+    nonce_increment: Felt,
 }
 
 impl AccountDeltaTracker {
@@ -30,21 +30,19 @@ impl AccountDeltaTracker {
             account_id: account.id(),
             storage: AccountStorageDelta::new(),
             vault: AccountVaultDelta::default(),
-            nonce_delta: ZERO,
+            nonce_increment: ZERO,
         }
     }
 
     /// Consumes `self` and returns the resulting [AccountDelta].
     pub fn into_delta(self) -> AccountDelta {
-        let nonce_delta = (self.nonce_delta != ZERO).then_some(self.nonce_delta);
-
-        AccountDelta::new(self.account_id, self.storage, self.vault, nonce_delta)
+        AccountDelta::new(self.account_id, self.storage, self.vault, self.nonce_increment)
             .expect("account delta created in delta tracker should be valid")
     }
 
     /// Tracks nonce delta.
     pub fn increment_nonce(&mut self, value: Felt) {
-        self.nonce_delta += value;
+        self.nonce_increment += value;
     }
 
     /// Get a mutable reference to the current vault delta

--- a/crates/miden-tx/src/host/account_delta_tracker.rs
+++ b/crates/miden-tx/src/host/account_delta_tracker.rs
@@ -13,7 +13,6 @@ use miden_objects::{
 /// - Changes to the account nonce.
 ///
 /// TODO: implement tracking of:
-/// - all account storage changes.
 /// - account code changes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountDeltaTracker {


### PR DESCRIPTION
Refactor account delta nonce from `Option<Felt>` to `Felt`.

Previously (I think) `None` was used to represent "nonce has not changed" but since the nonce was changed to represent the increment of the nonce rather than its absolute new value in #1404, this is no longer necessary now and `0` can be used to represent "no change" instead.

Also removes an unused `From<Account> for AccountDelta` implementation, though if we still need this, that commit can be easily reverted. I don't think this should really be necessary since deltas are created in the transaction executor, but cc @igamigo in case you need this in the client.

part of #1198