### PR TITLE
Auth procedure arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [BREAKING] `Digest` was removed in favor of `Word` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{NoteInclusionProof, AccountWitness}::inner_nodes` to `authenticated_nodes` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1571](https://github.com/0xMiden/miden-base/pull/1571)).
+- Add arguments to the auth procedure ([#1501](https://github.com/0xMiden/miden-base/pull/1501)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -167,10 +167,14 @@ end
 #! Inputs:  []
 #! Outputs: []
 proc.execute_auth_procedure
-    padw padw padw push.0.0.0
+    padw padw padw
+    # get the auth procedure arguments key
+    exec.memory::get_auth_procedure_args_key
+    # => [AUTH_PROCEDURE_ARGS_KEY, pad(12)]
+
     # auth procedure is at index 0 within the account procedures section.
     push.0 exec.memory::get_acct_procedure_ptr
-    # => [auth_procedure_ptr, pad(15)]
+    # => [auth_procedure_ptr, AUTH_PROCEDURE_ARGS_KEY, pad(12)]
 
     # execute the auth procedure
     dyncall

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -169,12 +169,12 @@ end
 proc.execute_auth_procedure
     padw padw padw
     # get the auth procedure arguments key
-    exec.memory::get_auth_procedure_args_key
-    # => [AUTH_PROCEDURE_ARGS_KEY, pad(12)]
+    exec.memory::get_auth_args
+    # => [AUTH_ARGS, pad(12)]
 
     # auth procedure is at index 0 within the account procedures section.
     push.0 exec.memory::get_acct_procedure_ptr
-    # => [auth_procedure_ptr, AUTH_PROCEDURE_ARGS_KEY, pad(12)]
+    # => [auth_procedure_ptr, AUTH_ARGS, pad(12)]
 
     # execute the auth procedure
     dyncall

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -168,7 +168,7 @@ end
 #! Outputs: []
 proc.execute_auth_procedure
     padw padw padw
-    # get the auth procedure arguments key
+    # get the auth procedure arguments
     exec.memory::get_auth_args
     # => [AUTH_ARGS, pad(12)]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -82,7 +82,7 @@ const.TX_SCRIPT_ROOT_PTR=420
 const.TX_SCRIPT_ARGS_KEY_PTR=424
 
 # The memory address at which the key of the auth procedure arguments is stored.
-const.AUTH_PROCEDURE_ARGS_KEY_PTR=428
+const.AUTH_ARGS_PTR=428
 
 # GLOBAL BLOCK DATA
 # -------------------------------------------------------------------------------------------------
@@ -538,28 +538,26 @@ export.set_tx_script_args_key
     mem_storew.TX_SCRIPT_ARGS_KEY_PTR
 end
 
-#! Returns the auth procedure arguments key.
+#! Returns the auth procedure arguments.
 #!
 #! Inputs:  []
-#! Outputs: [AUTH_PROCEDURE_ARGS_KEY]
+#! Outputs: [AUTH_ARGS]
 #!
 #! Where:
-#! - AUTH_PROCEDURE_ARGS_KEY is the key which could be used to obtain the auth procedure arguments.
-#!   from the advice map.
-export.get_auth_procedure_args_key
-    padw mem_loadw.AUTH_PROCEDURE_ARGS_KEY_PTR
+#! - AUTH_ARGS is the argument passed to the auth procedure.
+export.get_auth_args
+    padw mem_loadw.AUTH_ARGS_PTR
 end
 
-#! Sets the auth procedure arguments key.
+#! Sets the auth procedure arguments.
 #!
-#! Inputs:  [AUTH_PROCEDURE_ARGS_KEY]
-#! Outputs: [AUTH_PROCEDURE_ARGS_KEY]
+#! Inputs:  [AUTH_ARGS]
+#! Outputs: [AUTH_ARGS]
 #!
 #! Where:
-#! - AUTH_PROCEDURE_ARGS_KEY is the key which could be used to obtain the auth procedure arguments.
-#!   from the advice map.
-export.set_auth_procedure_args_key
-    mem_storew.AUTH_PROCEDURE_ARGS_KEY_PTR
+#! - AUTH_ARGS is the argument passed to the auth procedure.
+export.set_auth_args
+    mem_storew.AUTH_ARGS_PTR
 end
 
 # BLOCK DATA

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -81,6 +81,9 @@ const.TX_SCRIPT_ROOT_PTR=420
 # The memory address at which the key of the transaction script arguments is stored.
 const.TX_SCRIPT_ARGS_KEY_PTR=424
 
+# The memory address at which the key of the auth procedure arguments is stored.
+const.AUTH_PROCEDURE_ARGS_KEY_PTR=428
+
 # GLOBAL BLOCK DATA
 # -------------------------------------------------------------------------------------------------
 
@@ -533,6 +536,30 @@ end
 #!   from the advice map.
 export.set_tx_script_args_key
     mem_storew.TX_SCRIPT_ARGS_KEY_PTR
+end
+
+#! Returns the auth procedure arguments key.
+#!
+#! Inputs:  []
+#! Outputs: [AUTH_PROCEDURE_ARGS_KEY]
+#!
+#! Where:
+#! - AUTH_PROCEDURE_ARGS_KEY is the key which could be used to obtain the auth procedure arguments.
+#!   from the advice map.
+export.get_auth_procedure_args_key
+    padw mem_loadw.AUTH_PROCEDURE_ARGS_KEY_PTR
+end
+
+#! Sets the auth procedure arguments key.
+#!
+#! Inputs:  [AUTH_PROCEDURE_ARGS_KEY]
+#! Outputs: [AUTH_PROCEDURE_ARGS_KEY]
+#!
+#! Where:
+#! - AUTH_PROCEDURE_ARGS_KEY is the key which could be used to obtain the auth procedure arguments.
+#!   from the advice map.
+export.set_auth_procedure_args_key
+    mem_storew.AUTH_PROCEDURE_ARGS_KEY_PTR
 end
 
 # BLOCK DATA

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -81,7 +81,7 @@ const.TX_SCRIPT_ROOT_PTR=420
 # The memory address at which the key of the transaction script arguments is stored.
 const.TX_SCRIPT_ARGS_KEY_PTR=424
 
-# The memory address at which the key of the auth procedure arguments is stored.
+# The memory address at which the auth procedure arguments are stored.
 const.AUTH_ARGS_PTR=428
 
 # GLOBAL BLOCK DATA

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1084,7 +1084,7 @@ end
 # TRANSACTION SCRIPT
 # =================================================================================================
 
-#! Saves the transaction script root and args key to memory.
+#! Saves the transaction script root and args to memory.
 #!
 #! Inputs:
 #!   Operand stack: []

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1115,26 +1115,25 @@ proc.process_tx_script_data
     # => []
 end
 
-#! Saves the auth procedure args key to memory.
+#! Saves the auth procedure args to memory.
 #! The auth procedure root has already been saved to memory via `process_account_data`.
 #!
 #! Inputs:
 #!   Operand stack: []
-#!   Advice stack: [AUTH_PROCEDURE_ARGS_KEY]
+#!   Advice stack: [AUTH_ARGS]
 #! Outputs:
 #!   Operand stack: []
 #!   Advice stack: []
 #!
 #! Where:
-#! - AUTH_PROCEDURE_ARGS_KEY is the commitment of the auth procedure args used to obtain them from
-#!   the advice map.
+#! - AUTH_ARGS is the argument passed to the auth procedure.
 proc.process_auth_procedure_data
-    # read the auth procedure args key from the advice stack
+    # read the auth procedure args from the advice stack
     padw adv_loadw
-    # => [AUTH_PROCEDURE_ARGS_KEY]
+    # => [AUTH_ARGS]
 
-    # store the auth procedure args key in memory
-    exec.memory::set_auth_procedure_args_key dropw
+    # store the auth procedure args in memory
+    exec.memory::set_auth_args dropw
     # => []
 end
 
@@ -1172,7 +1171,7 @@ end
 #!     number_of_input_notes,
 #!     TX_SCRIPT_ROOT,
 #!     TX_SCRIPT_ARGS_KEY,
-#!     AUTH_PROCEDURE_ARGS_KEY,
+#!     AUTH_ARGS,
 #!   ]
 #!   Advice map: {
 #!      PARTIAL_BLOCKCHAIN_COMMITMENT: [MMR_PEAKS],

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1084,7 +1084,7 @@ end
 # TRANSACTION SCRIPT
 # =================================================================================================
 
-#! Saves the transaction script root to memory.
+#! Saves the transaction script root and args key to memory.
 #!
 #! Inputs:
 #!   Operand stack: []
@@ -1095,11 +1095,11 @@ end
 #!
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction's script root.
-#! - TX_SCRIPT_ARGS_KEY is the commitment of the transaction script args used to obtain them from 
+#! - TX_SCRIPT_ARGS_KEY is the commitment of the transaction script args used to obtain them from
 #!   the advice map.
 proc.process_tx_script_data
     # read the transaction script root from the advice stack
-    adv_loadw
+    padw adv_loadw
     # => [TX_SCRIPT_ROOT]
 
     # store the transaction script root in memory
@@ -1107,11 +1107,34 @@ proc.process_tx_script_data
     # => []
 
     # read the transaction script args key from the advice stack
-    adv_loadw
+    padw adv_loadw
     # => [TX_SCRIPT_ARGS_KEY]
 
     # store the transaction script args key in memory
     exec.memory::set_tx_script_args_key dropw
+    # => []
+end
+
+#! Saves the auth procedure args key to memory.
+#! The auth procedure root has already been saved to memory via `process_account_data`.
+#!
+#! Inputs:
+#!   Operand stack: []
+#!   Advice stack: [AUTH_PROCEDURE_ARGS_KEY]
+#! Outputs:
+#!   Operand stack: []
+#!   Advice stack: []
+#!
+#! Where:
+#! - AUTH_PROCEDURE_ARGS_KEY is the commitment of the auth procedure args used to obtain them from
+#!   the advice map.
+proc.process_auth_procedure_data
+    # read the auth procedure args key from the advice stack
+    padw adv_loadw
+    # => [AUTH_PROCEDURE_ARGS_KEY]
+
+    # store the auth procedure args key in memory
+    exec.memory::set_auth_procedure_args_key dropw
     # => []
 end
 
@@ -1149,6 +1172,7 @@ end
 #!     number_of_input_notes,
 #!     TX_SCRIPT_ROOT,
 #!     TX_SCRIPT_ARGS_KEY,
+#!     AUTH_PROCEDURE_ARGS_KEY,
 #!   ]
 #!   Advice map: {
 #!      PARTIAL_BLOCKCHAIN_COMMITMENT: [MMR_PEAKS],
@@ -1208,6 +1232,7 @@ export.prepare_transaction
     exec.process_account_data
     exec.process_input_notes_data
     exec.process_tx_script_data
+    exec.process_auth_procedure_data
     # => []
 
     push.MAX_BLOCK_NUM exec.memory::set_expiration_block_num

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1116,6 +1116,7 @@ proc.process_tx_script_data
 end
 
 #! Saves the auth procedure args to memory.
+#!
 #! The auth procedure root has already been saved to memory via `process_account_data`.
 #!
 #! Inputs:

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1103,11 +1103,11 @@ proc.process_tx_script_data
     # => [TX_SCRIPT_ROOT]
 
     # store the transaction script root in memory
-    exec.memory::set_tx_script_root dropw
-    # => []
+    exec.memory::set_tx_script_root
+    # => [TX_SCRIPT_ROOT]
 
-    # read the transaction script args key from the advice stack
-    padw adv_loadw
+    # read the transaction script args key from the advice stack (overwrites TX_SCRIPT_ROOT)
+    adv_loadw
     # => [TX_SCRIPT_ARGS_KEY]
 
     # store the transaction script args key in memory

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -148,7 +148,7 @@ impl TransactionAdviceInputs {
         // --- number of notes, script root and args key ----------------------
         self.extend_stack([Felt::from(tx_inputs.input_notes().num_notes())]);
         self.extend_stack(tx_args.tx_script().map_or(Word::empty(), |script| script.root()));
-        self.extend_stack(tx_args.tx_script_arg());
+        self.extend_stack(tx_args.tx_script_args());
 
         // --- auth procedure args key -------------------------------------------
         self.extend_stack(tx_args.auth_arg());

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -151,7 +151,7 @@ impl TransactionAdviceInputs {
         self.extend_stack(tx_args.tx_script_arg());
 
         // --- auth procedure args key -------------------------------------------
-        self.extend_stack(tx_args.auth_argument());
+        self.extend_stack(tx_args.auth_arg());
     }
 
     // BLOCKCHAIN INJECTIONS

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -104,7 +104,7 @@ impl TransactionAdviceInputs {
     ///     number_of_input_notes,
     ///     TX_SCRIPT_ROOT,
     ///     TX_SCRIPT_ARGS_KEY,
-    ///     AUTH_PROCEDURE_ARG,
+    ///     AUTH_ARGS,
     /// ]
     fn build_stack(
         &mut self,
@@ -150,8 +150,8 @@ impl TransactionAdviceInputs {
         self.extend_stack(tx_args.tx_script().map_or(Word::empty(), |script| script.root()));
         self.extend_stack(tx_args.tx_script_args());
 
-        // --- auth procedure args key -------------------------------------------
-        self.extend_stack(tx_args.auth_arg());
+        // --- auth procedure args -------------------------------------------
+        self.extend_stack(tx_args.auth_args());
     }
 
     // BLOCKCHAIN INJECTIONS

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -104,6 +104,7 @@ impl TransactionAdviceInputs {
     ///     number_of_input_notes,
     ///     TX_SCRIPT_ROOT,
     ///     TX_SCRIPT_ARGS_KEY,
+    ///     AUTH_PROCEDURE_ARG,
     /// ]
     fn build_stack(
         &mut self,
@@ -148,6 +149,9 @@ impl TransactionAdviceInputs {
         self.extend_stack([Felt::from(tx_inputs.input_notes().num_notes())]);
         self.extend_stack(tx_args.tx_script().map_or(Word::empty(), |script| script.root()));
         self.extend_stack(tx_args.tx_script_arg());
+
+        // --- auth procedure args key -------------------------------------------
+        self.extend_stack(tx_args.auth_argument());
     }
 
     // BLOCKCHAIN INJECTIONS

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -17,7 +17,7 @@ pub type StorageSlot = u8;
 // | Section            | Start address, pointer (word pointer) | End address, pointer (word pointer) | Comment                                     |
 // | ------------------ | :-----------------------------------: | :---------------------------------: | ------------------------------------------- |
 // | Bookkeeping        | 0 (0)                                 | 287 (71)                            |                                             |
-// | Global inputs      | 400 (100)                             | 427 (106)                           |                                             |
+// | Global inputs      | 400 (100)                             | 431 (107)                           |                                             |
 // | Block header       | 800 (200)                             | 835 (208)                           |                                             |
 // | Partial blockchain | 1_200 (300)                           | 1_331? (332?)                       |                                             |
 // | Kernel data        | 1_600 (400)                           | 1_739 (434)                         | 34 procedures in total, 4 elements each     |
@@ -135,6 +135,9 @@ pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 420;
 
 /// The memory address at which the key of the transaction script arguments is stored.
 pub const TX_SCRIPT_ARGS_KEY: MemoryAddress = 424;
+
+/// The memory address at which the key of the auth procedure arguments is stored.
+pub const AUTH_PROCEDURE_ARGS_KEY_PTR: MemoryAddress = 428;
 
 // BLOCK DATA
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -137,7 +137,7 @@ pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 420;
 pub const TX_SCRIPT_ARGS_KEY: MemoryAddress = 424;
 
 /// The memory address at which the key of the auth procedure arguments is stored.
-pub const AUTH_PROCEDURE_ARGS_KEY_PTR: MemoryAddress = 428;
+pub const AUTH_ARGS_PTR: MemoryAddress = 428;
 
 // BLOCK DATA
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -136,7 +136,6 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
             # OS => [AUTH_ARGS_KEY]
             # AS => [99, 98, 97, 96, incr_nonce_flag]
 
-            debug.stack
             # drop the args commitment
             dropw
             # OS => []
@@ -147,13 +146,11 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
             # OS => [99, 98, 97, 96]
             # AS => []
 
-            debug.stack
 
             # If [99, 98, 97, 96] is passed as an argument, all good.
             # Otherwise we error out.
-            push.99.98.97.96 debug.stack eqw assert.err=WRONG_ARGS
+            push.99.98.97.96 eqw assert.err=WRONG_ARGS
 
-            debug.stack
             # Load the `incr_nonce_flag` from the advice stack.
             adv_push.1
 

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -121,7 +121,7 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
         r#"
         use.miden::account
 
-        const.WRONG_ARGS="{}"
+        const.WRONG_ARGS="{ERR_WRONG_ARGS_MSG}"
 
         export.auth__conditional
             # OS => [AUTH_ARGS_KEY]
@@ -163,8 +163,7 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
 
             dropw dropw dropw dropw
         end
-"#,
-        ERR_WRONG_ARGS_MSG
+"#
     )
 });
 

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -124,40 +124,17 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
         const.WRONG_ARGS="{ERR_WRONG_ARGS_MSG}"
 
         export.auth__conditional
-            # OS => [AUTH_ARGS_KEY]
-            # AS => []
+            # => [AUTH_ARG]
 
-            # `AUTH_ARGS_KEY` value, which is located on the stack at the beginning of
-            # the execution, is the advice map key which allows to obtain auth procedure args
-            # which were specified during the `AuthArguments` creation.
-
-            # move the auth args from advice map to the advice stack
-            adv.push_mapval
-            # OS => [AUTH_ARGS_KEY]
-            # AS => [99, 98, 97, 96, incr_nonce_flag]
-
-            # drop the args commitment
-            dropw
-            # OS => []
-            # AS => [99, 98, 97, 96, incr_nonce_flag]
-
-            # Move the auth arguments array from advice stack to the operand stack.
-            adv_push.4
-            # OS => [99, 98, 97, 96]
-            # AS => []
-
-
-            # If [99, 98, 97, 96] is passed as an argument, all good.
+            # If [97, 98, 99, incr_nonce_flag] is passed as an argument, all good.
             # Otherwise we error out.
-            push.99.98.97.96 eqw assert.err=WRONG_ARGS
-
-            # Load the `incr_nonce_flag` from the advice stack.
-            adv_push.1
+            push.97 assert_eq.err=WRONG_ARGS
+            push.98 assert_eq.err=WRONG_ARGS
+            push.99 assert_eq.err=WRONG_ARGS
 
             if.true
                 push.1 exec.account::incr_nonce
             end
-
             dropw dropw dropw dropw
         end
 "#

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -124,7 +124,7 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
         const.WRONG_ARGS="{ERR_WRONG_ARGS_MSG}"
 
         export.auth__conditional
-            # => [AUTH_ARG]
+            # => [AUTH_ARGS]
 
             # If [97, 98, 99] is passed as an argument, all good.
             # Otherwise we error out.

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -126,12 +126,13 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
         export.auth__conditional
             # => [AUTH_ARG]
 
-            # If [97, 98, 99, incr_nonce_flag] is passed as an argument, all good.
+            # If [97, 98, 99] is passed as an argument, all good.
             # Otherwise we error out.
             push.97 assert_eq.err=WRONG_ARGS
             push.98 assert_eq.err=WRONG_ARGS
             push.99 assert_eq.err=WRONG_ARGS
 
+            # Last element is the incr_nonce_flag.
             if.true
                 push.1 exec.account::incr_nonce
             end

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -39,7 +39,7 @@ pub struct TransactionArgs {
     note_args: BTreeMap<NoteId, Word>,
     advice_inputs: AdviceInputs,
     foreign_account_inputs: Vec<AccountInputs>,
-    auth_argument: Word,
+    auth_arg: Word,
 }
 
 impl TransactionArgs {
@@ -55,7 +55,7 @@ impl TransactionArgs {
             note_args: Default::default(),
             advice_inputs: AdviceInputs::default().with_map(advice_map),
             foreign_account_inputs,
-            auth_argument: EMPTY_WORD,
+            auth_arg: EMPTY_WORD,
         }
     }
 
@@ -97,8 +97,8 @@ impl TransactionArgs {
 
     /// Returns new [TransactionArgs] instantiated with the provided auth arguments.
     #[must_use]
-    pub fn with_auth_argument(mut self, auth_argument: Word) -> Self {
-        self.auth_argument = auth_argument;
+    pub fn with_auth_arg(mut self, auth_arg: Word) -> Self {
+        self.auth_arg = auth_arg;
         self
     }
 
@@ -144,9 +144,15 @@ impl TransactionArgs {
             .collect()
     }
 
-    /// Returns a reference to the authentication arguments.
-    pub fn auth_argument(&self) -> Word {
-        self.auth_argument
+    /// Returns a reference to the authentication procedure argument, or [`EMPTY_WORD`] if the
+    /// argument was not specified.
+    ///
+    /// This argument could be potentially used as a key to access the advice map during the
+    /// transaction script execution. Notice that the corresponding map entry should be provided
+    /// separately during the creation with the [`TransactionArgs::new`] or using the
+    /// [`TransactionArgs::extend_advice_map`] method.
+    pub fn auth_arg(&self) -> Word {
+        self.auth_arg
     }
 
     // STATE MUTATORS
@@ -215,7 +221,7 @@ impl Serializable for TransactionArgs {
         self.note_args.write_into(target);
         self.advice_inputs.write_into(target);
         self.foreign_account_inputs.write_into(target);
-        self.auth_argument.write_into(target);
+        self.auth_arg.write_into(target);
     }
 }
 
@@ -234,7 +240,7 @@ impl Deserializable for TransactionArgs {
             note_args,
             advice_inputs,
             foreign_account_inputs,
-            auth_argument,
+            auth_arg: auth_argument,
         })
     }
 }

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -39,7 +39,7 @@ pub struct TransactionArgs {
     note_args: BTreeMap<NoteId, Word>,
     advice_inputs: AdviceInputs,
     foreign_account_inputs: Vec<AccountInputs>,
-    auth_arg: Word,
+    auth_args: Word,
 }
 
 impl TransactionArgs {
@@ -55,7 +55,7 @@ impl TransactionArgs {
             note_args: Default::default(),
             advice_inputs: AdviceInputs::default().with_map(advice_map),
             foreign_account_inputs,
-            auth_arg: EMPTY_WORD,
+            auth_args: EMPTY_WORD,
         }
     }
 
@@ -97,8 +97,8 @@ impl TransactionArgs {
 
     /// Returns new [TransactionArgs] instantiated with the provided auth arguments.
     #[must_use]
-    pub fn with_auth_arg(mut self, auth_arg: Word) -> Self {
-        self.auth_arg = auth_arg;
+    pub fn with_auth_args(mut self, auth_args: Word) -> Self {
+        self.auth_args = auth_args;
         self
     }
 
@@ -151,8 +151,8 @@ impl TransactionArgs {
     /// transaction script execution. Notice that the corresponding map entry should be provided
     /// separately during the creation with the [`TransactionArgs::new`] or using the
     /// [`TransactionArgs::extend_advice_map`] method.
-    pub fn auth_arg(&self) -> Word {
-        self.auth_arg
+    pub fn auth_args(&self) -> Word {
+        self.auth_args
     }
 
     // STATE MUTATORS
@@ -221,7 +221,7 @@ impl Serializable for TransactionArgs {
         self.note_args.write_into(target);
         self.advice_inputs.write_into(target);
         self.foreign_account_inputs.write_into(target);
-        self.auth_arg.write_into(target);
+        self.auth_args.write_into(target);
     }
 }
 
@@ -232,7 +232,7 @@ impl Deserializable for TransactionArgs {
         let note_args = BTreeMap::<NoteId, Word>::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
         let foreign_account_inputs = Vec::<AccountInputs>::read_from(source)?;
-        let auth_arg = Word::read_from(source)?;
+        let auth_args = Word::read_from(source)?;
 
         Ok(Self {
             tx_script,
@@ -240,7 +240,7 @@ impl Deserializable for TransactionArgs {
             note_args,
             advice_inputs,
             foreign_account_inputs,
-            auth_arg,
+            auth_args,
         })
     }
 }

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -232,7 +232,7 @@ impl Deserializable for TransactionArgs {
         let note_args = BTreeMap::<NoteId, Word>::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
         let foreign_account_inputs = Vec::<AccountInputs>::read_from(source)?;
-        let auth_argument = Word::read_from(source)?;
+        let auth_arg = Word::read_from(source)?;
 
         Ok(Self {
             tx_script,
@@ -240,7 +240,7 @@ impl Deserializable for TransactionArgs {
             note_args,
             advice_inputs,
             foreign_account_inputs,
-            auth_arg: auth_argument,
+            auth_arg,
         })
     }
 }

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -35,7 +35,7 @@ use crate::{
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TransactionArgs {
     tx_script: Option<TransactionScript>,
-    tx_script_arg: Word,
+    tx_script_args: Word,
     note_args: BTreeMap<NoteId, Word>,
     advice_inputs: AdviceInputs,
     foreign_account_inputs: Vec<AccountInputs>,
@@ -51,7 +51,7 @@ impl TransactionArgs {
     pub fn new(advice_map: AdviceMap, foreign_account_inputs: Vec<AccountInputs>) -> Self {
         Self {
             tx_script: None,
-            tx_script_arg: EMPTY_WORD,
+            tx_script_args: EMPTY_WORD,
             note_args: Default::default(),
             advice_inputs: AdviceInputs::default().with_map(advice_map),
             foreign_account_inputs,
@@ -78,10 +78,10 @@ impl TransactionArgs {
     pub fn with_tx_script_and_arg(
         mut self,
         tx_script: TransactionScript,
-        tx_script_arg: Word,
+        tx_script_args: Word,
     ) -> Self {
         self.tx_script = Some(tx_script);
-        self.tx_script_arg = tx_script_arg;
+        self.tx_script_args = tx_script_args;
         self
     }
 
@@ -117,8 +117,8 @@ impl TransactionArgs {
     /// transaction script execution. Notice that the corresponding map entry should be provided
     /// separately during the creation with the [`TransactionArgs::new`] or using the
     /// [`TransactionArgs::extend_advice_map`] method.
-    pub fn tx_script_arg(&self) -> Word {
-        self.tx_script_arg
+    pub fn tx_script_args(&self) -> Word {
+        self.tx_script_args
     }
 
     /// Returns a reference to a specific note argument.
@@ -217,7 +217,7 @@ impl TransactionArgs {
 impl Serializable for TransactionArgs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.tx_script.write_into(target);
-        self.tx_script_arg.write_into(target);
+        self.tx_script_args.write_into(target);
         self.note_args.write_into(target);
         self.advice_inputs.write_into(target);
         self.foreign_account_inputs.write_into(target);
@@ -228,7 +228,7 @@ impl Serializable for TransactionArgs {
 impl Deserializable for TransactionArgs {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let tx_script = Option::<TransactionScript>::read_from(source)?;
-        let tx_script_arg = Word::read_from(source)?;
+        let tx_script_args = Word::read_from(source)?;
         let note_args = BTreeMap::<NoteId, Word>::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
         let foreign_account_inputs = Vec::<AccountInputs>::read_from(source)?;
@@ -236,7 +236,7 @@ impl Deserializable for TransactionArgs {
 
         Ok(Self {
             tx_script,
-            tx_script_arg,
+            tx_script_args,
             note_args,
             advice_inputs,
             foreign_account_inputs,

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -32,6 +32,10 @@ use crate::{
 /// - Advice inputs: provides data needed by the runtime, like the details of public output notes.
 /// - Foreign account inputs: provides foreign account data that will be used during the foreign
 ///   procedure invocation (FPI).
+/// - Auth arguments: data put onto the stack right before authentication procedure execution. If
+///   this argument is not specified, the [`EMPTY_WORD`] would be used as a default value. If the
+///   [AdviceInputs] are propagated with some user defined map entries, this argument could be used
+///   as a key to access the corresponding value.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TransactionArgs {
     tx_script: Option<TransactionScript>,

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -39,6 +39,7 @@ pub struct TransactionArgs {
     note_args: BTreeMap<NoteId, Word>,
     advice_inputs: AdviceInputs,
     foreign_account_inputs: Vec<AccountInputs>,
+    auth_argument: Word,
 }
 
 impl TransactionArgs {
@@ -54,6 +55,7 @@ impl TransactionArgs {
             note_args: Default::default(),
             advice_inputs: AdviceInputs::default().with_map(advice_map),
             foreign_account_inputs,
+            auth_argument: EMPTY_WORD,
         }
     }
 
@@ -90,6 +92,13 @@ impl TransactionArgs {
     #[must_use]
     pub fn with_note_args(mut self, note_args: BTreeMap<NoteId, Word>) -> Self {
         self.note_args = note_args;
+        self
+    }
+
+    /// Returns new [TransactionArgs] instantiated with the provided auth arguments.
+    #[must_use]
+    pub fn with_auth_argument(mut self, auth_argument: Word) -> Self {
+        self.auth_argument = auth_argument;
         self
     }
 
@@ -133,6 +142,11 @@ impl TransactionArgs {
             .iter()
             .map(|acc| acc.code().commitment())
             .collect()
+    }
+
+    /// Returns a reference to the authentication arguments.
+    pub fn auth_argument(&self) -> Word {
+        self.auth_argument
     }
 
     // STATE MUTATORS
@@ -201,6 +215,7 @@ impl Serializable for TransactionArgs {
         self.note_args.write_into(target);
         self.advice_inputs.write_into(target);
         self.foreign_account_inputs.write_into(target);
+        self.auth_argument.write_into(target);
     }
 }
 
@@ -211,6 +226,7 @@ impl Deserializable for TransactionArgs {
         let note_args = BTreeMap::<NoteId, Word>::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
         let foreign_account_inputs = Vec::<AccountInputs>::read_from(source)?;
+        let auth_argument = Word::read_from(source)?;
 
         Ok(Self {
             tx_script,
@@ -218,6 +234,7 @@ impl Deserializable for TransactionArgs {
             note_args,
             advice_inputs,
             foreign_account_inputs,
+            auth_argument,
         })
     }
 }

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -14,7 +14,13 @@ use super::utils::{
     generate_fungible_asset, generate_tracked_note_with_asset, generate_tx_with_expiration,
     generate_tx_with_unauthenticated_notes, generate_untracked_note, setup_chain,
 };
-use crate::ProvenTransactionExt;
+use crate::{
+    ProvenTransactionExt,
+    kernel_tests::block::utils::{
+        generate_account_with_conditional_auth, generate_noop_tx,
+        generate_tx_with_storage_increment,
+    },
+};
 
 /// Tests that we can build empty blocks.
 #[test]
@@ -243,6 +249,50 @@ fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
     // at block 3 (due to tx1) should still be accepted into the block.
     let block_inputs = chain.get_block_inputs(&batches)?;
     ProposedBlock::new(block_inputs.clone(), batches.clone())?;
+
+    Ok(())
+}
+
+/// Tests that a NOOP transaction with state commitments X -> X against account A can appear
+/// in one batch while another batch contains a state-updating transaction with state commitments X
+/// -> Y against the same account A. Both batches are in the same block.
+#[test]
+fn noop_tx_and_state_updating_tx_against_same_account_in_same_block() -> anyhow::Result<()> {
+    let TestSetup { mut chain, .. } = setup_chain(0);
+
+    let account0 = generate_account_with_conditional_auth(&mut chain);
+
+    let tx0 = generate_noop_tx(&mut chain, account0.id());
+    let tx1 = generate_tx_with_storage_increment(&mut chain, tx0.clone());
+
+    // sanity check: NOOP transaction's init and final commitment should be the same.
+    assert_eq!(tx0.initial_account().commitment(), tx0.final_account().commitment());
+    // sanity check: State-updating transaction's init and final commitment should *not* be the
+    // same.
+    assert_ne!(
+        tx1.account_update().initial_state_commitment(),
+        tx1.account_update().final_state_commitment()
+    );
+
+    assert_eq!(tx0.initial_account().commitment(), tx0.final_account().commitment());
+    assert_ne!(
+        tx1.account_update().initial_state_commitment(),
+        tx1.account_update().final_state_commitment()
+    );
+
+    let tx0 = ProvenTransaction::from_executed_transaction_mocked(tx0);
+
+    let batch0 = generate_batch(&mut chain, vec![tx0]);
+    let batch1 = generate_batch(&mut chain, vec![tx1.clone()]);
+
+    let batches = vec![batch0.clone(), batch1.clone()];
+
+    let block_inputs = chain.get_block_inputs(&batches)?;
+    let block = ProposedBlock::new(block_inputs, batches.clone())?;
+
+    let (_, update) = block.updated_accounts().iter().next().unwrap();
+    assert_eq!(update.initial_state_commitment(), account0.commitment());
+    assert_eq!(update.final_state_commitment(), tx1.account_update().final_state_commitment());
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -139,21 +139,21 @@ pub fn generate_conditional_tx(
     chain.add_pending_note(OutputNote::Full(noop_note.clone()));
     chain.prove_next_block().unwrap();
 
-    let auth_argument = [
+    let auth_arg_values = [
         Felt::new(99),
         Felt::new(98),
         Felt::new(97),
         Felt::new(96),
         if modify_storage { ONE } else { ZERO }, // increment nonce if modify_storage is true
     ];
-    let auth_argument_key = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = chain
         .build_tx_context(input.into(), &[noop_note.id()], &[])
         .unwrap()
         .extend_input_notes(vec![noop_note])
-        .auth_argument(auth_argument_key)
-        .extend_advice_map([(auth_argument_key, auth_argument.to_vec())])
+        .auth_arg(auth_arg)
+        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
         .build()
         .unwrap();
     tx_context.execute().unwrap()

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -139,21 +139,18 @@ pub fn generate_conditional_tx(
     chain.add_pending_note(OutputNote::Full(noop_note.clone()));
     chain.prove_next_block().unwrap();
 
-    let auth_arg_values = [
+    let auth_arg = [
+        if modify_storage { ONE } else { ZERO }, // increment nonce if modify_storage is true
         Felt::new(99),
         Felt::new(98),
         Felt::new(97),
-        Felt::new(96),
-        if modify_storage { ONE } else { ZERO }, // increment nonce if modify_storage is true
     ];
-    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = chain
         .build_tx_context(input.into(), &[noop_note.id()], &[])
         .unwrap()
         .extend_input_notes(vec![noop_note])
-        .auth_arg(auth_arg)
-        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
+        .auth_arg(auth_arg.into())
         .build()
         .unwrap();
     tx_context.execute().unwrap()

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -139,7 +139,7 @@ pub fn generate_conditional_tx(
     chain.add_pending_note(OutputNote::Full(noop_note.clone()));
     chain.prove_next_block().unwrap();
 
-    let auth_arg = [
+    let auth_args = [
         if modify_storage { ONE } else { ZERO }, // increment nonce if modify_storage is true
         Felt::new(99),
         Felt::new(98),
@@ -150,7 +150,7 @@ pub fn generate_conditional_tx(
         .build_tx_context(input.into(), &[noop_note.id()], &[])
         .unwrap()
         .extend_input_notes(vec![noop_note])
-        .auth_arg(auth_arg.into())
+        .auth_args(auth_args.into())
         .build()
         .unwrap();
     tx_context.execute().unwrap()

--- a/crates/miden-testing/src/kernel_tests/tx/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/mod.rs
@@ -18,6 +18,7 @@ mod test_account_delta;
 mod test_account_interface;
 mod test_asset;
 mod test_asset_vault;
+mod test_auth;
 mod test_epilogue;
 mod test_faucet;
 mod test_fpi;

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -26,18 +26,18 @@ fn test_auth_procedure_args() {
         TransactionKernel::testing_assembler(),
     );
 
-    let auth_arguments = [
+    let auth_arg_values = [
         Felt::new(99),
         Felt::new(98),
         Felt::new(97),
         Felt::new(96),
         ONE, // incr_nonce = true
     ];
-    let auth_argument_key = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = TransactionContextBuilder::new(account)
-        .auth_argument(auth_argument_key)
-        .extend_advice_map([(auth_argument_key, auth_arguments.to_vec())])
+        .auth_arg(auth_arg)
+        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
         .build()
         .unwrap();
 
@@ -61,18 +61,18 @@ fn test_auth_procedure_args_wrong_inputs() {
     );
 
     // The auth script expects [99, 98, 97, 96, nonce_increment_flag]
-    let auth_arguments = [
+    let auth_arg_values = [
         Felt::new(103),
         Felt::new(102),
         Felt::new(101),
         Felt::new(100),
         ONE, // incr_nonce = true
     ];
-    let auth_argument_key = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = TransactionContextBuilder::new(account)
-        .auth_argument(auth_argument_key)
-        .extend_advice_map([(auth_argument_key, auth_arguments.to_vec())])
+        .auth_arg(auth_arg)
+        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
         .build()
         .unwrap();
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,7 +1,6 @@
 use crate::assert_execution_error;
 use miden_lib::{errors::MasmError, transaction::TransactionKernel};
 use miden_objects::{
-    Word,
     account::Account,
     testing::{
         account_component::{ConditionalAuthComponent, ERR_WRONG_ARGS_MSG},
@@ -26,18 +25,15 @@ fn test_auth_procedure_args() {
         TransactionKernel::testing_assembler(),
     );
 
-    let auth_arg_values = [
+    let auth_arg = [
+        ONE, // incr_nonce = true
         Felt::new(99),
         Felt::new(98),
         Felt::new(97),
-        Felt::new(96),
-        ONE, // incr_nonce = true
     ];
-    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = TransactionContextBuilder::new(account)
-        .auth_arg(auth_arg)
-        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
+        .auth_arg(auth_arg.into())
         .build()
         .unwrap();
 
@@ -60,19 +56,16 @@ fn test_auth_procedure_args_wrong_inputs() {
         TransactionKernel::testing_assembler(),
     );
 
-    // The auth script expects [99, 98, 97, 96, nonce_increment_flag]
-    let auth_arg_values = [
+    // The auth script expects [99, 98, 97, nonce_increment_flag]
+    let auth_arg = [
+        ONE, // incr_nonce = true
         Felt::new(103),
         Felt::new(102),
         Felt::new(101),
-        Felt::new(100),
-        ONE, // incr_nonce = true
     ];
-    let auth_arg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
 
     let tx_context = TransactionContextBuilder::new(account)
-        .auth_arg(auth_arg)
-        .extend_advice_map([(auth_arg, auth_arg_values.to_vec())])
+        .auth_arg(auth_arg.into())
         .build()
         .unwrap();
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,0 +1,91 @@
+use crate::assert_execution_error;
+use miden_lib::{errors::MasmError, transaction::TransactionKernel};
+use miden_objects::{
+    Word,
+    account::Account,
+    testing::{
+        account_component::{ConditionalAuthComponent, ERR_WRONG_ARGS_MSG},
+        account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
+    },
+};
+use miden_tx::TransactionExecutorError;
+
+use super::{Felt, ONE};
+use crate::TransactionContextBuilder;
+
+pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);
+
+#[test]
+fn test_auth_procedure_args() {
+    let auth_component =
+        ConditionalAuthComponent::new(TransactionKernel::testing_assembler()).unwrap();
+    let account = Account::mock(
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
+        ONE,
+        auth_component,
+        TransactionKernel::testing_assembler(),
+    );
+
+    let auth_arguments = [
+        Felt::new(99),
+        Felt::new(98),
+        Felt::new(97),
+        Felt::new(96),
+        ONE, // incr_nonce = true
+    ];
+    let auth_argument_key = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+
+    let tx_context = TransactionContextBuilder::new(account)
+        .auth_argument(auth_argument_key)
+        .extend_advice_map([(auth_argument_key, auth_arguments.to_vec())])
+        .build()
+        .unwrap();
+
+    let executed_transaction = tx_context.execute();
+
+    assert!(
+        executed_transaction.is_ok(),
+        "Transaction execution failed {:?}",
+        executed_transaction,
+    );
+}
+
+#[test]
+fn test_auth_procedure_args_wrong_inputs() {
+    let auth_component =
+        ConditionalAuthComponent::new(TransactionKernel::testing_assembler()).unwrap();
+    let account = Account::mock(
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
+        ONE,
+        auth_component,
+        TransactionKernel::testing_assembler(),
+    );
+
+    // The auth script expects [99, 98, 97, 96, nonce_increment_flag]
+    let auth_arguments = [
+        Felt::new(103),
+        Felt::new(102),
+        Felt::new(101),
+        Felt::new(100),
+        ONE, // incr_nonce = true
+    ];
+    let auth_argument_key = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+
+    let tx_context = TransactionContextBuilder::new(account)
+        .auth_argument(auth_argument_key)
+        .extend_advice_map([(auth_argument_key, auth_arguments.to_vec())])
+        .build()
+        .unwrap();
+
+    let executed_transaction = tx_context.execute();
+
+    assert!(executed_transaction.is_err());
+
+    let err = executed_transaction.unwrap_err();
+
+    let TransactionExecutorError::TransactionProgramExecutionFailed(err) = err else {
+        panic!("unexpected error")
+    };
+
+    assert_execution_error!(Err::<(), _>(err), ERR_WRONG_ARGS);
+}

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,4 +1,3 @@
-use crate::assert_execution_error;
 use miden_lib::{errors::MasmError, transaction::TransactionKernel};
 use miden_objects::{
     account::Account,
@@ -10,7 +9,7 @@ use miden_objects::{
 use miden_tx::TransactionExecutorError;
 
 use super::{Felt, ONE};
-use crate::TransactionContextBuilder;
+use crate::{TransactionContextBuilder, assert_execution_error};
 
 pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -45,8 +45,7 @@ fn test_auth_procedure_args() {
 
     assert!(
         executed_transaction.is_ok(),
-        "Transaction execution failed {:?}",
-        executed_transaction,
+        "Transaction execution failed {executed_transaction:?}",
     );
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use miden_lib::{errors::MasmError, transaction::TransactionKernel};
 use miden_objects::{
     account::Account,
@@ -13,10 +14,14 @@ use crate::{TransactionContextBuilder, assert_execution_error};
 
 pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);
 
+/// Tests that authentication arguments are correctly passed to the auth procedure.
+///
+/// This test creates an account with a conditional auth component that expects specific
+/// auth arguments [97, 98, 99] to not error out. When the correct arguments are provided,
+/// the nonce is incremented (because of `incr_nonce_flag`).
 #[test]
-fn test_auth_procedure_args() {
-    let auth_component =
-        ConditionalAuthComponent::new(TransactionKernel::testing_assembler()).unwrap();
+fn test_auth_procedure_args() -> anyhow::Result<()> {
+    let auth_component = ConditionalAuthComponent::new(TransactionKernel::testing_assembler())?;
     let account = Account::mock(
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
         ONE,
@@ -31,23 +36,21 @@ fn test_auth_procedure_args() {
         Felt::new(97),
     ];
 
-    let tx_context = TransactionContextBuilder::new(account)
-        .auth_arg(auth_arg.into())
-        .build()
-        .unwrap();
+    let tx_context = TransactionContextBuilder::new(account).auth_arg(auth_arg.into()).build()?;
 
-    let executed_transaction = tx_context.execute();
+    tx_context.execute().context("failed to execute transaction")?;
 
-    assert!(
-        executed_transaction.is_ok(),
-        "Transaction execution failed {executed_transaction:?}",
-    );
+    Ok(())
 }
 
+/// Tests that incorrect authentication procedure arguments cause transaction execution to fail.
+///
+/// This test creates an account with a conditional auth component that expects specific
+/// auth arguments [97, 98, 99, incr_nonce_flag]. When incorrect arguments are provided
+/// (in this case [101, 102, 103]), the transaction should fail with an appropriate error message.
 #[test]
-fn test_auth_procedure_args_wrong_inputs() {
-    let auth_component =
-        ConditionalAuthComponent::new(TransactionKernel::testing_assembler()).unwrap();
+fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
+    let auth_component = ConditionalAuthComponent::new(TransactionKernel::testing_assembler())?;
     let account = Account::mock(
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
         ONE,
@@ -63,20 +66,17 @@ fn test_auth_procedure_args_wrong_inputs() {
         Felt::new(101),
     ];
 
-    let tx_context = TransactionContextBuilder::new(account)
-        .auth_arg(auth_arg.into())
-        .build()
-        .unwrap();
+    let tx_context = TransactionContextBuilder::new(account).auth_arg(auth_arg.into()).build()?;
 
-    let executed_transaction = tx_context.execute();
+    let execution_result = tx_context.execute();
 
-    assert!(executed_transaction.is_err());
-
-    let err = executed_transaction.unwrap_err();
-
-    let TransactionExecutorError::TransactionProgramExecutionFailed(err) = err else {
-        panic!("unexpected error")
+    let TransactionExecutorError::TransactionProgramExecutionFailed(err) =
+        execution_result.unwrap_err()
+    else {
+        panic!("unexpected error type")
     };
 
     assert_execution_error!(Err::<(), _>(err), ERR_WRONG_ARGS);
+
+    Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -29,14 +29,14 @@ fn test_auth_procedure_args() -> anyhow::Result<()> {
         TransactionKernel::testing_assembler(),
     );
 
-    let auth_arg = [
+    let auth_args = [
         ONE, // incr_nonce = true
         Felt::new(99),
         Felt::new(98),
         Felt::new(97),
     ];
 
-    let tx_context = TransactionContextBuilder::new(account).auth_arg(auth_arg.into()).build()?;
+    let tx_context = TransactionContextBuilder::new(account).auth_args(auth_args.into()).build()?;
 
     tx_context.execute().context("failed to execute transaction")?;
 
@@ -59,14 +59,14 @@ fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
     );
 
     // The auth script expects [99, 98, 97, nonce_increment_flag]
-    let auth_arg = [
+    let auth_args = [
         ONE, // incr_nonce = true
         Felt::new(103),
         Felt::new(102),
         Felt::new(101),
     ];
 
-    let tx_context = TransactionContextBuilder::new(account).auth_arg(auth_arg.into()).build()?;
+    let tx_context = TransactionContextBuilder::new(account).auth_args(auth_args.into()).build()?;
 
     let execution_result = tx_context.execute();
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1290,7 +1290,7 @@ fn test_tx_script_inputs() -> anyhow::Result<()> {
 /// Tests transaction script arguments.
 #[test]
 fn test_tx_script_args() -> anyhow::Result<()> {
-    let tx_script_arg = Word::from([1, 2, 3, 4u32]);
+    let tx_script_args = Word::from([1, 2, 3, 4u32]);
 
     let tx_script_src = r#"
         use.miden::account
@@ -1322,10 +1322,10 @@ fn test_tx_script_args() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
         .extend_advice_map([(
-            tx_script_arg,
+            tx_script_args,
             vec![Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)],
         )])
-        .tx_script_arg(tx_script_arg)
+        .tx_script_args(tx_script_args)
         .build()?;
 
     tx_context.execute()?;

--- a/crates/miden-testing/src/mock_chain/auth.rs
+++ b/crates/miden-testing/src/mock_chain/auth.rs
@@ -36,7 +36,11 @@ pub enum Auth {
     /// Creates a mock authentication mechanism for the account that does nothing.
     Noop,
 
-    /// TODO update once #1501 is ready.
+    /// Creates a mock authentication mechanism for the account that conditionally succeeds and
+    /// conditionally increments the nonce based on the authentication arguments.
+    ///
+    /// The auth procedure expects the first three arguments as [99, 98, 97] to succeed.
+    /// In case it succeeds, it conditionally increments the nonce based on the fourth argument.
     Conditional,
 }
 

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -71,6 +71,7 @@ pub struct TransactionContextBuilder {
     tx_script_arg: Word,
     note_args: BTreeMap<NoteId, Word>,
     transaction_inputs: Option<TransactionInputs>,
+    auth_argument: Word,
 }
 
 impl TransactionContextBuilder {
@@ -88,6 +89,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
+            auth_argument: EMPTY_WORD,
         }
     }
 
@@ -128,6 +130,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
+            auth_argument: EMPTY_WORD,
         }
     }
 
@@ -228,6 +231,12 @@ impl TransactionContextBuilder {
         self
     }
 
+    /// Set the desired auth arguments
+    pub fn auth_argument(mut self, auth_argument: Word) -> Self {
+        self.auth_argument = auth_argument;
+        self
+    }
+
     /// Set the desired transaction inputs
     pub fn tx_inputs(mut self, tx_inputs: TransactionInputs) -> Self {
         self.transaction_inputs = Some(tx_inputs);
@@ -295,6 +304,8 @@ impl TransactionContextBuilder {
         } else {
             tx_args
         };
+
+        tx_args = tx_args.with_auth_argument(self.auth_argument);
 
         tx_args.extend_advice_inputs(self.advice_inputs.clone());
         tx_args.extend_output_note_recipients(self.expected_output_notes.clone());

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -71,7 +71,7 @@ pub struct TransactionContextBuilder {
     tx_script_args: Word,
     note_args: BTreeMap<NoteId, Word>,
     transaction_inputs: Option<TransactionInputs>,
-    auth_arg: Word,
+    auth_args: Word,
 }
 
 impl TransactionContextBuilder {
@@ -89,7 +89,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
-            auth_arg: EMPTY_WORD,
+            auth_args: EMPTY_WORD,
         }
     }
 
@@ -130,7 +130,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
-            auth_arg: EMPTY_WORD,
+            auth_args: EMPTY_WORD,
         }
     }
 
@@ -232,8 +232,8 @@ impl TransactionContextBuilder {
     }
 
     /// Set the desired auth arguments
-    pub fn auth_arg(mut self, auth_arg: Word) -> Self {
-        self.auth_arg = auth_arg;
+    pub fn auth_args(mut self, auth_args: Word) -> Self {
+        self.auth_args = auth_args;
         self
     }
 
@@ -305,7 +305,7 @@ impl TransactionContextBuilder {
             tx_args
         };
 
-        tx_args = tx_args.with_auth_arg(self.auth_arg);
+        tx_args = tx_args.with_auth_args(self.auth_args);
 
         tx_args.extend_advice_inputs(self.advice_inputs.clone());
         tx_args.extend_output_note_recipients(self.expected_output_notes.clone());

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -71,7 +71,7 @@ pub struct TransactionContextBuilder {
     tx_script_arg: Word,
     note_args: BTreeMap<NoteId, Word>,
     transaction_inputs: Option<TransactionInputs>,
-    auth_argument: Word,
+    auth_arg: Word,
 }
 
 impl TransactionContextBuilder {
@@ -89,7 +89,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
-            auth_argument: EMPTY_WORD,
+            auth_arg: EMPTY_WORD,
         }
     }
 
@@ -130,7 +130,7 @@ impl TransactionContextBuilder {
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
-            auth_argument: EMPTY_WORD,
+            auth_arg: EMPTY_WORD,
         }
     }
 
@@ -232,8 +232,8 @@ impl TransactionContextBuilder {
     }
 
     /// Set the desired auth arguments
-    pub fn auth_argument(mut self, auth_argument: Word) -> Self {
-        self.auth_argument = auth_argument;
+    pub fn auth_arg(mut self, auth_arg: Word) -> Self {
+        self.auth_arg = auth_arg;
         self
     }
 
@@ -305,7 +305,7 @@ impl TransactionContextBuilder {
             tx_args
         };
 
-        tx_args = tx_args.with_auth_argument(self.auth_argument);
+        tx_args = tx_args.with_auth_arg(self.auth_arg);
 
         tx_args.extend_advice_inputs(self.advice_inputs.clone());
         tx_args.extend_output_note_recipients(self.expected_output_notes.clone());

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -68,7 +68,7 @@ pub struct TransactionContextBuilder {
     foreign_account_inputs: Vec<AccountInputs>,
     input_notes: Vec<Note>,
     tx_script: Option<TransactionScript>,
-    tx_script_arg: Word,
+    tx_script_args: Word,
     note_args: BTreeMap<NoteId, Word>,
     transaction_inputs: Option<TransactionInputs>,
     auth_arg: Word,
@@ -83,7 +83,7 @@ impl TransactionContextBuilder {
             input_notes: Vec::new(),
             expected_output_notes: Vec::new(),
             tx_script: None,
-            tx_script_arg: EMPTY_WORD,
+            tx_script_args: EMPTY_WORD,
             authenticator: None,
             advice_inputs: Default::default(),
             transaction_inputs: None,
@@ -126,7 +126,7 @@ impl TransactionContextBuilder {
             expected_output_notes: Vec::new(),
             advice_inputs: Default::default(),
             tx_script: None,
-            tx_script_arg: EMPTY_WORD,
+            tx_script_args: EMPTY_WORD,
             transaction_inputs: None,
             note_args: BTreeMap::new(),
             foreign_account_inputs: vec![],
@@ -226,8 +226,8 @@ impl TransactionContextBuilder {
     }
 
     /// Set the transaction script argument
-    pub fn tx_script_arg(mut self, tx_script_arg: Word) -> Self {
-        self.tx_script_arg = tx_script_arg;
+    pub fn tx_script_args(mut self, tx_script_args: Word) -> Self {
+        self.tx_script_args = tx_script_args;
         self
     }
 
@@ -300,7 +300,7 @@ impl TransactionContextBuilder {
             .with_note_args(self.note_args);
 
         let mut tx_args = if let Some(tx_script) = self.tx_script {
-            tx_args.with_tx_script_and_arg(tx_script, self.tx_script_arg)
+            tx_args.with_tx_script_and_arg(tx_script, self.tx_script_args)
         } else {
             tx_args
         };


### PR DESCRIPTION
Pass authentication arguments to the auth component:
- similar to how tx arguments are passed, but we don't need to add TX_SCRIPT_ROOT to the advice stack (it's already there via loading account procedures)
- allow tx builder to specify these arguments


closes https://github.com/0xMiden/miden-base/issues/1579