### PR TITLE
Fix `miden-testing` all-features compilation

### DIFF
--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -17,8 +17,7 @@ name = "miden-integration-tests"
 path = "tests/integration/main.rs"
 
 [features]
-async = ["winter-maybe-async/async"]
-masm-debug = ["miden-lib/with-debug-info"]
+async = ["winter-maybe-async/async", "miden-tx/async"]
 
 [dependencies]
 # Workspace dependencies


### PR DESCRIPTION
Fixes compilation of `cargo check --all-features -p miden-testing` which previously did not enable the `async` feature in `miden-tx`.