### PR TITLE
Define the commitment to an empty account delta as `EMPTY_WORD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Implement serialization for `LexicographicWord` (#1524).
 - Add `with_auth_component` to `AccountBuilder` (#1480).
 - [BREAKING] Refactor account authentication to require a procedure containing `auth__` in its name (#1480).
+- Define the commitment to an empty account delta as `EMPTY_WORD` (#1528).
 
 ## 0.9.5 (2025-06-20) - `miden-lib` crate only
 

--- a/Makefile
+++ b/Makefile
@@ -64,17 +64,17 @@ book: ## Builds the book & serves documentation site
 
 .PHONY: test-build
 test-build: ## Build the test binary
-	cargo nextest run --cargo-profile test-dev --features concurrent,testing --no-run
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo nextest run --cargo-profile test-dev --features concurrent,testing --no-run
 
 
 .PHONY: test
-test: ## Run all tests
-	$(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing
+test: ## Run all tests. Running `make test name=test_name` will only run the test `test_name`.
+	$(BUILD_GENERATED_FILES_IN_SRC) $(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing $(name)
 
 
 .PHONY: test-dev
 test-dev: ## Run default tests excluding slow prove tests in debug mode intended to be run locally
-	$(BACKTRACE) cargo nextest run --profile default --features concurrent,testing --filter-expr "not test(prove)"
+	$(BUILD_GENERATED_FILES_IN_SRC) $(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing --filter-expr "not test(prove)"
 
 
 .PHONY: test-docs

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -226,8 +226,8 @@ export.incr_nonce
     u32assert.err=ERR_ACCOUNT_NONCE_INCREASE_MUST_BE_U32
     # => [nonce_increment]
 
-    dup exec.memory::incr_account_delta_nonce_increment
-    # => [nonce_increment]
+    dup exec.memory::incr_account_nonce_delta
+    # => [nonce_delta]
 
     # emit event to signal that account nonce is being incremented
     emit.ACCOUNT_BEFORE_INCREMENT_NONCE_EVENT

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -226,7 +226,7 @@ export.incr_nonce
     u32assert.err=ERR_ACCOUNT_NONCE_INCREASE_MUST_BE_U32
     # => [nonce_increment]
 
-    dup exec.memory::incr_account_nonce_delta
+    dup exec.memory::incr_account_delta_nonce_increment
     # => [nonce_increment]
 
     # emit event to signal that account nonce is being incremented

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -7,6 +7,11 @@ use.kernel::asset_vault
 use.std::crypto::hashes::rpo
 use.std::math::u64
 
+# ERRORS
+# =================================================================================================
+
+const.ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_WITH_VAULT_OR_STORAGE_CHANGES="account delta nonce must incremented if vault or storage changed"
+
 # CONSTANTS
 # =================================================================================================
 
@@ -32,6 +37,9 @@ const.DOMAIN_MAP=3
 #!
 #! Where:
 #! - DELTA_COMMITMENT is the commitment to the account delta.
+#!
+#! Panics if:
+#! - the vault or storage delta is not empty but the nonce increment is zero.
 export.compute_commitment
     # pad capacity element of the hasher
     padw
@@ -50,38 +58,43 @@ export.compute_commitment
     hperm
     # => [RATE, RATE, PERM]
 
+    # save the ID and nonce digest (the 2nd rate word) for a later check
+    dupw.1 movdnw.3
+    # => [RATE, RATE, PERM, ID_AND_NONCE_DIGEST]
+
     exec.update_fungible_asset_delta
-    # => [RATE, RATE, PERM]
+    # => [RATE, RATE, PERM, ID_AND_NONCE_DIGEST]
 
     exec.update_non_fungible_asset_delta
-    # => [RATE, RATE, PERM]
+    # => [RATE, RATE, PERM, ID_AND_NONCE_DIGEST]
 
     exec.update_storage_delta
-    # => [RATE, RATE, PERM]
+    # => [RATE, RATE, PERM, ID_AND_NONCE_DIGEST]
 
     exec.rpo::squeeze_digest
-    # => [DELTA_COMMITMENT]
+    # => [DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
 
-    # if the account delta is empty (no storage and vault changes and a nonce increment of zero)
-    # then the commitment to it is defined as the empty word
-    padw
-    # => [EMPTY_WORD, DELTA_COMMITMENT]
-
-    # the epilogue will ensure that if the state has changed, then the
-    # nonce must be incremented.
-    # so if the nonce increment is zero, then the delta must be empty
-    # important caveat: this is only true if the delta sees no further changes after computing
-    # the commitment
     exec.memory::get_account_delta_nonce_increment
-    # => [nonce_increment, EMPTY_WORD, DELTA_COMMITMENT]
+    # => [nonce_increment, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
 
     eq.0
-    # => [is_delta_empty, EMPTY_WORD, DELTA_COMMITMENT]
+    # => [is_nonce_zero, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
 
-    # If is_delta_empty EMPTY_WORD remains.
-    # If !is_delta_empty DELTA_COMMITMENT remains.
-    cdropw
-    # => [EMPTY_WORD, DELTA_COMMITMENT]
+    if.true
+        # if the nonce wasn't incremented, then the vault and storage changes must be empty
+        # if the delta commitment is equivalent to the ID_AND_NONCE_DIGEST, then storage
+        # and vault delta were empty
+        assert_eqw.err=ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_WITH_VAULT_OR_STORAGE_CHANGES
+        # => []
+
+        # if the delta is empty, its commitment is defined as the empty word
+        padw
+        # => [EMPTY_WORD]
+    else
+        # drop the ID and nonce digest
+        swapw dropw
+        # => [DELTA_COMMITMENT]
+    end
 end
 
 #! Updates the given delta hasher with the storage slots.

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -45,11 +45,11 @@ export.compute_commitment
     padw
     # => [CAPACITY]
 
-    exec.memory::get_account_delta_nonce_increment push.0
-    # => [0, nonce_increment, CAPACITY]
+    exec.memory::get_account_nonce_delta push.0
+    # => [0, nonce_delta, CAPACITY]
 
     exec.memory::get_native_account_id
-    # => [native_acct_id_prefix, native_acct_id_suffix, 0, nonce_increment, CAPACITY]
+    # => [native_acct_id_prefix, native_acct_id_suffix, 0, nonce_delta, CAPACITY]
     # => [ID_AND_NONCE, CAPACITY]
 
     padw
@@ -74,8 +74,8 @@ export.compute_commitment
     exec.rpo::squeeze_digest
     # => [DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
 
-    exec.memory::get_account_delta_nonce_increment
-    # => [nonce_increment, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
+    exec.memory::get_account_nonce_delta
+    # => [nonce_delta, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
 
     eq.0
     # => [is_nonce_zero, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -37,11 +37,11 @@ export.compute_commitment
     padw
     # => [CAPACITY]
 
-    exec.memory::get_account_nonce_delta push.0
-    # => [0, nonce_delta, CAPACITY]
+    exec.memory::get_account_delta_nonce_increment push.0
+    # => [0, nonce_increment, CAPACITY]
 
     exec.memory::get_native_account_id
-    # => [native_acct_id_prefix, native_acct_id_suffix, 0, nonce_delta, CAPACITY]
+    # => [native_acct_id_prefix, native_acct_id_suffix, 0, nonce_increment, CAPACITY]
     # => [ID_AND_NONCE, CAPACITY]
 
     padw
@@ -72,7 +72,7 @@ export.compute_commitment
     # so if the nonce increment is zero, then the delta must be empty
     # important caveat: this is only true if the delta sees no further changes after computing
     # the commitment
-    exec.memory::get_account_nonce_delta
+    exec.memory::get_account_delta_nonce_increment
     # => [nonce_increment, EMPTY_WORD, DELTA_COMMITMENT]
 
     eq.0

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -61,6 +61,27 @@ export.compute_commitment
 
     exec.rpo::squeeze_digest
     # => [DELTA_COMMITMENT]
+
+    # if the account delta is empty (no storage and vault changes and a nonce increment of zero)
+    # then the commitment to it is defined as the empty word
+    padw
+    # => [EMPTY_WORD, DELTA_COMMITMENT]
+
+    # the epilogue will ensure that if the state has changed, then the
+    # nonce must be incremented.
+    # so if the nonce increment is zero, then the delta must be empty
+    # important caveat: this is only true if the delta sees no further changes after computing
+    # the commitment
+    exec.memory::get_account_nonce_delta
+    # => [nonce_increment, EMPTY_WORD, DELTA_COMMITMENT]
+
+    eq.0
+    # => [is_delta_empty, EMPTY_WORD, DELTA_COMMITMENT]
+
+    # If is_delta_empty EMPTY_WORD remains.
+    # If !is_delta_empty DELTA_COMMITMENT remains.
+    cdropw
+    # => [EMPTY_WORD, DELTA_COMMITMENT]
 end
 
 #! Updates the given delta hasher with the storage slots.

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -171,7 +171,7 @@ const.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET=4128
 # -------------------------------------------------------------------------------------------------
 
 # The pointer at which the delta of the nonce is stored.
-# Layout: [nonce_delta, 0, 0, 0]
+# Layout: [nonce_increment, 0, 0, 0]
 const.ACCOUNT_DELTA_NONCE_PTR=532480
 
 # The link map pointer at which the delta of the fungible asset vault is stored.
@@ -1223,26 +1223,26 @@ end
 
 #! Increments the delta of the account's nonce.
 #!
-#! Example: If this procedure is called with nonce_delta 3 and again with nonce_delta 2, then the
-#! stored nonce_delta will be 5.
+#! Example: If this procedure is called with nonce_increment 3 and again with nonce_increment 2, then the
+#! stored nonce_increment will be 5.
 #!
-#! Inputs:  [nonce_delta]
+#! Inputs:  [nonce_increment]
 #! Outputs: []
 #!
 #! Where:
-#! - nonce_delta is the value by which the nonce changed.
-export.incr_account_nonce_delta
-    exec.get_account_nonce_delta add mem_store.ACCOUNT_DELTA_NONCE_PTR
+#! - nonce_increment is the value by which the nonce changed.
+export.incr_account_delta_nonce_increment
+    exec.get_account_delta_nonce_increment add mem_store.ACCOUNT_DELTA_NONCE_PTR
 end
 
 #! Returns the delta of the account's nonce.
 #!
 #! Inputs:  []
-#! Outputs: [nonce_delta]
+#! Outputs: [nonce_increment]
 #!
 #! Where:
-#! - nonce_delta is the value by which the nonce changed.
-export.get_account_nonce_delta
+#! - nonce_increment is the value by which the nonce changed.
+export.get_account_delta_nonce_increment
     mem_load.ACCOUNT_DELTA_NONCE_PTR
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -171,7 +171,7 @@ const.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET=4128
 # -------------------------------------------------------------------------------------------------
 
 # The pointer at which the delta of the nonce is stored.
-# Layout: [nonce_increment, 0, 0, 0]
+# Layout: [nonce_delta, 0, 0, 0]
 const.ACCOUNT_DELTA_NONCE_PTR=532480
 
 # The link map pointer at which the delta of the fungible asset vault is stored.
@@ -1223,26 +1223,26 @@ end
 
 #! Increments the delta of the account's nonce.
 #!
-#! Example: If this procedure is called with nonce_increment 3 and again with nonce_increment 2,
-#! then the stored nonce_increment will be 5.
+#! Example: If this procedure is called with nonce_delta 3 and again with nonce_delta 2,
+#! then the stored nonce_delta will be 5.
 #!
-#! Inputs:  [nonce_increment]
+#! Inputs:  [nonce_delta]
 #! Outputs: []
 #!
 #! Where:
-#! - nonce_increment is the value by which the nonce changed.
-export.incr_account_delta_nonce_increment
-    exec.get_account_delta_nonce_increment add mem_store.ACCOUNT_DELTA_NONCE_PTR
+#! - nonce_delta is the value by which the nonce changed.
+export.incr_account_nonce_delta
+    exec.get_account_nonce_delta add mem_store.ACCOUNT_DELTA_NONCE_PTR
 end
 
 #! Returns the delta of the account's nonce.
 #!
 #! Inputs:  []
-#! Outputs: [nonce_increment]
+#! Outputs: [nonce_delta]
 #!
 #! Where:
-#! - nonce_increment is the value by which the nonce changed.
-export.get_account_delta_nonce_increment
+#! - nonce_delta is the value by which the nonce changed.
+export.get_account_nonce_delta
     mem_load.ACCOUNT_DELTA_NONCE_PTR
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -1223,8 +1223,8 @@ end
 
 #! Increments the delta of the account's nonce.
 #!
-#! Example: If this procedure is called with nonce_increment 3 and again with nonce_increment 2, then the
-#! stored nonce_increment will be 5.
+#! Example: If this procedure is called with nonce_increment 3 and again with nonce_increment 2,
+#! then the stored nonce_increment will be 5.
 #!
 #! Inputs:  [nonce_increment]
 #! Outputs: []

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -14,6 +14,8 @@ use crate::errors::MasmError;
 pub const ERR_ACCOUNT_CODE_COMMITMENT_MISMATCH: MasmError = MasmError::from_static_str("computed account code commitment does not match recorded account code commitment");
 /// Error Message: "account code must be updatable for it to be possible to set new code"
 pub const ERR_ACCOUNT_CODE_IS_NOT_UPDATABLE: MasmError = MasmError::from_static_str("account code must be updatable for it to be possible to set new code");
+/// Error Message: "account delta nonce must incremented if vault or storage changed"
+pub const ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_WITH_VAULT_OR_STORAGE_CHANGES: MasmError = MasmError::from_static_str("account delta nonce must incremented if vault or storage changed");
 /// Error Message: "the account ID must have storage mode public if the network flag is set"
 pub const ERR_ACCOUNT_ID_NON_PUBLIC_NETWORK_ACCOUNT: MasmError = MasmError::from_static_str("the account ID must have storage mode public if the network flag is set");
 /// Error Message: "least significant byte of the account ID suffix must be zero"

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -456,7 +456,7 @@ mod tests {
 
     use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
     use crate::{
-        AccountDeltaError, Digest, ONE, ZERO,
+        AccountDeltaError, ONE, ZERO,
         account::{
             Account, AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType,
             StorageMapDelta, delta::AccountUpdateDetails,
@@ -601,20 +601,5 @@ mod tests {
 
         let update_details_new = AccountUpdateDetails::New(account);
         assert_eq!(update_details_new.to_bytes().len(), update_details_new.get_size_hint());
-    }
-
-    #[test]
-    fn empty_account_update_commitment_is_empty_word() -> anyhow::Result<()> {
-        let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-        let delta = AccountDelta::new(
-            account_id,
-            AccountStorageDelta::default(),
-            AccountVaultDelta::default(),
-            ZERO,
-        )?;
-
-        assert_eq!(delta.commitment(), Digest::default());
-
-        Ok(())
     }
 }

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -90,9 +90,9 @@ impl AccountDelta {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns true if this account delta does not contain any updates.
+    /// Returns true if this account delta does not contain any vault, storage or nonce updates.
     pub fn is_empty(&self) -> bool {
-        self.storage.is_empty() && self.vault.is_empty()
+        self.storage.is_empty() && self.vault.is_empty() && self.nonce_increment == ZERO
     }
 
     /// Returns storage updates for this account delta.
@@ -248,8 +248,7 @@ impl AccountDelta {
     /// pair have changed and 2) when two key-value pairs have changed.
     pub fn commitment(&self) -> Digest {
         // The commitment to an empty delta is defined as the empty word.
-        // Note that is_empty does not take the nonce into account.
-        if self.is_empty() && self.nonce_increment() == ZERO {
+        if self.is_empty() {
             return Digest::default();
         }
 

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -126,9 +126,9 @@ impl AccountDelta {
     /// is appended to in the following way. Whenever sorting is expected, it is that of a link map
     /// key. The WORD layout is in memory-order.
     ///
-    /// - Append `[[nonce_delta, 0, account_id_suffix, account_id_prefix], EMPTY_WORD]`, where
+    /// - Append `[[nonce_increment, 0, account_id_suffix, account_id_prefix], EMPTY_WORD]`, where
     ///   account_id_{prefix,suffix} are the prefix and suffix felts of the native account id and
-    ///   nonce_delta is the value by which the nonce was incremented.
+    ///   nonce_increment is the value by which the nonce was incremented.
     /// - Fungible Asset Delta
     ///   - For each **updated** fungible asset, sorted by its vault key, whose amount delta is
     ///     **non-zero**:

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -40,7 +40,7 @@ pub struct AccountDelta {
     vault: AccountVaultDelta,
     /// The value by which the nonce was incremented. Must be greater than zero if storage or vault
     /// are non-empty.
-    nonce_increment: Felt,
+    nonce_delta: Felt,
 }
 
 impl AccountDelta {
@@ -56,32 +56,27 @@ impl AccountDelta {
         account_id: AccountId,
         storage: AccountStorageDelta,
         vault: AccountVaultDelta,
-        nonce_increment: Felt,
+        nonce_delta: Felt,
     ) -> Result<Self, AccountDeltaError> {
         // nonce must be updated if either account storage or vault were updated
-        validate_nonce(nonce_increment, &storage, &vault)?;
+        validate_nonce(nonce_delta, &storage, &vault)?;
 
-        Ok(Self {
-            account_id,
-            storage,
-            vault,
-            nonce_increment,
-        })
+        Ok(Self { account_id, storage, vault, nonce_delta })
     }
 
     /// Merge another [AccountDelta] into this one.
     pub fn merge(&mut self, other: Self) -> Result<(), AccountDeltaError> {
-        let new_nonce_increment = self.nonce_increment + other.nonce_increment;
+        let new_nonce_delta = self.nonce_delta + other.nonce_delta;
 
-        if new_nonce_increment.as_int() < self.nonce_increment.as_int() {
+        if new_nonce_delta.as_int() < self.nonce_delta.as_int() {
             return Err(AccountDeltaError::NonceIncrementOverflow {
-                current: self.nonce_increment,
-                increment: other.nonce_increment,
-                new: new_nonce_increment,
+                current: self.nonce_delta,
+                increment: other.nonce_delta,
+                new: new_nonce_delta,
             });
         }
 
-        self.nonce_increment = new_nonce_increment;
+        self.nonce_delta = new_nonce_delta;
 
         self.storage.merge(other.storage)?;
         self.vault.merge(other.vault)
@@ -92,7 +87,7 @@ impl AccountDelta {
 
     /// Returns true if this account delta does not contain any vault, storage or nonce updates.
     pub fn is_empty(&self) -> bool {
-        self.storage.is_empty() && self.vault.is_empty() && self.nonce_increment == ZERO
+        self.storage.is_empty() && self.vault.is_empty() && self.nonce_delta == ZERO
     }
 
     /// Returns storage updates for this account delta.
@@ -106,8 +101,8 @@ impl AccountDelta {
     }
 
     /// Returns the amount by which the nonce was incremented.
-    pub fn nonce_increment(&self) -> Felt {
-        self.nonce_increment
+    pub fn nonce_delta(&self) -> Felt {
+        self.nonce_delta
     }
 
     /// Returns the account ID to which this delta applies.
@@ -117,7 +112,7 @@ impl AccountDelta {
 
     /// Converts this storage delta into individual delta components.
     pub fn into_parts(self) -> (AccountStorageDelta, AccountVaultDelta, Felt) {
-        (self.storage, self.vault, self.nonce_increment)
+        (self.storage, self.vault, self.nonce_delta)
     }
 
     /// Computes the commitment to the account delta.
@@ -126,9 +121,9 @@ impl AccountDelta {
     /// is appended to in the following way. Whenever sorting is expected, it is that of a link map
     /// key. The WORD layout is in memory-order.
     ///
-    /// - Append `[[nonce_increment, 0, account_id_suffix, account_id_prefix], EMPTY_WORD]`, where
+    /// - Append `[[nonce_delta, 0, account_id_suffix, account_id_prefix], EMPTY_WORD]`, where
     ///   account_id_{prefix,suffix} are the prefix and suffix felts of the native account id and
-    ///   nonce_increment is the value by which the nonce was incremented.
+    ///   nonce_delta is the value by which the nonce was incremented.
     /// - Fungible Asset Delta
     ///   - For each **updated** fungible asset, sorted by its vault key, whose amount delta is
     ///     **non-zero**:
@@ -257,7 +252,7 @@ impl AccountDelta {
 
         // ID and Nonce
         elements.extend_from_slice(&[
-            self.nonce_increment,
+            self.nonce_delta,
             ZERO,
             self.account_id.suffix(),
             self.account_id.prefix().as_felt(),
@@ -351,14 +346,14 @@ impl Serializable for AccountDelta {
         self.account_id.write_into(target);
         self.storage.write_into(target);
         self.vault.write_into(target);
-        self.nonce_increment.write_into(target);
+        self.nonce_delta.write_into(target);
     }
 
     fn get_size_hint(&self) -> usize {
         self.account_id.get_size_hint()
             + self.storage.get_size_hint()
             + self.vault.get_size_hint()
-            + self.nonce_increment.get_size_hint()
+            + self.nonce_delta.get_size_hint()
     }
 }
 
@@ -367,17 +362,12 @@ impl Deserializable for AccountDelta {
         let account_id = AccountId::read_from(source)?;
         let storage = AccountStorageDelta::read_from(source)?;
         let vault = AccountVaultDelta::read_from(source)?;
-        let nonce_increment = Felt::read_from(source)?;
+        let nonce_delta = Felt::read_from(source)?;
 
-        validate_nonce(nonce_increment, &storage, &vault)
+        validate_nonce(nonce_delta, &storage, &vault)
             .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
 
-        Ok(Self {
-            account_id,
-            storage,
-            vault,
-            nonce_increment,
-        })
+        Ok(Self { account_id, storage, vault, nonce_delta })
     }
 }
 
@@ -431,13 +421,13 @@ impl Deserializable for AccountUpdateDetails {
 /// # Errors
 ///
 /// Returns an error if:
-/// - storage or vault were updated, but the nonce_increment was set to 0.
+/// - storage or vault were updated, but the nonce_delta was set to 0.
 fn validate_nonce(
-    nonce_increment: Felt,
+    nonce_delta: Felt,
     storage: &AccountStorageDelta,
     vault: &AccountVaultDelta,
 ) -> Result<(), AccountDeltaError> {
-    if (!storage.is_empty() || !vault.is_empty()) && nonce_increment == ZERO {
+    if (!storage.is_empty() || !vault.is_empty()) && nonce_delta == ZERO {
         return Err(AccountDeltaError::ZeroNonceForNonEmptyDelta);
     }
 
@@ -489,31 +479,26 @@ mod tests {
     }
 
     #[test]
-    fn account_delta_nonce_increment_overflow() {
+    fn account_delta_nonce_overflow() {
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
         let storage_delta = AccountStorageDelta::new();
         let vault_delta = AccountVaultDelta::default();
 
-        let delta0_nonce_increment = ONE;
-        let delta1_nonce_increment = Felt::try_from(0xffff_ffff_0000_0000u64).unwrap();
+        let nonce_delta0 = ONE;
+        let nonce_delta1 = Felt::try_from(0xffff_ffff_0000_0000u64).unwrap();
 
-        let mut delta0 = AccountDelta::new(
-            account_id,
-            storage_delta.clone(),
-            vault_delta.clone(),
-            delta0_nonce_increment,
-        )
-        .unwrap();
-        let delta1 =
-            AccountDelta::new(account_id, storage_delta, vault_delta, delta1_nonce_increment)
+        let mut delta0 =
+            AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), nonce_delta0)
                 .unwrap();
+        let delta1 =
+            AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta1).unwrap();
 
         assert_matches!(delta0.merge(delta1).unwrap_err(), AccountDeltaError::NonceIncrementOverflow {
           current, increment, new
         } => {
-            assert_eq!(current, delta0_nonce_increment);
-            assert_eq!(increment, delta1_nonce_increment);
-            assert_eq!(new, delta0_nonce_increment + delta1_nonce_increment);
+            assert_eq!(current, nonce_delta0);
+            assert_eq!(increment, nonce_delta1);
+            assert_eq!(new, nonce_delta0 + nonce_delta1);
         });
     }
 

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -282,7 +282,7 @@ impl Account {
         self.storage.apply_delta(delta.storage())?;
 
         // update nonce
-        self.increment_nonce(delta.nonce_increment())?;
+        self.increment_nonce(delta.nonce_delta())?;
 
         Ok(())
     }
@@ -293,13 +293,13 @@ impl Account {
     ///
     /// Returns an error if:
     /// - Incrementing the nonce overflows a [`Felt`].
-    fn increment_nonce(&mut self, nonce_increment: Felt) -> Result<(), AccountError> {
-        let new_nonce = self.nonce + nonce_increment;
+    fn increment_nonce(&mut self, nonce_delta: Felt) -> Result<(), AccountError> {
+        let new_nonce = self.nonce + nonce_delta;
 
         if new_nonce.as_int() < self.nonce.as_int() {
             return Err(AccountError::NonceOverflow {
                 current: self.nonce,
-                increment: nonce_increment,
+                increment: nonce_delta,
                 new: new_nonce,
             });
         }
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn test_serde_account_delta() {
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-        let nonce_increment = Felt::new(2);
+        let nonce_delta = Felt::new(2);
         let asset_0 = FungibleAsset::mock(15);
         let asset_1 = NonFungibleAsset::mock(&[5, 5, 5]);
         let storage_delta = AccountStorageDeltaBuilder::new()
@@ -464,7 +464,7 @@ mod tests {
             account_id,
             vec![asset_1],
             vec![asset_0],
-            nonce_increment,
+            nonce_delta,
             storage_delta,
         );
 
@@ -605,12 +605,12 @@ mod tests {
         let mut account = build_account(vec![], init_nonce, vec![storage_slot]);
 
         // build account delta
-        let nonce_increment = Felt::new(1);
+        let nonce_delta = Felt::new(1);
         let account_delta = AccountDelta::new(
             account_id,
             AccountStorageDelta::new(),
             AccountVaultDelta::default(),
-            nonce_increment,
+            nonce_delta,
         )
         .unwrap();
 
@@ -622,11 +622,11 @@ mod tests {
         account_id: AccountId,
         added_assets: Vec<Asset>,
         removed_assets: Vec<Asset>,
-        nonce_increment: Felt,
+        nonce_delta: Felt,
         storage_delta: AccountStorageDelta,
     ) -> AccountDelta {
         let vault_delta = AccountVaultDelta::from_iters(added_assets, removed_assets);
-        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_increment).unwrap()
+        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta).unwrap()
     }
 
     pub fn build_account(assets: Vec<Asset>, nonce: Felt, slots: Vec<StorageSlot>) -> Account {

--- a/crates/miden-testing/src/kernel_tests/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/mod.rs
@@ -323,7 +323,7 @@ fn executed_transaction_account_delta_new() -> anyhow::Result<()> {
     // nonce delta
     // --------------------------------------------------------------------------------------------
 
-    assert_eq!(executed_transaction.account_delta().nonce_increment(), Felt::new(1));
+    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::new(1));
 
     // storage delta
     // --------------------------------------------------------------------------------------------
@@ -483,7 +483,7 @@ fn test_send_note_proc() -> miette::Result<()> {
         // --------------------------------------------------------------------------------------------
 
         // nonce was incremented by 1
-        assert_eq!(executed_transaction.account_delta().nonce_increment(), ONE);
+        assert_eq!(executed_transaction.account_delta().nonce_delta(), ONE);
 
         // vault delta
         // --------------------------------------------------------------------------------------------
@@ -955,7 +955,7 @@ fn transaction_executor_account_code_using_custom_library() {
     let executed_tx = tx_context.execute().unwrap();
 
     // Account's initial nonce of 1 should have been incremented by 1.
-    assert_eq!(executed_tx.account_delta().nonce_increment(), Felt::new(1));
+    assert_eq!(executed_tx.account_delta().nonce_delta(), Felt::new(1));
 
     // Make sure that account storage has been updated as per the tx script call.
     assert_eq!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -67,6 +67,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
 
     Ok(())
 }
+
 /// Tests that a noop transaction with [`Auth::IncrNonce`] results in a nonce delta of 1.
 #[test]
 fn delta_nonce() -> anyhow::Result<()> {

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -61,7 +61,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
         .execute()
         .context("failed to execute transaction")?;
 
-    assert_eq!(executed_tx.account_delta().nonce_increment(), ZERO);
+    assert_eq!(executed_tx.account_delta().nonce_delta(), ZERO);
     assert!(executed_tx.account_delta().is_empty());
     assert_eq!(executed_tx.account_delta().commitment(), Digest::default());
 
@@ -80,7 +80,7 @@ fn delta_nonce() -> anyhow::Result<()> {
         .execute()
         .context("failed to execute transaction")?;
 
-    assert_eq!(executed_tx.account_delta().nonce_increment(), Felt::new(1));
+    assert_eq!(executed_tx.account_delta().nonce_delta(), Felt::new(1));
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    Digest, EMPTY_WORD, Felt, Word,
+    Digest, EMPTY_WORD, Felt, Word, ZERO,
     account::{
         AccountBuilder, AccountId, AccountStorageMode, AccountType, StorageMap, StorageSlot,
         delta::LexicographicWord,
@@ -61,7 +61,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
         .execute()
         .context("failed to execute transaction")?;
 
-    assert_eq!(executed_tx.account_delta().nonce_increment(), miden_objects::ZERO);
+    assert_eq!(executed_tx.account_delta().nonce_increment(), ZERO);
     assert!(executed_tx.account_delta().is_empty());
     assert_eq!(executed_tx.account_delta().commitment(), Digest::default());
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -488,7 +488,7 @@ fn create_simple_account() -> anyhow::Result<()> {
         .execute()
         .context("failed to execute account-creating transaction")?;
 
-    assert_eq!(tx.account_delta().nonce_increment(), Felt::new(1));
+    assert_eq!(tx.account_delta().nonce_delta(), Felt::new(1));
     // except for the nonce, the delta should be empty
     assert!(tx.account_delta().storage().is_empty());
     assert!(tx.account_delta().vault().is_empty());

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -490,7 +490,8 @@ fn create_simple_account() -> anyhow::Result<()> {
 
     assert_eq!(tx.account_delta().nonce_increment(), Felt::new(1));
     // except for the nonce, the delta should be empty
-    assert!(tx.account_delta().is_empty());
+    assert!(tx.account_delta().storage().is_empty());
+    assert!(tx.account_delta().vault().is_empty());
     assert_eq!(tx.final_account().nonce(), Felt::new(1));
     // account commitment should not be the empty word
     assert_ne!(*tx.account_delta().commitment(), EMPTY_WORD);

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -28,8 +28,6 @@ pub fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
 ///
 /// The created note does not require authentication and can be consumed by any account.
 pub fn create_p2any_note(sender: AccountId, assets: &[Asset]) -> Note {
-    assert!(!assets.is_empty(), "note must carry at least one asset");
-
     let mut code_body = String::new();
     for i in 0..assets.len() {
         if i == 0 {

--- a/crates/miden-testing/tests/integration/scripts/faucet.rs
+++ b/crates/miden-testing/tests/integration/scripts/faucet.rs
@@ -213,6 +213,6 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() {
     // Prove, serialize/deserialize and verify the transaction
     prove_and_verify_transaction(executed_transaction.clone()).unwrap();
 
-    assert_eq!(executed_transaction.account_delta().nonce_increment(), Felt::new(1));
+    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::new(1));
     assert_eq!(executed_transaction.input_notes().get_note(0).id(), note.id());
 }

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -399,11 +399,11 @@ fn build_executed_transaction(
     }
 
     // make sure nonce delta was computed correctly
-    let nonce_increment = final_account.nonce() - initial_account.nonce();
-    if nonce_increment != account_delta.nonce_increment() {
+    let nonce_delta = final_account.nonce() - initial_account.nonce();
+    if nonce_delta != account_delta.nonce_delta() {
         return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
-            expected: nonce_increment,
-            actual: account_delta.nonce_increment(),
+            expected: nonce_delta,
+            actual: account_delta.nonce_delta(),
         });
     }
 

--- a/crates/miden-tx/src/host/account_delta_tracker.rs
+++ b/crates/miden-tx/src/host/account_delta_tracker.rs
@@ -22,7 +22,7 @@ pub struct AccountDeltaTracker {
     account_id: AccountId,
     storage: StorageDeltaTracker,
     vault: AccountVaultDelta,
-    nonce_increment: Felt,
+    nonce_delta: Felt,
 }
 
 impl AccountDeltaTracker {
@@ -32,13 +32,13 @@ impl AccountDeltaTracker {
             account_id,
             storage: StorageDeltaTracker::new(storage_header),
             vault: AccountVaultDelta::default(),
-            nonce_increment: ZERO,
+            nonce_delta: ZERO,
         }
     }
 
     /// Tracks nonce delta.
     pub fn increment_nonce(&mut self, value: Felt) {
-        self.nonce_increment += value;
+        self.nonce_delta += value;
     }
 
     /// Get a mutable reference to the current vault delta
@@ -57,12 +57,12 @@ impl AccountDeltaTracker {
     /// value are equal.
     pub fn into_delta(self) -> AccountDelta {
         let account_id = self.account_id;
-        let nonce_increment = self.nonce_increment;
+        let nonce_delta = self.nonce_delta;
 
         let storage_delta = self.storage.into_delta();
         let vault_delta = self.vault;
 
-        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_increment)
+        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta)
             .expect("account delta created in delta tracker should be valid")
     }
 }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -242,7 +242,7 @@ impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
 
     /// Extracts the nonce increment from the process state and adds it to the nonce delta tracker.
     ///
-    /// Expected stack state: [nonce_increment, ...]
+    /// Expected stack state: [nonce_delta, ...]
     pub fn on_account_before_increment_nonce(
         &mut self,
         process: ProcessState,

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -242,7 +242,7 @@ impl<'store, 'auth, A: AdviceProvider> TransactionHost<'store, 'auth, A> {
 
     /// Extracts the nonce increment from the process state and adds it to the nonce delta tracker.
     ///
-    /// Expected stack state: [nonce_delta, ...]
+    /// Expected stack state: [nonce_increment, ...]
     pub fn on_account_before_increment_nonce(
         &mut self,
         process: ProcessState,


### PR DESCRIPTION
Define the commitment to an empty account delta as `EMPTY_WORD`.

This assumes that `account_delta::compute_commitment` is only called when no more changes to the delta will be made. Otherwise, using `nonce_increment == 0` as an indicator for an empty delta is not good enough (see https://github.com/0xMiden/miden-base/issues/1522#issuecomment-3034831973).

Ideally, we'd have a concept of sealing the transaction, i.e. a point after which no more changes can be made. Before the transaction is sealed, calling `compute_commitment` would fail, so it could only be called afterward (most likely by an auth procedure after it has incremented the nonce).

Misc changes:
- Removed the TODO for adding a delta commitment test called from foreign accounts, because due to the above, this scenario might never actually happen.
- `P2ANY` notes are allowed to not contain any assets. This is useful for the newly added test where a note must be consumed to make the transaction non-empty, but no state change to the account should occur to keep the account delta empty. For reference, P2ID notes may also contain no assets. cc @igamigo 
- Renames `nonce_increment` to `nonce_delta` everywhere for consistency.

closes #1522