### PR TITLE
refactor: Change return type in advice inputs constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Added `Note::is_network_note()` accessor (#1485).
 - [BREAKING] Update handling of the shared modules (#1490).
 - Added a new constructor for `TransactionExecutor` that accepts `ExecutionOptions` (#1502).
+- [BREAKING] `TransactionAdviceInputs` cannot return `Err` anymore (#1517).
 
 ## 0.9.5 (2025-06-20) - `miden-lib` crate only
 

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -125,7 +125,7 @@ impl TransactionKernel {
             tx_inputs.block_header().block_num(),
         );
 
-        let mut tx_advice_inputs = TransactionAdviceInputs::new(tx_inputs, tx_args)?;
+        let mut tx_advice_inputs = TransactionAdviceInputs::new(tx_inputs, tx_args);
         if let Some(init_advice_inputs) = init_advice_inputs {
             tx_advice_inputs.extend(init_advice_inputs);
         }

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -177,11 +177,6 @@ impl TransactionArgs {
         }
     }
 
-    /// Extends the advice inputs in self with the provided ones.
-    pub fn extend_advice_inputs(&mut self, advice_inputs: AdviceInputs) {
-        self.advice_inputs.extend(advice_inputs);
-    }
-
     /// Extends the internal advice inputs' map with the provided key-value pairs.
     pub fn extend_advice_map<T: IntoIterator<Item = (Digest, Vec<Felt>)>>(&mut self, iter: T) {
         self.advice_inputs.extend_map(iter)
@@ -190,6 +185,12 @@ impl TransactionArgs {
     /// Extends the internal advice inputs' merkle store with the provided nodes.
     pub fn extend_merkle_store<I: Iterator<Item = InnerNodeInfo>>(&mut self, iter: I) {
         self.advice_inputs.extend_merkle_store(iter)
+    }
+
+    /// Extends the advice inputs in self with the provided ones.
+    #[cfg(feature = "testing")]
+    pub fn extend_advice_inputs(&mut self, advice_inputs: AdviceInputs) {
+        self.advice_inputs.extend(advice_inputs);
     }
 }
 


### PR DESCRIPTION
I think the last few commits in https://github.com/0xMiden/miden-base/pull/1425 refactored a few functions so that we don't need to return `Result<>` anymore. This PR adds this change, as well as a smaller one that gates a mutator behind the `testing` feature.