### PR TITLE
Fix Typo in OutputNote Documentation

### DIFF
--- a/crates/miden-objects/src/transaction/outputs.rs
+++ b/crates/miden-objects/src/transaction/outputs.rs
@@ -180,7 +180,7 @@ impl OutputNote {
         }
     }
 
-    /// Returns the recipient of the precessed [`Full`](OutputNote::Full) output note. Returns
+    /// Returns the recipient of the processed [`Full`](OutputNote::Full) output note. Returns
     /// [`None`] if the note type is not [`Full`](OutputNote::Full).
     ///
     /// See [crate::note::NoteRecipient] for more details.


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in the documentation comment for the `OutputNote` implementation.  
- Changed "precessed" to "processed" for improved clarity and accuracy.

