### PR TITLE
chore: small cycle count optimizations

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -704,11 +704,11 @@ export.assert_auth_procedure
     # => [index, PROC_ROOT]
 
     # get procedure info (PROC_ROOT, storage_offset, storage_size) from memory stored at index
-    exec.get_procedure_info
-    # => [MEM_PROC_ROOT, storage_offset, storage_size, PROC_ROOT]
+    exec.get_procedure_root
+    # => [MEM_PROC_ROOT, PROC_ROOT]
 
     # verify that PROC_ROOT exists in memory at index
-    movup.4 drop movup.4 drop assert_eqw.err=ERR_ACCOUNT_PROC_NOT_AUTH_PROC
+    assert_eqw.err=ERR_ACCOUNT_PROC_NOT_AUTH_PROC
     # => []
 end
 
@@ -1043,6 +1043,26 @@ proc.set_item_raw
     # => [OLD_VALUE]
 end
 
+#! Returns the procedure root.
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Inputs:  [index]
+#! Outputs: [PROC_ROOT]
+#!
+#! Where:
+#! - PROC_ROOT is the hash of the procedure.
+proc.get_procedure_root
+    # get procedure pointer
+    exec.memory::get_acct_procedure_ptr
+    # => [proc_ptr]
+
+    # load procedure root from memory
+    padw movup.4 mem_loadw
+    # => [PROC_ROOT]
+end
+
 #! Returns the procedure metadata.
 #!
 #! Note:
@@ -1196,11 +1216,12 @@ export.was_procedure_called
 
     dup movdn.5
 
-    # get procedure info (PROC_ROOT, storage_offset, storage_size) from memory stored at index
-    exec.get_procedure_info
-    # => [MEM_PROC_ROOT, storage_offset, storage_size, PROC_ROOT, index]
+    # get procedure root from memory stored at index
+    exec.get_procedure_root
+    # => [MEM_PROC_ROOT, PROC_ROOT, index]
 
-    movup.4 drop movup.4 drop assert_eqw.err=ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE
+    # verify that PROC_ROOT exists in memory at index
+    assert_eqw.err=ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE
     # => [index]
 
     exec.memory::get_acct_procedures_call_tracking_ptr

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -1076,11 +1076,11 @@ end
 #! - storage_size is the number of storage slots the procedure is allowed to access.
 proc.get_procedure_metadata
     # get procedure storage metadata pointer
-    exec.memory::get_acct_procedure_ptr add.4
-    # => [storage_offset_ptr]
+    padw exec.memory::get_acct_procedure_ptr add.4
+    # => [storage_offset_ptr, 0, 0, 0, 0]
 
     # load procedure metadata from memory and keep relevant data
-    padw movup.4 mem_loadw drop drop swap
+    mem_loadw drop drop swap
     # => [storage_offset, storage_size]
 end
 

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -16,7 +16,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 37] = [
     // account_get_nonce
     digest!("0xf1dfe3621b9147803b6668352915be7fb7f85df476c9d18052272270a854fa75"),
     // account_incr_nonce
-    digest!("0xf9ca79cdae5646f62246d7132ca7ebf2c7ca771e0f936aae983ef5aea3d8feab"),
+    digest!("0x54cec6fe9cfaded47c12e579353e900cf0eb5912190a8cb854b6c7f509a2a567"),
     // account_get_code_commitment
     digest!("0x7aa35fc4882683a4a31c162038d4a5ec31551b9c2b64930cce61bdecbae72b32"),
     // account_get_storage_commitment
@@ -40,7 +40,7 @@ pub const KERNEL0_PROCEDURES: [Digest; 37] = [
     // account_has_non_fungible_asset
     digest!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // account_was_procedure_called
-    digest!("0xc5139f0895d165fe81ecaffb247dfb2863e0dd55f9718e930c256845cef3921a"),
+    digest!("0x3793a1a66dd99f6b0ec9a53c9c1c6f5020d02edaf968e87d017afa0de634432e"),
     // faucet_mint_asset
     digest!("0xa7c85178735c45456e77bc7ee04df3d005ddfe5946cfb0f39c3f597c15f166c6"),
     // faucet_burn_asset


### PR DESCRIPTION
Optimizations: 
1. introduce `get_procedure_root` for cycle optimizations
2. `get_{...}_ptr padw movup.4 mem_loadw` -> `padw get_{...}_ptr mem_loadw` (remove a `movup` instruction)