### PR TITLE
chore: Remove erroneous `#[cfg(any(feature = "testing", test))]`

### DIFF
--- a/crates/miden-lib/src/lib.rs
+++ b/crates/miden-lib/src/lib.rs
@@ -16,7 +16,6 @@ use miden_objects::{
 mod auth;
 pub use auth::AuthScheme;
 
-#[cfg(any(feature = "testing", test))]
 pub mod account;
 pub mod errors;
 pub mod note;


### PR DESCRIPTION
Removes an erroneous `#[cfg(any(feature = "testing", test))]`. That should have been on the `errors` below probably but that was actually changed in #1507 to only gate the tx kernel and note script errors within the errors module.

closes #1552