### PR TITLE
test: Fix test after merge

### DIFF
--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -57,7 +57,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
     let executed_tx = mock_chain
         .build_tx_context(account_id, &[p2any_note.id()], &[])
         .expect("failed to build tx context")
-        .build()
+        .build()?
         .execute()
         .context("failed to execute transaction")?;
 


### PR DESCRIPTION
A test was merged just after merging the changes on the testing framework and so it didn't take them into account. This PR fixes this.