### PR TITLE
Expose note-related `tx` procedures

### DIFF
--- a/crates/miden-lib/asm/account_components/basic_wallet.masm
+++ b/crates/miden-lib/asm/account_components/basic_wallet.masm
@@ -3,5 +3,4 @@
 # See the `BasicWallet` Rust type's documentation for more details.
 
 export.::miden::contracts::wallets::basic::receive_asset
-export.::miden::contracts::wallets::basic::create_note
 export.::miden::contracts::wallets::basic::move_asset_to_note

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -765,14 +765,6 @@ end
 #!
 #! Invocation: dynexec
 export.tx_create_note
-    # check that this procedure was executed against the native account
-    exec.memory::assert_native_account
-    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
-
-    # authenticate that the procedure invocation originates from the account context
-    exec.authenticate_account_origin drop drop
-    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
-
     exec.tx::create_note
     # => [note_idx, pad(15)]
 end

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -759,10 +759,6 @@ end
 #! - RECIPIENT is the recipient of the note.
 #! - note_idx is the index of the created note.
 #!
-#! Panics if:
-#! - the procedure is called from a non-account context.
-#! - the invocation of this procedure does not originate from the native account.
-#!
 #! Invocation: dynexec
 export.tx_create_note
     exec.tx::create_note

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -636,20 +636,8 @@ end
 #! - note_idx is the index of the note to which the asset is added.
 #! - ASSET can be a fungible or non-fungible asset.
 #!
-#! Panics if:
-#! - the procedure is called from a non-account context.
-#! - the invocation of this procedure does not originate from the native account.
-#!
 #! Invocation: dynexec
 export.note_add_asset
-    # check that this procedure was executed against the native account
-    exec.memory::assert_native_account
-    # => [note_idx, ASSET, pad(11)]
-
-    # authenticate that the procedure invocation originates from the account context
-    exec.authenticate_account_origin drop drop
-    # => [note_idx, ASSET, pad(11)]
-
     # duplicate the asset word to be able to return it
     movdn.4 dupw movup.8
     # => [note_idx, ASSET, ASSET, pad(11)]

--- a/crates/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -28,32 +28,6 @@ export.receive_asset
     # => [pad(16)]
 end
 
-#! Creates a new note.
-#!
-#! The created note will not have any assets attached to it. To add assets to this note use the
-#! `move_asset_to_note` procedure.
-#!
-#! This procedure is expected to be invoked using a `call` instruction. It makes no guarantees about
-#! the contents of the `PAD` elements shown below. It is the caller's responsibility to make sure
-#! these elements do not contain any meaningful data.
-#!
-#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
-#! Outputs: [note_idx, pad(15)]
-#!
-#! Where:
-#! - tag is the tag to be included in the note.
-#! - aux is the auxiliary data to be included in the note.
-#! - note_type is the note's storage type
-#! - execution_hint is the note's execution hint
-#! - RECIPIENT is the recipient of the note, i.e.,
-#!   hash(hash(hash(serial_num, [0; 4]), script_root), input_commitment)
-#!
-#! Invocation: call
-export.create_note
-    exec.tx::create_note
-    # => [note_idx, pad(15) ...]
-end
-
 #! Removes the specified asset from the account and adds it to the output note with the specified
 #! index.
 #!

--- a/crates/miden-lib/asm/note_scripts/SWAP.masm
+++ b/crates/miden-lib/asm/note_scripts/SWAP.masm
@@ -1,4 +1,5 @@
 use.miden::note
+use.miden::tx
 use.miden::contracts::wallets::basic->wallet
 
 # CONSTANTS
@@ -18,7 +19,6 @@ const.ERR_SWAP_WRONG_NUMBER_OF_ASSETS="SWAP script requires exactly 1 note asset
 #!
 #! Requires that the account exposes:
 #! - miden::contracts::wallets::basic::receive_asset procedure.
-#! - miden::contracts::wallets::basic::create_note procedure.
 #! - miden::contracts::wallets::basic::move_asset_to_note procedure.
 #!
 #! Inputs:  []
@@ -31,7 +31,6 @@ const.ERR_SWAP_WRONG_NUMBER_OF_ASSETS="SWAP script requires exactly 1 note asset
 #!
 #! Panics if:
 #! - account does not expose miden::contracts::wallets::basic::receive_asset procedure.
-#! - account does not expose miden::contracts::wallets::basic::create_note procedure.
 #! - account does not expose miden::contracts::wallets::basic::move_asset_to_note procedure.
 #! - account vault does not contain the requested asset.
 #! - adding a fungible asset would result in amount overflow, i.e., the total amount would be
