### PR TITLE
chore: rename `inner` functions to be more precise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [BREAKING] Upgrade Miden VM to `0.16`, `miden-crypto` to `0.15` and `winterfell` crates to `0.13` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] `Digest` was removed in favor of `Word` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{NoteInclusionProof, AccountWitness}::inner_nodes` to `authenticated_nodes` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
-- [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1570](https://github.com/0xMiden/miden-base/pull/1570)).
+- [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1571](https://github.com/0xMiden/miden-base/pull/1571)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [BREAKING] Upgrade Miden VM to `0.16`, `miden-crypto` to `0.15` and `winterfell` crates to `0.13` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] `Digest` was removed in favor of `Word` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{NoteInclusionProof, AccountWitness}::inner_nodes` to `authenticated_nodes` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
+- [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1570](https://github.com/0xMiden/miden-base/pull/1570)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -70,7 +70,7 @@ impl TransactionAdviceInputs {
     }
 
     /// Converts these transaction advice inputs into the underlying advice inputs.
-    pub fn into_inner(self) -> AdviceInputs {
+    pub fn into_advice_inputs(self) -> AdviceInputs {
         self.0
     }
 

--- a/crates/miden-objects/src/block/nullifier_tree.rs
+++ b/crates/miden-objects/src/block/nullifier_tree.rs
@@ -49,7 +49,7 @@ impl NullifierTree {
         entries: impl IntoIterator<Item = (Nullifier, BlockNumber)>,
     ) -> Result<Self, NullifierTreeError> {
         let leaves = entries.into_iter().map(|(nullifier, block_num)| {
-            (nullifier.inner(), Self::block_num_to_leaf_value(block_num))
+            (nullifier.as_word(), Self::block_num_to_leaf_value(block_num))
         });
 
         let smt = Smt::with_entries(leaves)
@@ -85,13 +85,13 @@ impl NullifierTree {
     /// This witness is a proof of the current block number of the given nullifier. If that block
     /// number is zero, it proves that the nullifier is unspent.
     pub fn open(&self, nullifier: &Nullifier) -> NullifierWitness {
-        NullifierWitness::new(self.smt.open(&nullifier.inner()))
+        NullifierWitness::new(self.smt.open(&nullifier.as_word()))
     }
 
     /// Returns the block number for the given nullifier or `None` if the nullifier wasn't spent
     /// yet.
     pub fn get_block_num(&self, nullifier: &Nullifier) -> Option<BlockNumber> {
-        let value = self.smt.get_value(&nullifier.inner());
+        let value = self.smt.get_value(&nullifier.as_word());
         if value == Self::UNSPENT_NULLIFIER {
             return None;
         }
@@ -122,7 +122,7 @@ impl NullifierTree {
 
         let mutation_set =
             self.smt.compute_mutations(nullifiers.into_iter().map(|(nullifier, block_num)| {
-                (nullifier.inner(), Self::block_num_to_leaf_value(block_num))
+                (nullifier.as_word(), Self::block_num_to_leaf_value(block_num))
             }));
 
         Ok(NullifierMutationSet::new(mutation_set))
@@ -143,7 +143,7 @@ impl NullifierTree {
         block_num: BlockNumber,
     ) -> Result<(), NullifierTreeError> {
         let prev_nullifier_value =
-            self.smt.insert(nullifier.inner(), Self::block_num_to_leaf_value(block_num));
+            self.smt.insert(nullifier.as_word(), Self::block_num_to_leaf_value(block_num));
 
         if prev_nullifier_value != Self::UNSPENT_NULLIFIER {
             Err(NullifierTreeError::NullifierAlreadySpent(nullifier))

--- a/crates/miden-objects/src/block/partial_nullifier_tree.rs
+++ b/crates/miden-objects/src/block/partial_nullifier_tree.rs
@@ -91,7 +91,7 @@ impl PartialNullifierTree {
     ) -> Result<(), NullifierTreeError> {
         let prev_nullifier_value = self
             .0
-            .insert(nullifier.inner(), NullifierTree::block_num_to_leaf_value(block_num))
+            .insert(nullifier.as_word(), NullifierTree::block_num_to_leaf_value(block_num))
             .map_err(|source| NullifierTreeError::UntrackedNullifier { nullifier, source })?;
 
         if prev_nullifier_value != NullifierTree::UNSPENT_NULLIFIER {

--- a/crates/miden-objects/src/block/proposed_block.rs
+++ b/crates/miden-objects/src/block/proposed_block.rs
@@ -420,7 +420,7 @@ fn check_nullifiers(
     for block_input_note in block_input_notes {
         match nullifier_witnesses
             .get(&block_input_note)
-            .and_then(|x| x.proof().get(&block_input_note.inner()))
+            .and_then(|x| x.proof().get(&block_input_note.as_word()))
         {
             Some(nullifier_value) => {
                 if nullifier_value != EMPTY_WORD {

--- a/crates/miden-objects/src/note/header.rs
+++ b/crates/miden-objects/src/note/header.rs
@@ -57,7 +57,7 @@ impl NoteHeader {
 /// This value is used primarily for authenticating notes consumed when they are consumed
 /// in a transaction.
 pub fn compute_note_commitment(id: NoteId, metadata: &NoteMetadata) -> Word {
-    Hasher::merge(&[id.inner(), Word::from(metadata)])
+    Hasher::merge(&[id.as_word(), Word::from(metadata)])
 }
 
 // CONVERSIONS FROM NOTE HEADER

--- a/crates/miden-objects/src/note/note_id.rs
+++ b/crates/miden-objects/src/note/note_id.rs
@@ -49,7 +49,7 @@ impl NoteId {
     }
 
     /// Returns the digest defining this note ID.
-    pub fn inner(&self) -> Word {
+    pub fn as_word(&self) -> Word {
         self.0
     }
 }
@@ -87,7 +87,7 @@ impl NoteId {
 
 impl From<NoteId> for Word {
     fn from(id: NoteId) -> Self {
-        id.inner()
+        id.as_word()
     }
 }
 
@@ -136,6 +136,6 @@ mod tests {
         let note_id_hex = "0xc9d31c82c098e060c9b6e3af2710b3fc5009a1a6f82ef9465f8f35d1f5ba4a80";
         let note_id = NoteId::try_from_hex(note_id_hex).unwrap();
 
-        assert_eq!(note_id.inner().to_string(), note_id_hex)
+        assert_eq!(note_id.as_word().to_string(), note_id_hex)
     }
 }

--- a/crates/miden-objects/src/note/nullifier.rs
+++ b/crates/miden-objects/src/note/nullifier.rs
@@ -57,7 +57,7 @@ impl Nullifier {
     }
 
     /// Returns the digest defining this nullifier.
-    pub fn inner(&self) -> Word {
+    pub fn as_word(&self) -> Word {
         self.0
     }
 
@@ -65,7 +65,7 @@ impl Nullifier {
     ///
     /// Nullifier prefix is defined as the 16 most significant bits of the nullifier value.
     pub fn prefix(&self) -> u16 {
-        (self.inner()[3].as_int() >> NULLIFIER_PREFIX_SHIFT) as u16
+        (self.as_word()[3].as_int() >> NULLIFIER_PREFIX_SHIFT) as u16
     }
 
     /// Creates a Nullifier from a hex string. Assumes that the string starts with "0x" and

--- a/crates/miden-objects/src/transaction/inputs/notes.rs
+++ b/crates/miden-objects/src/transaction/inputs/notes.rs
@@ -51,7 +51,7 @@ impl<T: ToInputNoteCommitments> InputNotes<T> {
 
         let mut seen_notes = BTreeSet::new();
         for note in notes.iter() {
-            if !seen_notes.insert(note.nullifier().inner()) {
+            if !seen_notes.insert(note.nullifier().as_word()) {
                 return Err(TransactionInputError::DuplicateInputNote(note.nullifier()));
             }
         }

--- a/crates/miden-objects/src/transaction/transaction_id.rs
+++ b/crates/miden-objects/src/transaction/transaction_id.rs
@@ -54,7 +54,7 @@ impl TransactionId {
     }
 
     /// Returns the digest defining this transaction ID.
-    pub fn inner(&self) -> Word {
+    pub fn as_word(&self) -> Word {
         self.0
     }
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -385,13 +385,13 @@ fn input_notes_memory_assertions(
             process.get_kernel_mem_word(
                 INPUT_NOTE_NULLIFIER_SECTION_PTR + note_idx * WORD_SIZE as u32
             ),
-            note.nullifier().inner(),
+            note.nullifier().as_word(),
             "note nullifier should be computer and stored at the correct offset"
         );
 
         assert_eq!(
             read_note_element(process, note_idx, INPUT_NOTE_ID_OFFSET),
-            note.id().inner(),
+            note.id().as_word(),
             "ID hash should be computed and stored at the correct offset"
         );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -898,7 +898,7 @@ fn advice_inputs_from_transaction_witness_are_sufficient_to_reexecute_transactio
         Some(executed_transaction.advice_witness().clone()),
     );
 
-    let mut advice_inputs = advice_inputs.into_inner();
+    let mut advice_inputs = advice_inputs.into_advice_inputs();
 
     // load account/note/tx_script MAST to the mast_store
     let mast_store = Arc::new(TransactionMastStore::new());

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -98,7 +98,7 @@ impl TransactionContext {
             mast_store.load_account_code(acc_inputs.code());
         }
 
-        let advice_inputs = advice_inputs.into_inner();
+        let advice_inputs = advice_inputs.into_advice_inputs();
         CodeExecutor::new(MockHost::new(
             self.tx_inputs.account().into(),
             &advice_inputs,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -156,7 +156,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
         let (stack_inputs, advice_inputs) =
             TransactionKernel::prepare_inputs(&tx_inputs, &tx_args, None);
 
-        let mut advice_inputs = advice_inputs.into_inner();
+        let mut advice_inputs = advice_inputs.into_advice_inputs();
 
         let script_mast_store = ScriptMastForestStore::new(
             tx_args.tx_script(),
@@ -235,7 +235,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
 
         let (stack_inputs, advice_inputs) =
             TransactionKernel::prepare_inputs(&tx_inputs, &tx_args, Some(advice_inputs));
-        let mut advice_inputs = advice_inputs.into_inner();
+        let mut advice_inputs = advice_inputs.into_advice_inputs();
 
         let scripts_mast_store =
             ScriptMastForestStore::new(tx_args.tx_script(), core::iter::empty::<&NoteScript>());
@@ -307,7 +307,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
         let (stack_inputs, advice_inputs) =
             TransactionKernel::prepare_inputs(&tx_inputs, &tx_args, None);
 
-        let mut advice_inputs = advice_inputs.into_inner();
+        let mut advice_inputs = advice_inputs.into_advice_inputs();
 
         let scripts_mast_store = ScriptMastForestStore::new(
             tx_args.tx_script(),

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -122,7 +122,7 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
         // advice provider has all the necessary data for script execution
         advice_inputs.extend_map(
             scripts_mast_store
-                .advice_data()
+                .advice_map()
                 .iter()
                 .map(|(key, values)| (*key, values.clone())),
         );

--- a/crates/miden-tx/src/host/script_mast_forest_store.rs
+++ b/crates/miden-tx/src/host/script_mast_forest_store.rs
@@ -12,7 +12,7 @@ use vm_processor::MastForestStore;
 /// transaction and input note scripts.
 pub struct ScriptMastForestStore {
     mast_forests: BTreeMap<Word, Arc<MastForest>>,
-    adv_data: AdviceMap,
+    advice_map: AdviceMap,
 }
 
 impl ScriptMastForestStore {
@@ -23,7 +23,7 @@ impl ScriptMastForestStore {
     ) -> Self {
         let mut mast_store = ScriptMastForestStore {
             mast_forests: BTreeMap::new(),
-            adv_data: AdviceMap::new(),
+            advice_map: AdviceMap::new(),
         };
 
         for note_script in note_scripts {
@@ -45,13 +45,13 @@ impl ScriptMastForestStore {
 
         // collect advice data from the forest
         for (key, values) in mast_forest.advice_map().clone() {
-            self.adv_data.insert((*key).into(), values);
+            self.advice_map.insert((*key).into(), values);
         }
     }
 
     /// Returns a reference to the advice data collected from all forests.
-    pub fn advice_data(&self) -> &AdviceMap {
-        &self.adv_data
+    pub fn advice_map(&self) -> &AdviceMap {
+        &self.advice_map
     }
 }
 

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -86,7 +86,7 @@ impl TransactionProver for LocalTransactionProver {
         // execute and prove
         let (stack_inputs, advice_inputs) =
             TransactionKernel::prepare_inputs(&tx_inputs, &tx_args, Some(advice_witness));
-        let mut advice_inputs = advice_inputs.into_inner();
+        let mut advice_inputs = advice_inputs.into_advice_inputs();
 
         // load the store with account/note/tx_script MASTs
         self.mast_store.load_account_code(account.code());


### PR DESCRIPTION
VM Migration follow-up:

- Rename `ScriptMastForestStore::advice_data` -> `advice_map` which is more precise.
- Rename `{TransactionId, NoteId, Nullifier}::inner` -> `as_word`.
- Rename `TransactionAdviceInputs::into_inner` -> `into_advice_inputs`.