### PR TITLE
Introduce `get_acct_procedure_ptr` method in `miden::memory`

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -633,7 +633,7 @@ export.get_procedure_info
     # => [index]
 
     # get procedure pointer
-    mul.8 exec.memory::get_acct_procedures_section_ptr add
+    exec.memory::get_acct_procedure_ptr
     # => [proc_ptr]
 
     # get metadata pointer
@@ -969,7 +969,8 @@ export.save_account_procedure_data
     # AS => [[ACCOUNT_PROCEDURE_DATA]]
 
     # setup acct_proc_offset and end_ptr for reading from advice stack
-    mul.8 exec.memory::get_acct_procedures_section_ptr dup movdn.2 add swap
+    exec.memory::get_acct_procedure_ptr
+    push.0 exec.memory::get_acct_procedure_ptr
     # OS => [acct_proc_offset, end_ptr, CODE_COMMITMENT]
     # AS => [[ACCOUNT_PROCEDURE_DATA]]
 
@@ -1043,7 +1044,7 @@ end
 #! - storage_size is the number of storage slots the procedure is allowed to access.
 proc.get_procedure_metadata
     # get procedure storage metadata pointer
-    mul.8 exec.memory::get_acct_procedures_section_ptr add add.4
+    exec.memory::get_acct_procedure_ptr add.4
     # => [storage_offset_ptr]
 
     # load procedure metadata from memory and keep relevant data

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -238,7 +238,7 @@ end
 proc.execute_auth_procedure
     padw padw padw push.0.0.0
     # auth procedure is at index 0 within the account procedures section so no offsetting is needed.
-    exec.memory::get_acct_procedures_section_ptr
+    push.0 exec.memory::get_acct_procedure_ptr
     # => [auth_procedure_ptr, pad(15)]
 
     # execute the auth procedure

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -237,7 +237,7 @@ end
 #! Outputs: []
 proc.execute_auth_procedure
     padw padw padw push.0.0.0
-    # auth procedure is at index 0 within the account procedures section so no offsetting is needed.
+    # auth procedure is at index 0 within the account procedures section.
     push.0 exec.memory::get_acct_procedure_ptr
     # => [auth_procedure_ptr, pad(15)]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -1087,6 +1087,18 @@ export.get_acct_procedures_section_ptr
     exec.get_current_account_data_ptr push.ACCT_PROCEDURES_SECTION_OFFSET add
 end
 
+#! Returns the memory pointer to a specific account procedure.
+#!
+#! Inputs:  [proc_idx]
+#! Outputs: [proc_ptr]
+#!
+#! Where:
+#! - proc_idx is the index of the account procedure.
+#! - proc_ptr is the memory pointer to the account procedure at the specified index.
+export.get_acct_procedure_ptr
+    mul.8 exec.get_acct_procedures_section_ptr add
+end
+
 ### ACCOUNT STORAGE #################################################
 
 #! Returns the account storage commitment.

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -72,7 +72,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 36] = [
     // tx_get_block_timestamp
     digest!("0x786863e6dbcd5026619afd3831b7dcbf824cda54950b0e0724ebf9d9370ec723"),
     // tx_start_foreign_context
-    digest!("0x50e31990bc918903f0babea20d4eb840828fdd41b539adb98f70cde6fffa8bfc"),
+    digest!("0x20f874f328809be9174240a4272f8f1a41437b22662c1790109e5ad7f201cd40"),
     // tx_end_foreign_context
     digest!("0x90a107168d81c1c0c23890e61fb7910a64b4711afd0bf8c3098d74737e4853ba"),
     // tx_get_expiration_delta


### PR DESCRIPTION
closes #1510 