@@ -97,7 +96,7 @@ begin
     # create a note using inputs
     padw swapdw padw movdnw.2
     # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8), ASSET]
-    call.wallet::create_note
+    call.tx::create_note
     # => [note_idx, pad(15), ASSET]
 
     swapw dropw movupw.3

--- a/crates/miden-lib/src/account/interface/component.rs
+++ b/crates/miden-lib/src/account/interface/component.rs
@@ -241,7 +241,7 @@ impl AccountComponentInterface {
                     // stack => []
                 },
                 AccountComponentInterface::BasicWallet => {
-                    body.push_str("call.::miden::contracts::wallets::basic::create_note\n");
+                    body.push_str("call.::miden::tx::create_note\n");
                     // stack => [note_idx]
 
                     for asset in partial_note.assets().iter() {

--- a/crates/miden-lib/src/account/interface/test.rs
+++ b/crates/miden-lib/src/account/interface/test.rs
@@ -229,24 +229,23 @@ fn test_basic_wallet_custom_notes() {
     let vault = NoteAssets::new(vec![FungibleAsset::mock(100)]).unwrap();
 
     let compatible_source_code = "
+        use.miden::tx
         use.miden::contracts::wallets::basic->wallet
         use.miden::contracts::faucets::basic_fungible->fungible_faucet
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
                 call.wallet::move_asset_to_note
-                
+
                 # unsupported procs
                 call.fungible_faucet::distribute
                 call.fungible_faucet::burn
             else
                 # supported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
                 call.wallet::move_asset_to_note
             end
         end
@@ -262,12 +261,13 @@ fn test_basic_wallet_custom_notes() {
     );
 
     let incompatible_source_code = "
+        use.miden::tx
         use.miden::contracts::wallets::basic->wallet
         use.miden::contracts::faucets::basic_fungible->fungible_faucet
 
         begin
             push.1
-            if.true 
+            if.true
                 # unsupported procs
                 call.fungible_faucet::distribute
                 call.fungible_faucet::burn
@@ -276,7 +276,6 @@ fn test_basic_wallet_custom_notes() {
                 call.fungible_faucet::distribute
 
                 # supported procs
-                call.wallet::create_note
                 call.wallet::receive_asset
                 call.wallet::move_asset_to_note
             end
@@ -326,12 +325,13 @@ fn test_basic_fungible_faucet_custom_notes() {
     let vault = NoteAssets::new(vec![FungibleAsset::mock(100)]).unwrap();
 
     let compatible_source_code = "
+        use.miden::tx
         use.miden::contracts::wallets::basic->wallet
         use.miden::contracts::faucets::basic_fungible->fungible_faucet
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported procs
                 call.fungible_faucet::distribute
                 call.fungible_faucet::burn
@@ -341,7 +341,7 @@ fn test_basic_fungible_faucet_custom_notes() {
 
                 # unsupported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
+                call.tx::create_note
                 call.wallet::move_asset_to_note
             end
         end
@@ -357,16 +357,17 @@ fn test_basic_fungible_faucet_custom_notes() {
     );
 
     let incompatible_source_code = "
+        use.miden::tx
         use.miden::contracts::wallets::basic->wallet
         use.miden::contracts::faucets::basic_fungible->fungible_faucet
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported procs
                 call.fungible_faucet::distribute
                 call.fungible_faucet::burn
-            
+
                 # unsupported proc
                 call.wallet::receive_asset
             else
@@ -374,7 +375,7 @@ fn test_basic_fungible_faucet_custom_notes() {
                 call.fungible_faucet::burn
 
                 # unsupported procs
-                call.wallet::create_note
+                call.tx::create_note
                 call.wallet::move_asset_to_note
             end
         end
@@ -449,7 +450,7 @@ fn test_custom_account_custom_notes() {
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported proc
                 call.test_account::procedure_1
 
@@ -477,17 +478,18 @@ fn test_custom_account_custom_notes() {
     );
 
     let incompatible_source_code = "
+        use.miden::tx
         use.miden::contracts::wallets::basic->wallet
         use.test::account::component_1->test_account
 
         begin
             push.1
-            if.true 
+            if.true
                 call.wallet::receive_asset
                 call.test_account::procedure_1
             else
                 call.test_account::procedure_2
-                call.wallet::create_note
+                call.tx::create_note
                 call.wallet::move_asset_to_note
             end
         end
@@ -573,10 +575,9 @@ fn test_custom_account_multiple_components_custom_notes() {
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
                 call.wallet::move_asset_to_note
                 call.test_account::procedure_1
                 call.test_account::procedure_2
@@ -584,7 +585,6 @@ fn test_custom_account_multiple_components_custom_notes() {
             else
                 # supported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
                 call.wallet::move_asset_to_note
                 call.test_account::procedure_1
                 call.test_account::procedure_2
@@ -617,10 +617,9 @@ fn test_custom_account_multiple_components_custom_notes() {
 
         begin
             push.1
-            if.true 
+            if.true
                 # supported procs
                 call.wallet::receive_asset
-                call.wallet::create_note
                 call.wallet::move_asset_to_note
                 call.test_account::procedure_1
                 call.test_account::procedure_2

--- a/crates/miden-lib/src/account/wallets/mod.rs
+++ b/crates/miden-lib/src/account/wallets/mod.rs
@@ -18,7 +18,6 @@ use crate::account::{auth::RpoFalcon512, components::basic_wallet_library};
 /// assembler which is the case when using [`TransactionKernel::assembler()`][kasm]. The procedures
 /// of this component are:
 /// - `receive_asset`, which can be used to add an asset to the account.
-/// - `create_note`, which can be used to create a new note without any assets attached to it.
 /// - `move_asset_to_note`, which can be used to remove the specified asset from the account and add
 ///   it to the output note with the specified index.
 ///
@@ -43,7 +42,6 @@ impl From<BasicWallet> for AccountComponent {
 ///
 /// The basic wallet interface exposes three procedures:
 /// - `receive_asset`, which can be used to add an asset to the account.
-/// - `create_note`, which can be used to create a new note without any assets attached to it.
 /// - `move_asset_to_note`, which can be used to remove the specified asset from the account and add
 ///   it to the output note with the specified index.
 ///

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -60,7 +60,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // note_get_script_root
     digest!("0x66fb188ca538d9f8bc6fd1aedbd19336bf6e3a1c0ae67b5f725cbc9cb4f7867f"),
     // tx_create_note
-    digest!("0xb0ce6d0bd9dfa8b77408fac615eb570381d28769914e7ca0475ba5dd00a2283a"),
+    digest!("0xdf9803f63ee8ab53868f48b337b7689faff84de8ab7eeca1356195a6c7dd7362"),
     // tx_get_input_notes_commitment
     digest!("0x16cb840dc9131e2fd2b3e83b8d796eb466722ae36f29f27b4b053f1bee2ed473"),
     // tx_get_output_notes_commitment

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -50,7 +50,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // note_get_assets_info
     digest!("0x8a1a66c95fd9dd85e47e30d9ba64be7803dcb7d03f612235722cc484ea865b3f"),
     // note_add_asset
-    digest!("0xb325acb9f8c21ba7253dd374fc23edc399c3aab15be77c6dbea76dcc71c822c2"),
+    digest!("0x215b89969345d374a003f782c5176227ace19605cbd4c020dc67ac5b50e5d1ba"),
     // note_get_serial_number
     digest!("0x59b3ea650232049bb333867841012c3694bd557fa199cd65655c0006edccc3ab"),
     // note_get_inputs_commitment_and_len

--- a/crates/miden-objects/src/testing/account_code.rs
+++ b/crates/miden-objects/src/testing/account_code.rs
@@ -21,7 +21,6 @@ pub(crate) const MOCK_ACCOUNT_CODE: &str = "
     use.miden::tx
 
     export.::miden::contracts::wallets::basic::receive_asset
-    export.::miden::contracts::wallets::basic::create_note
     export.::miden::contracts::wallets::basic::move_asset_to_note
     export.::miden::contracts::auth::basic::auth_tx_rpo_falcon512
     export.::miden::contracts::faucets::basic_fungible::distribute

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -12,7 +12,6 @@ use crate::{
 
 pub const BASIC_WALLET_CODE: &str = "
     export.::miden::contracts::wallets::basic::receive_asset
-    export.::miden::contracts::wallets::basic::create_note
     export.::miden::contracts::wallets::basic::move_asset_to_note
 ";
 

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -73,7 +73,7 @@ pub fn generate_untracked_note_with_output_note(sender: AccountId, output_note: 
     // A note script that creates the note that was passed in.
     let code = format!(
         "
-    use.test::account
+    use.miden::tx
 
     begin
         padw padw
@@ -84,7 +84,7 @@ pub fn generate_untracked_note_with_output_note(sender: AccountId, output_note: 
         push.{tag}
         # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
-        call.account::create_note drop
+        call.tx::create_note drop
         # => [pad(16)]
 
         dropw dropw dropw dropw dropw

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -195,7 +195,7 @@ fn executed_transaction_account_delta_new() {
             # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
             # create the note
-            call.::miden::contracts::wallets::basic::create_note
+            call.tx::create_note
             # => [note_idx, pad(15)]
 
             # move an asset to the created note to partially deplete fungible asset balance
@@ -217,6 +217,7 @@ fn executed_transaction_account_delta_new() {
     let tx_script_src = format!(
         "\
         use.test::account
+        use.miden::tx
 
         ## TRANSACTION SCRIPT
         ## ========================================================================================
@@ -448,6 +449,7 @@ fn test_send_note_proc() -> miette::Result<()> {
         let tx_script_src = format!(
             "\
             use.miden::contracts::wallets::basic->wallet
+            use.miden::tx
             use.test::account
 
             ## TRANSACTION SCRIPT
@@ -465,7 +467,7 @@ fn test_send_note_proc() -> miette::Result<()> {
                 padw padw swapdw
                 # => [tag, aux, execution_hint, note_type, RECIPIENT, pad(8) ...]
 
-                call.wallet::create_note
+                call.tx::create_note
                 # => [note_idx, GARBAGE(15)]
 
                 movdn.4
@@ -608,6 +610,7 @@ fn executed_transaction_output_notes() {
     let tx_script_src = format!(
         "\
         use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
         use.test::account
 
         # Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
@@ -618,7 +621,7 @@ fn executed_transaction_output_notes() {
             padw padw swapdw
             # => [tag, aux, execution_hint, note_type, RECIPIENT, pad(8)]
 
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx, pad(15)]
 
             # remove excess PADs from the stack

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -600,6 +600,7 @@ fn word(data: [u32; 4]) -> Word {
 
 const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
       use.test::account
+      use.miden::tx
 
       #! Inputs:  [nonce_increment]
       #! Outputs: []
@@ -664,7 +665,7 @@ const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
           repeat.8 push.0 movdn.8 end
           # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
-          call.account::create_note
+          call.tx::create_note
           # => [note_idx, pad(15)]
 
           repeat.15 swap drop end

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -126,7 +126,7 @@ fn test_create_note() {
 
     let code = format!(
         "
-        use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
         
         use.kernel::prologue
 
@@ -139,7 +139,7 @@ fn test_create_note() {
             push.{aux}
             push.{tag}
 
-            call.wallet::create_note
+            call.tx::create_note
 
             # truncate the stack
             swapdw dropw dropw
@@ -233,7 +233,7 @@ fn test_create_note_with_invalid_tag() {
     fn note_creation_script(tag: Felt) -> String {
         format!(
             "
-            use.miden::contracts::wallets::basic->wallet
+            use.miden::tx
             use.kernel::prologue
     
             begin
@@ -245,7 +245,7 @@ fn test_create_note_with_invalid_tag() {
                 push.{aux}
                 push.{tag}
     
-                call.wallet::create_note
+                call.tx::create_note
 
                 # clean the stack
                 dropw dropw
@@ -265,7 +265,7 @@ fn test_create_note_too_many_notes() {
 
     let code = format!(
         "
-        use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
         use.kernel::constants
         use.kernel::memory
         use.kernel::prologue
@@ -281,7 +281,7 @@ fn test_create_note_too_many_notes() {
             push.{aux}
             push.{tag}
 
-            call.wallet::create_note
+            call.tx::create_note
         end
         ",
         tag = NoteTag::for_local_use_case(1234, 5678).unwrap(),
@@ -359,7 +359,6 @@ fn test_get_output_notes_commitment() {
         "
         use.std::sys
 
-        use.miden::contracts::wallets::basic->wallet
         use.miden::tx
 
         use.kernel::prologue
@@ -376,7 +375,7 @@ fn test_get_output_notes_commitment() {
             push.{PUBLIC_NOTE}
             push.{aux_1}
             push.{tag_1}
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx]
 
             push.{asset_1}
@@ -392,7 +391,7 @@ fn test_get_output_notes_commitment() {
             push.{PUBLIC_NOTE}
             push.{aux_2}
             push.{tag_2}
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx]
 
             push.{asset_2} 
@@ -475,7 +474,7 @@ fn test_create_note_and_add_asset() {
 
     let code = format!(
         "
-        use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
 
         use.kernel::prologue
         use.test::account
@@ -489,7 +488,7 @@ fn test_create_note_and_add_asset() {
             push.{aux}
             push.{tag}
 
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx]
 
             push.{asset}
@@ -552,7 +551,7 @@ fn test_create_note_and_add_multiple_assets() {
 
     let code = format!(
         "
-        use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
 
         use.kernel::prologue
         use.test::account
@@ -565,7 +564,7 @@ fn test_create_note_and_add_multiple_assets() {
             push.{aux}
             push.{tag}
 
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx]
 
             push.{asset}
@@ -649,7 +648,7 @@ fn test_create_note_and_add_same_nft_twice() {
         "
         use.kernel::prologue
         use.test::account
-        use.miden::contracts::wallets::basic->wallet
+        use.miden::tx
 
         begin
             exec.prologue::prepare_transaction
@@ -662,7 +661,7 @@ fn test_create_note_and_add_same_nft_twice() {
             push.{aux}
             push.{tag}
 
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx, pad(15)]
 
             push.{nft} 
@@ -712,7 +711,6 @@ fn test_build_recipient_hash() {
     let recipient = NoteRecipient::new(output_serial_no, input_note_1.script().clone(), inputs);
     let code = format!(
         "
-        use.miden::contracts::wallets::basic->wallet
         use.miden::tx
         use.kernel::prologue
 
@@ -743,7 +741,7 @@ fn test_build_recipient_hash() {
             push.{tag}
             # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(12)]
 
-            call.wallet::create_note
+            call.tx::create_note
             # => [note_idx, pad(19)]
 
             # clean the stack

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -274,6 +274,7 @@ impl TransactionContextBuilder {
         let code = format!(
             "
             use.miden::contracts::wallets::basic->wallet
+            use.miden::tx
             use.test::account
 
             begin
@@ -287,7 +288,7 @@ impl TransactionContextBuilder {
                 push.{tag}
                 # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
-                call.wallet::create_note
+                call.tx::create_note
                 # => [note_idx, pad(15)]
 
                 push.{asset}
@@ -328,6 +329,7 @@ impl TransactionContextBuilder {
         let code = format!(
             "
             use.miden::contracts::wallets::basic->wallet
+            use.miden::tx
             use.test::account
 
             begin
@@ -342,7 +344,7 @@ impl TransactionContextBuilder {
                 push.{tag0}
                 # => [tag_0, aux_0, note_type, execution_hint, RECIPIENT_0, pad(8)]
 
-                call.wallet::create_note
+                call.tx::create_note
                 # => [note_idx_0, pad(15)]
 
                 push.{asset0}
@@ -361,7 +363,7 @@ impl TransactionContextBuilder {
                 push.{tag1}
                 # => [tag_1, aux_1, note_type, execution_hint, RECIPIENT_1, pad(8)]
 
-                call.wallet::create_note
+                call.tx::create_note
                 # => [note_idx_1, pad(15)]
                 
                 push.{asset1}

--- a/crates/miden-testing/tests/integration/scripts/p2id.rs
+++ b/crates/miden-testing/tests/integration/scripts/p2id.rs
@@ -239,13 +239,14 @@ fn test_create_consume_multiple_notes() {
 
     let tx_script_src = &format!(
         "
+            use.miden::tx
             begin
                 push.{recipient_1}
                 push.{note_execution_hint_1}
                 push.{note_type_1}
                 push.0              # aux
                 push.{tag_1}
-                call.::miden::contracts::wallets::basic::create_note
+                call.tx::create_note
 
                 push.{asset_1}
                 call.::miden::contracts::wallets::basic::move_asset_to_note
@@ -256,7 +257,7 @@ fn test_create_consume_multiple_notes() {
                 push.{note_type_2}
                 push.0              # aux
                 push.{tag_2}
-                call.::miden::contracts::wallets::basic::create_note
+                call.tx::create_note
 
                 push.{asset_2}
                 call.::miden::contracts::wallets::basic::move_asset_to_note

--- a/crates/miden-testing/tests/integration/scripts/swap.rs
+++ b/crates/miden-testing/tests/integration/scripts/swap.rs
@@ -29,13 +29,14 @@ pub fn prove_send_swap_note() {
 
     let tx_script_src = &format!(
         "
+        use.miden::tx
         begin
             push.{recipient}
             push.{note_execution_hint}
             push.{note_type}
             push.0              # aux
             push.{tag}
-            call.::miden::contracts::wallets::basic::create_note
+            call.tx::create_note
 
             push.{asset}
             call.::miden::contracts::wallets::basic::move_asset_to_note


### PR DESCRIPTION
Towards #1333

Tasks:
- [x] expose `tx::add_asset_to_note` without authentication
- [x] expose `tx::create_note` without authentication
- [x] remove `create_note` procedure from `BasicWallet` component
- [x] replace `wallet::create_note` with `tx::create_note` in associated tests

Missing:
- tests for directly calling `add_asset_to_note` from a tx/note script (à la [`AuxWallet`](https://github.com/0xMiden/miden-base/pull/1444))