### PR TITLE
fix: Re-add `ExecutionOptions` re-export

### DIFF
--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -10,8 +10,8 @@ pub use miden_objects::transaction::TransactionInputs;
 
 mod executor;
 pub use executor::{
-    DataStore, MastForestStore, NoteAccountExecution, NoteConsumptionChecker, NoteInputsCheck,
-    TransactionExecutor,
+    DataStore, ExecutionOptions, MastForestStore, NoteAccountExecution, NoteConsumptionChecker,
+    NoteInputsCheck, TransactionExecutor,
 };
 
 pub mod host;


### PR DESCRIPTION
Looks like (probably while solving merge conflicts) I might have [accidentally removed](https://github.com/0xMiden/miden-base/pull/1518/files#diff-8425b256bd1459318a47d96a5eb74e5e8e0482dc657c56b144cdc9abf66b9962R13) a re-export originally introduced [here](https://github.com/0xMiden/miden-base/pull/1502/files#diff-8425b256bd1459318a47d96a5eb74e5e8e0482dc657c56b144cdc9abf66b9962R13). This PR re-adds it.