### PR TITLE
feat: split `TransactionHost` into prover and executor host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [BREAKING] `Digest` was removed in favor of `Word` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{NoteInclusionProof, AccountWitness}::inner_nodes` to `authenticated_nodes` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1571](https://github.com/0xMiden/miden-base/pull/1571)).
+- [BREAKING] Split `TransactionHost` into `TransactionProverHost` and `TransactionExecutorHost` ([#1581](https://github.com/0xMiden/miden-base/pull/1581)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/src/errors/transaction_errors.rs
+++ b/crates/miden-lib/src/errors/transaction_errors.rs
@@ -21,8 +21,12 @@ pub enum TransactionKernelError {
         "storage slot index {actual} is invalid, must be smaller than the number of account storage slots {max}"
     )]
     InvalidStorageSlotIndex { max: u64, actual: u64 },
-    #[error("failed to generate signature: {0}")]
-    FailedSignatureGeneration(&'static str),
+    #[error(
+        "failed to respond to signature requested since no authenticator is assigned to the host"
+    )]
+    MissingAuthenticator,
+    #[error("failed to generate signature")]
+    SignatureGenerationFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
     MalformedAssetInEventHandler {
         handler: &'static str,

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -38,8 +38,8 @@ use miden_objects::{
     transaction::{InputNotes, OutputNote, OutputNotes, TransactionArgs, TransactionScript},
 };
 use miden_tx::{
-    ExecutionOptions, TransactionExecutor, TransactionExecutorError, TransactionHost,
-    TransactionMastStore, host::ScriptMastForestStore,
+    ExecutionOptions, TransactionExecutor, TransactionExecutorError, TransactionMastStore,
+    host::{ScriptMastForestStore, TransactionExecutorHost},
 };
 use vm_processor::Process;
 
@@ -904,7 +904,7 @@ fn advice_inputs_from_transaction_witness_are_sufficient_to_reexecute_transactio
     let mast_store = Arc::new(TransactionMastStore::new());
     mast_store.load_account_code(tx_inputs.account().code());
 
-    let mut host = TransactionHost::new(
+    let mut host = TransactionExecutorHost::new(
         &tx_inputs.account().into(),
         &mut advice_inputs,
         mast_store.as_ref(),

--- a/crates/miden-testing/tests/auth/rpo_falcon_procedure_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_procedure_acl.rs
@@ -145,12 +145,7 @@ fn test_rpo_falcon_procedure_acl() -> anyhow::Result<()> {
     )) => {
         assert_matches!(execution_error, ExecutionError::EventError { error, .. } => {
             let kernel_error = error.downcast_ref::<TransactionKernelError>().unwrap();
-            assert_matches!(kernel_error, TransactionKernelError::FailedSignatureGeneration(msg) => {
-                assert_eq!(
-                    *msg, "No authenticator assigned to transaction host",
-                    "Expected 'No authenticator assigned to transaction host' error, got: {msg}"
-                );
-            })
+            assert_matches!(kernel_error, TransactionKernelError::MissingAuthenticator);
         })
     });
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -17,8 +17,11 @@ use vm_processor::{AdviceInputs, Process};
 pub use vm_processor::{ExecutionOptions, MastForestStore};
 use winter_maybe_async::{maybe_async, maybe_await};
 
-use super::{TransactionExecutorError, TransactionHost};
-use crate::{auth::TransactionAuthenticator, host::ScriptMastForestStore};
+use super::TransactionExecutorError;
+use crate::{
+    auth::TransactionAuthenticator,
+    host::{ScriptMastForestStore, TransactionExecutorHost},
+};
 
 mod data_store;
 pub use data_store::DataStore;
@@ -163,7 +166,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
             tx_inputs.input_notes().iter().map(|n| n.note().script()),
         );
 
-        let mut host = TransactionHost::new(
+        let mut host = TransactionExecutorHost::new(
             &tx_inputs.account().into(),
             &mut advice_inputs,
             self.data_store,
@@ -240,7 +243,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
         let scripts_mast_store =
             ScriptMastForestStore::new(tx_args.tx_script(), core::iter::empty::<&NoteScript>());
 
-        let mut host = TransactionHost::new(
+        let mut host = TransactionExecutorHost::new(
             &tx_inputs.account().into(),
             &mut advice_inputs,
             self.data_store,
@@ -314,7 +317,7 @@ impl<'store, 'auth> TransactionExecutor<'store, 'auth> {
             tx_inputs.input_notes().iter().map(|n| n.note().script()),
         );
 
-        let mut host = TransactionHost::new(
+        let mut host = TransactionExecutorHost::new(
             &tx_inputs.account().into(),
             &mut advice_inputs,
             self.data_store,
@@ -375,7 +378,7 @@ fn build_executed_transaction(
     tx_args: TransactionArgs,
     tx_inputs: TransactionInputs,
     stack_outputs: StackOutputs,
-    host: TransactionHost,
+    host: TransactionExecutorHost,
 ) -> Result<ExecutedTransaction, TransactionExecutorError> {
     let (account_delta, output_notes, generated_signatures, tx_progress) = host.into_parts();
 

--- a/crates/miden-tx/src/host/exec_host.rs
+++ b/crates/miden-tx/src/host/exec_host.rs
@@ -1,0 +1,169 @@
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
+
+use miden_lib::{errors::TransactionKernelError, transaction::TransactionEvent};
+use miden_objects::{
+    Felt, Hasher, Word,
+    account::{AccountDelta, PartialAccount},
+    transaction::OutputNote,
+};
+use vm_processor::{
+    AdviceInputs, BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore,
+    ProcessState, SyncHost,
+};
+
+use crate::{
+    TransactionProgress,
+    auth::TransactionAuthenticator,
+    errors::TransactionHostError,
+    host::{ScriptMastForestStore, TransactionBaseHost},
+};
+
+/// The transaction executor host is responsible for handling [`SyncHost`] requests made by the
+/// transaction kernel during execution. In particular, it responds to signature generation requests
+/// by forwarding the request to the contained [`TransactionAuthenticator`].
+///
+/// Transaction hosts are created on a per-transaction basis. That is, a transaction host is meant
+/// to support execution of a single transaction and is discarded after the transaction finishes
+/// execution.
+pub struct TransactionExecutorHost<'store, 'auth> {
+    /// The underlying base transaction host.
+    base_host: TransactionBaseHost<'store>,
+
+    /// Serves signature generation requests from the transaction runtime for signatures which are
+    /// not present in the `generated_signatures` field.
+    authenticator: Option<&'auth dyn TransactionAuthenticator>,
+
+    /// Contains generated signatures (as a message |-> signature map) required for transaction
+    /// execution. Once a signature was created for a given message, it is inserted into this map.
+    /// After transaction execution, these can be inserted into the advice inputs to re-execute the
+    /// transaction without having to regenerate the signature or requiring access to the
+    /// authenticator that produced it.
+    generated_signatures: BTreeMap<Word, Vec<Felt>>,
+}
+
+impl<'store, 'auth> TransactionExecutorHost<'store, 'auth> {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`TransactionExecutorHost`] instance from the provided inputs.
+    pub fn new(
+        account: &PartialAccount,
+        advice_inputs: &mut AdviceInputs,
+        mast_store: &'store dyn MastForestStore,
+        scripts_mast_store: ScriptMastForestStore,
+        authenticator: Option<&'auth dyn TransactionAuthenticator>,
+        foreign_account_code_commitments: BTreeSet<Word>,
+    ) -> Result<Self, TransactionHostError> {
+        let base_host = TransactionBaseHost::new(
+            account,
+            advice_inputs,
+            mast_store,
+            scripts_mast_store,
+            foreign_account_code_commitments,
+        )?;
+
+        Ok(Self {
+            base_host,
+            authenticator,
+            generated_signatures: BTreeMap::new(),
+        })
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a reference to the `tx_progress` field of this transaction host.
+    pub fn tx_progress(&self) -> &TransactionProgress {
+        self.base_host.tx_progress()
+    }
+
+    // ADVICE INJECTOR HANDLERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Pushes a signature to the advice stack as a response to the `FalconSigToStack` injector.
+    ///
+    /// The signature is fetched from the advice map or otherwise requested from the host's
+    /// authenticator.
+    pub fn on_signature_requested(
+        &mut self,
+        process: &mut ProcessState,
+    ) -> Result<(), TransactionKernelError> {
+        let pub_key = process.get_stack_word(0);
+        let msg = process.get_stack_word(1);
+        let signature_key = Hasher::merge(&[pub_key, msg]);
+
+        let signature = if let Ok(signature) =
+            process.advice_provider().get_mapped_values(&signature_key)
+        {
+            signature.to_vec()
+        } else {
+            let account_delta = self.base_host.account_delta.clone().into_delta();
+
+            let authenticator =
+                self.authenticator.ok_or(TransactionKernelError::MissingAuthenticator)?;
+
+            let signature: Vec<Felt> = authenticator
+                .get_signature(pub_key, msg, &account_delta)
+                .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;
+
+            self.generated_signatures.insert(signature_key, signature.clone());
+
+            signature
+        };
+
+        process.advice_provider_mut().stack.extend(signature);
+
+        Ok(())
+    }
+
+    /// Consumes `self` and returns the account delta, output notes, generated signatures and
+    /// transaction progress.
+    pub fn into_parts(
+        self,
+    ) -> (AccountDelta, Vec<OutputNote>, BTreeMap<Word, Vec<Felt>>, TransactionProgress) {
+        let (account_delta, output_notes, tx_progress) = self.base_host.into_parts();
+
+        (account_delta, output_notes, self.generated_signatures, tx_progress)
+    }
+}
+
+// HOST IMPLEMENTATION
+// ================================================================================================
+
+impl BaseHost for TransactionExecutorHost<'_, '_> {}
+
+impl SyncHost for TransactionExecutorHost<'_, '_> {
+    fn get_mast_forest(&self, procedure_root: &Word) -> Option<Arc<MastForest>> {
+        self.base_host.get_mast_forest(procedure_root)
+    }
+
+    fn on_event(
+        &mut self,
+        process: &mut ProcessState<'_>,
+        event_id: u32,
+        err_ctx: &impl ErrorContext,
+    ) -> Result<(), ExecutionError> {
+        let transaction_event = TransactionEvent::try_from(event_id)
+            .map_err(|err| ExecutionError::event_error(Box::new(err), err_ctx))?;
+
+        match transaction_event {
+            // Override the base host's on signature requested implementation, which would not call
+            // the authenticator.
+            TransactionEvent::FalconSigToStack => {
+                self.on_signature_requested(process)
+                    .map_err(|err| ExecutionError::event_error(Box::new(err), err_ctx))?;
+            },
+            // All other events are handled as in the base host.
+            _ => {
+                self.base_host.handle_event(process, transaction_event, err_ctx)?;
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -1,3 +1,27 @@
+mod account_delta_tracker;
+use account_delta_tracker::AccountDeltaTracker;
+
+mod storage_delta_tracker;
+
+mod link_map;
+pub use link_map::LinkMap;
+
+mod account_procedures;
+pub use account_procedures::AccountProcedureIndexMap;
+
+mod note_builder;
+use note_builder::OutputNoteBuilder;
+
+mod script_mast_forest_store;
+pub use script_mast_forest_store::ScriptMastForestStore;
+
+mod exec_host;
+pub use exec_host::TransactionExecutorHost;
+
+mod prover_host;
+pub use prover_host::TransactionProverHost;
+
+mod tx_progress;
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
@@ -17,43 +41,20 @@ use miden_objects::{
     transaction::{OutputNote, TransactionMeasurements},
     vm::RowIndex,
 };
+pub use tx_progress::TransactionProgress;
 use vm_processor::{
-    AdviceInputs, BaseHost, ContextId, ErrorContext, ExecutionError, Felt, KvMap, MastForest,
-    MastForestStore, MemoryError, ProcessState, SyncHost,
+    AdviceInputs, ContextId, ErrorContext, ExecutionError, Felt, KvMap, MastForest,
+    MastForestStore, MemoryError, ProcessState,
 };
 
-mod account_delta_tracker;
-use account_delta_tracker::AccountDeltaTracker;
+use crate::errors::TransactionHostError;
 
-mod storage_delta_tracker;
-
-mod link_map;
-pub use link_map::{Entry, EntryMetadata, LinkMap};
-
-mod account_procedures;
-pub use account_procedures::AccountProcedureIndexMap;
-
-mod note_builder;
-use note_builder::OutputNoteBuilder;
-
-mod script_mast_forest_store;
-pub use script_mast_forest_store::ScriptMastForestStore;
-
-mod tx_progress;
-pub use tx_progress::TransactionProgress;
-
-use crate::{auth::TransactionAuthenticator, errors::TransactionHostError};
-
-// TRANSACTION HOST
+// TRANSACTION BASE HOST
 // ================================================================================================
 
-/// The transaction host is responsible for handling [`SyncHost`] requests made by the transaction
-/// kernel.
-///
-/// Transaction hosts are created on a per-transaction basis. That is, a transaction host is meant
-/// to support execution of a single transaction and is discarded after the transaction finishes
-/// execution.
-pub struct TransactionHost<'store, 'auth> {
+/// The base transaction host that implements shared behavior of all transaction host
+/// implementations.
+pub struct TransactionBaseHost<'store> {
     /// MAST store which contains the code required to execute account code functions.
     mast_store: &'store dyn MastForestStore,
 
@@ -63,7 +64,7 @@ pub struct TransactionHost<'store, 'auth> {
 
     /// Account state changes accumulated during transaction execution.
     ///
-    /// This field is updated by the [TransactionHost::on_event()] handler.
+    /// The delta is updated by event handlers.
     account_delta: AccountDeltaTracker,
 
     /// A map of the procedure MAST roots to the corresponding procedure indices for all the
@@ -74,31 +75,22 @@ pub struct TransactionHost<'store, 'auth> {
     /// map.
     output_notes: BTreeMap<usize, OutputNoteBuilder>,
 
-    /// Serves signature generation requests from the transaction runtime for signatures which are
-    /// not present in the `generated_signatures` field.
-    authenticator: Option<&'auth dyn TransactionAuthenticator>,
-
-    /// Contains previously generated signatures (as a message |-> signature map) required for
-    /// transaction execution.
-    ///
-    /// If a required signature is not present in this map, the host will attempt to generate the
-    /// signature using the transaction authenticator.
-    generated_signatures: BTreeMap<Word, Vec<Felt>>,
-
     /// Tracks the number of cycles for each of the transaction execution stages.
     ///
-    /// This field is updated by the [TransactionHost::on_trace()] handler.
+    /// The progress is updated event handlers.
     tx_progress: TransactionProgress,
 }
 
-impl<'store, 'auth> TransactionHost<'store, 'auth> {
-    /// Creates a new [`TransactionHost`] instance from the provided inputs.
+impl<'store> TransactionBaseHost<'store> {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`TransactionBaseHost`] instance from the provided inputs.
     pub fn new(
         account: &PartialAccount,
         advice_inputs: &mut AdviceInputs,
         mast_store: &'store dyn MastForestStore,
         scripts_mast_store: ScriptMastForestStore,
-        authenticator: Option<&'auth dyn TransactionAuthenticator>,
         mut foreign_account_code_commitments: BTreeSet<Word>,
     ) -> Result<Self, TransactionHostError> {
         // currently, the executor/prover do not keep track of the code commitment of the native
@@ -130,7 +122,7 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
         let proc_index_map =
             AccountProcedureIndexMap::new(foreign_account_code_commitments, advice_inputs)?;
 
-        Ok(Self {
+        let base = Self {
             mast_store,
             scripts_mast_store,
             account_delta: AccountDeltaTracker::new(
@@ -139,25 +131,22 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
             ),
             acct_procedure_index_map: proc_index_map,
             output_notes: BTreeMap::default(),
-            authenticator,
             tx_progress: TransactionProgress::default(),
-            generated_signatures: BTreeMap::new(),
-        })
+        };
+
+        Ok(base)
     }
 
-    /// Consumes `self` and returns the advice provider, account delta, output notes, generated
-    /// signatures, and transaction progress.
-    pub fn into_parts(
-        self,
-    ) -> (AccountDelta, Vec<OutputNote>, BTreeMap<Word, Vec<Felt>>, TransactionProgress) {
-        let output_notes = self.output_notes.into_values().map(|builder| builder.build()).collect();
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
 
-        (
-            self.account_delta.into_delta(),
-            output_notes,
-            self.generated_signatures,
-            self.tx_progress,
-        )
+    /// Returns the [`MastForest`] that contains the procedure with the given `procedure_root`.
+    pub fn get_mast_forest(&self, procedure_root: &Word) -> Option<Arc<MastForest>> {
+        // Search in the note MAST forest store, otherwise fall back to the user-provided store
+        match self.scripts_mast_store.get(procedure_root) {
+            Some(forest) => Some(forest),
+            None => self.mast_store.get(procedure_root),
+        }
     }
 
     /// Returns a reference to the `tx_progress` field of this transaction host.
@@ -165,11 +154,160 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
         &self.tx_progress
     }
 
+    /// Consumes `self` and returns the account delta, output notes and transaction progress.
+    pub fn into_parts(self) -> (AccountDelta, Vec<OutputNote>, TransactionProgress) {
+        let output_notes = self.output_notes.into_values().map(|builder| builder.build()).collect();
+
+        (self.account_delta.into_delta(), output_notes, self.tx_progress)
+    }
+
     // EVENT HANDLERS
     // --------------------------------------------------------------------------------------------
 
+    /// Handles the given [`TransactionEvent`], for example by updating the account delta or pushing
+    /// requested advice to the advice stack.
+    fn handle_event(
+        &mut self,
+        process: &mut ProcessState,
+        transaction_event: TransactionEvent,
+        err_ctx: &impl ErrorContext,
+    ) -> Result<(), ExecutionError> {
+        // only the `FalconSigToStack` event can be executed outside the root context
+        if process.ctx() != ContextId::root()
+            && !matches!(transaction_event, TransactionEvent::FalconSigToStack)
+        {
+            return Err(ExecutionError::event_error(
+                Box::new(TransactionEventError::NotRootContext(transaction_event as u32)),
+                err_ctx,
+            ));
+        }
+
+        match transaction_event {
+            TransactionEvent::AccountVaultBeforeAddAsset => Ok(()),
+            TransactionEvent::AccountVaultAfterAddAsset => {
+                self.on_account_vault_after_add_asset(process)
+            },
+
+            TransactionEvent::AccountVaultBeforeRemoveAsset => Ok(()),
+            TransactionEvent::AccountVaultAfterRemoveAsset => {
+                self.on_account_vault_after_remove_asset(process)
+            },
+
+            TransactionEvent::AccountStorageBeforeSetItem => Ok(()),
+            TransactionEvent::AccountStorageAfterSetItem => {
+                self.on_account_storage_after_set_item(process)
+            },
+
+            TransactionEvent::AccountStorageBeforeSetMapItem => Ok(()),
+            TransactionEvent::AccountStorageAfterSetMapItem => {
+                self.on_account_storage_after_set_map_item(process)
+            },
+
+            TransactionEvent::AccountBeforeIncrementNonce => {
+                self.on_account_before_increment_nonce(process)
+            },
+            TransactionEvent::AccountAfterIncrementNonce => Ok(()),
+
+            TransactionEvent::AccountPushProcedureIndex => {
+                self.on_account_push_procedure_index(process)
+            },
+
+            TransactionEvent::NoteBeforeCreated => Ok(()),
+            TransactionEvent::NoteAfterCreated => self.on_note_after_created(process),
+
+            TransactionEvent::NoteBeforeAddAsset => self.on_note_before_add_asset(process),
+            TransactionEvent::NoteAfterAddAsset => Ok(()),
+
+            TransactionEvent::FalconSigToStack => self.on_signature_requested(process),
+
+            TransactionEvent::PrologueStart => {
+                self.tx_progress.start_prologue(process.clk());
+                Ok(())
+            },
+            TransactionEvent::PrologueEnd => {
+                self.tx_progress.end_prologue(process.clk());
+                Ok(())
+            },
+
+            TransactionEvent::NotesProcessingStart => {
+                self.tx_progress.start_notes_processing(process.clk());
+                Ok(())
+            },
+            TransactionEvent::NotesProcessingEnd => {
+                self.tx_progress.end_notes_processing(process.clk());
+                Ok(())
+            },
+
+            TransactionEvent::NoteExecutionStart => {
+                let note_id = Self::get_current_note_id(process,err_ctx)?.expect(
+                    "Note execution interval measurement is incorrect: check the placement of the start and the end of the interval",
+                );
+                self.tx_progress.start_note_execution(process.clk(), note_id);
+                Ok(())
+            },
+            TransactionEvent::NoteExecutionEnd => {
+                self.tx_progress.end_note_execution(process.clk());
+                Ok(())
+            },
+
+            TransactionEvent::TxScriptProcessingStart => {
+                self.tx_progress.start_tx_script_processing(process.clk());
+                Ok(())
+            }
+            TransactionEvent::TxScriptProcessingEnd => {
+                self.tx_progress.end_tx_script_processing(process.clk());
+                Ok(())
+            }
+
+            TransactionEvent::EpilogueStart => {
+                self.tx_progress.start_epilogue(process.clk());
+                Ok(())
+            }
+            TransactionEvent::EpilogueEnd => {
+                self.tx_progress.end_epilogue(process.clk());
+                Ok(())
+            }
+            TransactionEvent::LinkMapSetEvent => {
+                LinkMap::handle_set_event(process)?;
+                Ok(())
+            },
+            TransactionEvent::LinkMapGetEvent => {
+                LinkMap::handle_get_event(process)?;
+                Ok(())
+            }
+        }
+        .map_err(|err| ExecutionError::event_error(Box::new(err),err_ctx))?;
+
+        Ok(())
+    }
+
+    // ADVICE INJECTOR HANDLERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Pushes a signature to the advice stack as a response to the `FalconSigToStack` injector.
+    ///
+    /// The signature is fetched from the advice map and if it is not present, an error is returned.
+    pub fn on_signature_requested(
+        &mut self,
+        process: &mut ProcessState,
+    ) -> Result<(), TransactionKernelError> {
+        let pub_key = process.get_stack_word(0);
+        let msg = process.get_stack_word(1);
+        let signature_key = Hasher::merge(&[pub_key, msg]);
+
+        let signature = process
+            .advice_provider()
+            .get_mapped_values(&signature_key)
+            .map_err(|_| TransactionKernelError::MissingAuthenticator)?
+            .to_vec();
+
+        process.advice_provider_mut().stack.extend(signature);
+
+        Ok(())
+    }
+
     /// Creates a new [OutputNoteBuilder] from the data on the operand stack and stores it into the
-    /// `output_notes` field of this [TransactionHost].
+    /// `output_notes` field of this [`TransactionBaseHost`].
     ///
     /// Expected stack state: `[NOTE_METADATA, RECIPIENT, ...]`
     fn on_note_after_created(
@@ -396,52 +534,6 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
         Ok(())
     }
 
-    // ADVICE INJECTOR HANDLERS
-    // --------------------------------------------------------------------------------------------
-
-    /// Returns a signature as a response to the `SigToStack` injector.
-    ///
-    /// This signature is created during transaction execution and stored for use as advice map
-    /// inputs in the proving host. If not already present in the advice map, it is requested from
-    /// the host's authenticator.
-    pub fn on_signature_requested(
-        &mut self,
-        process: &mut ProcessState,
-    ) -> Result<(), TransactionKernelError> {
-        let pub_key = process.get_stack_word(0);
-        let msg = process.get_stack_word(1);
-        let signature_key = Hasher::merge(&[pub_key, msg]);
-
-        let signature =
-            if let Ok(signature) = process.advice_provider().get_mapped_values(&signature_key) {
-                signature.to_vec()
-            } else {
-                let account_delta = self.account_delta.clone().into_delta();
-
-                let signature: Vec<Felt> = match &self.authenticator {
-                    None => {
-                        return Err(TransactionKernelError::FailedSignatureGeneration(
-                            "No authenticator assigned to transaction host",
-                        ));
-                    },
-                    Some(authenticator) => {
-                        authenticator.get_signature(pub_key, msg, &account_delta).map_err(|_| {
-                            TransactionKernelError::FailedSignatureGeneration(
-                                "Error generating signature",
-                            )
-                        })
-                    },
-                }?;
-
-                self.generated_signatures.insert(signature_key, signature.clone());
-                signature
-            };
-
-        process.advice_provider_mut().stack.extend(signature);
-
-        Ok(())
-    }
-
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
@@ -492,138 +584,5 @@ impl<'store, 'auth> TransactionHost<'store, 'auth> {
             ))?;
 
         Ok(num_storage_slots_felt.as_int())
-    }
-}
-
-// HOST IMPLEMENTATION FOR TRANSACTION HOST
-// ================================================================================================
-
-impl BaseHost for TransactionHost<'_, '_> {}
-
-impl SyncHost for TransactionHost<'_, '_> {
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        // Search in the note MAST forest store, otherwise fall back to the user-provided store
-        match self.scripts_mast_store.get(node_digest) {
-            Some(forest) => Some(forest),
-            None => self.mast_store.get(node_digest),
-        }
-    }
-
-    fn on_event(
-        &mut self,
-        process: &mut ProcessState,
-        event_id: u32,
-        err_ctx: &impl ErrorContext,
-    ) -> Result<(), ExecutionError> {
-        let transaction_event = TransactionEvent::try_from(event_id)
-            .map_err(|err| ExecutionError::event_error(Box::new(err), err_ctx))?;
-
-        // only the `FalconSigToStack` event can be executed outside the root context
-        if process.ctx() != ContextId::root()
-            && !matches!(transaction_event, TransactionEvent::FalconSigToStack)
-        {
-            return Err(ExecutionError::event_error(
-                Box::new(TransactionEventError::NotRootContext(event_id)),
-                err_ctx,
-            ));
-        }
-
-        match transaction_event {
-            TransactionEvent::AccountVaultBeforeAddAsset => Ok(()),
-            TransactionEvent::AccountVaultAfterAddAsset => {
-                self.on_account_vault_after_add_asset(process)
-            },
-
-            TransactionEvent::AccountVaultBeforeRemoveAsset => Ok(()),
-            TransactionEvent::AccountVaultAfterRemoveAsset => {
-                self.on_account_vault_after_remove_asset(process)
-            },
-
-            TransactionEvent::AccountStorageBeforeSetItem => Ok(()),
-            TransactionEvent::AccountStorageAfterSetItem => {
-                self.on_account_storage_after_set_item(process)
-            },
-
-            TransactionEvent::AccountStorageBeforeSetMapItem => Ok(()),
-            TransactionEvent::AccountStorageAfterSetMapItem => {
-                self.on_account_storage_after_set_map_item(process)
-            },
-
-            TransactionEvent::AccountBeforeIncrementNonce => {
-                self.on_account_before_increment_nonce(process)
-            },
-            TransactionEvent::AccountAfterIncrementNonce => Ok(()),
-
-            TransactionEvent::AccountPushProcedureIndex => {
-                self.on_account_push_procedure_index(process)
-            },
-
-            TransactionEvent::NoteBeforeCreated => Ok(()),
-            TransactionEvent::NoteAfterCreated => self.on_note_after_created(process),
-
-            TransactionEvent::NoteBeforeAddAsset => self.on_note_before_add_asset(process),
-            TransactionEvent::NoteAfterAddAsset => Ok(()),
-
-            TransactionEvent::FalconSigToStack => self.on_signature_requested(process),
-
-            TransactionEvent::PrologueStart => {
-                self.tx_progress.start_prologue(process.clk());
-                Ok(())
-            },
-            TransactionEvent::PrologueEnd => {
-                self.tx_progress.end_prologue(process.clk());
-                Ok(())
-            },
-
-            TransactionEvent::NotesProcessingStart => {
-                self.tx_progress.start_notes_processing(process.clk());
-                Ok(())
-            },
-            TransactionEvent::NotesProcessingEnd => {
-                self.tx_progress.end_notes_processing(process.clk());
-                Ok(())
-            },
-
-            TransactionEvent::NoteExecutionStart => {
-                let note_id = Self::get_current_note_id(process,err_ctx)?.expect(
-                    "Note execution interval measurement is incorrect: check the placement of the start and the end of the interval",
-                );
-                self.tx_progress.start_note_execution(process.clk(), note_id);
-                Ok(())
-            },
-            TransactionEvent::NoteExecutionEnd => {
-                self.tx_progress.end_note_execution(process.clk());
-                Ok(())
-            },
-
-            TransactionEvent::TxScriptProcessingStart => {
-                self.tx_progress.start_tx_script_processing(process.clk());
-                Ok(())
-            }
-            TransactionEvent::TxScriptProcessingEnd => {
-                self.tx_progress.end_tx_script_processing(process.clk());
-                Ok(())
-            }
-
-            TransactionEvent::EpilogueStart => {
-                self.tx_progress.start_epilogue(process.clk());
-                Ok(())
-            }
-            TransactionEvent::EpilogueEnd => {
-                self.tx_progress.end_epilogue(process.clk());
-                Ok(())
-            }
-            TransactionEvent::LinkMapSetEvent => {
-                LinkMap::handle_set_event(process)?;
-                Ok(())
-            },
-            TransactionEvent::LinkMapGetEvent => {
-                LinkMap::handle_get_event(process)?;
-                Ok(())
-            }
-        }
-        .map_err(|err| ExecutionError::event_error(Box::new(err),err_ctx))?;
-
-        Ok(())
     }
 }

--- a/crates/miden-tx/src/host/prover_host.rs
+++ b/crates/miden-tx/src/host/prover_host.rs
@@ -1,0 +1,85 @@
+use alloc::{boxed::Box, collections::BTreeSet, sync::Arc, vec::Vec};
+
+use miden_lib::transaction::TransactionEvent;
+use miden_objects::{
+    Word,
+    account::{AccountDelta, PartialAccount},
+    transaction::OutputNote,
+};
+use vm_processor::{
+    AdviceInputs, BaseHost, ErrorContext, ExecutionError, MastForest, MastForestStore,
+    ProcessState, SyncHost,
+};
+
+use crate::{
+    TransactionProgress,
+    errors::TransactionHostError,
+    host::{ScriptMastForestStore, TransactionBaseHost},
+};
+
+/// The transaction prover host is responsible for handling [`SyncHost`] requests made by the
+/// transaction kernel during proving.
+pub struct TransactionProverHost<'store> {
+    /// The underlying base transaction host.
+    base_host: TransactionBaseHost<'store>,
+}
+
+impl<'store> TransactionProverHost<'store> {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`TransactionProverHost`] instance from the provided inputs.
+    pub fn new(
+        account: &PartialAccount,
+        advice_inputs: &mut AdviceInputs,
+        mast_store: &'store dyn MastForestStore,
+        scripts_mast_store: ScriptMastForestStore,
+        foreign_account_code_commitments: BTreeSet<Word>,
+    ) -> Result<Self, TransactionHostError> {
+        let base_host = TransactionBaseHost::new(
+            account,
+            advice_inputs,
+            mast_store,
+            scripts_mast_store,
+            foreign_account_code_commitments,
+        )?;
+
+        Ok(Self { base_host })
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a reference to the `tx_progress` field of this transaction host.
+    pub fn tx_progress(&self) -> &TransactionProgress {
+        self.base_host.tx_progress()
+    }
+
+    /// Consumes `self` and returns the account delta, output notes and transaction progress.
+    pub fn into_parts(self) -> (AccountDelta, Vec<OutputNote>, TransactionProgress) {
+        self.base_host.into_parts()
+    }
+}
+
+// HOST IMPLEMENTATION
+// ================================================================================================
+
+impl BaseHost for TransactionProverHost<'_> {}
+
+impl SyncHost for TransactionProverHost<'_> {
+    fn get_mast_forest(&self, procedure_root: &Word) -> Option<Arc<MastForest>> {
+        self.base_host.get_mast_forest(procedure_root)
+    }
+
+    fn on_event(
+        &mut self,
+        process: &mut ProcessState,
+        event_id: u32,
+        err_ctx: &impl ErrorContext,
+    ) -> Result<(), ExecutionError> {
+        let transaction_event = TransactionEvent::try_from(event_id)
+            .map_err(|err| ExecutionError::event_error(Box::new(err), err_ctx))?;
+
+        self.base_host.handle_event(process, transaction_event, err_ctx)
+    }
+}

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -15,7 +15,7 @@ pub use executor::{
 };
 
 pub mod host;
-pub use host::{TransactionHost, TransactionProgress};
+pub use host::{TransactionExecutorHost, TransactionProgress, TransactionProverHost};
 
 mod prover;
 pub use prover::{LocalTransactionProver, ProvingOptions, TransactionMastStore, TransactionProver};

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -13,8 +13,8 @@ use miden_prover::prove;
 use vm_processor::Word;
 use winter_maybe_async::*;
 
-use super::{TransactionHost, TransactionProverError};
-use crate::host::ScriptMastForestStore;
+use super::TransactionProverError;
+use crate::host::{ScriptMastForestStore, TransactionProverHost};
 
 mod mast_store;
 pub use mast_store::TransactionMastStore;
@@ -98,12 +98,11 @@ impl TransactionProver for LocalTransactionProver {
             input_notes.iter().map(|n| n.note().script()),
         );
 
-        let mut host: TransactionHost = TransactionHost::new(
+        let mut host: TransactionProverHost = TransactionProverHost::new(
             &account.into(),
             &mut advice_inputs,
             self.mast_store.as_ref(),
             script_mast_store,
-            None,
             account_code_commitments,
         )
         .map_err(TransactionProverError::TransactionHostCreationFailed)?;
@@ -123,7 +122,7 @@ impl TransactionProver for LocalTransactionProver {
         .map_err(TransactionProverError::TransactionProgramExecutionFailed)?;
 
         // extract transaction outputs and process transaction data
-        let (account_delta, output_notes, _signatures, _tx_progress) = host.into_parts();
+        let (account_delta, output_notes, _tx_progress) = host.into_parts();
         let tx_outputs = TransactionKernel::from_transaction_parts(
             &stack_outputs,
             &advice_inputs.map,


### PR DESCRIPTION
Splits the current `TransactionHost` into three parts, which are basically:

```rust
struct TransactionProverHost { base_host: TransactionBaseHost }
struct TransactionExecutorHost { base_host: TransactionBaseHost, authenticator: ... }
impl SyncHost for TransactionProverHost {}
// This will become AsyncHost in another PR.
impl SyncHost for TransactionExecutorHost {}
```

This is in preparation for https://github.com/0xMiden/miden-base/issues/1162 where we will need an async host.

The `TransactionExecutorHost` is used for transaction execution and contains a [`TransactionAuthenticator`] which can generate signature requests on demand. The `TransactionProverHost` on the other hand doesn't have that ability and only responds to such requests by looking up the signatures in the advice map.

Technically, we could get away with just two types: A base host implementing `SyncHost` and another host type with an authenticator. I wasn't able to come up with good names for these, and the current approach felt cleaner. For instance, if the base host was called `TransactionProverHost` and the `TransactionExecutorHost` would wrap it, it would feel odd that the prover host would be used as part of execution.
Happy to go in a different direction too though.

Also improves the authenticator-related errors by using concrete error types rather than strings.

Should we make the `TransactionBaseHost` public? It could be useful for custom implementations of a transaction host, but these could also just wrap the prover or executor hosts, so not sure it really has to be public and I would make it private to remove it from the API surface.

One other consideration: The authenticator in the executor host is still `Option` but it could also be made required. Previously, the legitimate use of `None` was in the prover host, but now it's typically only tests that don't use proper authentication that don't need it. Those could technically just pass `()` as the authenticator implementation. But overall I felt the `Option` was still a bit nicer to handle this, so I left it.

part of #1162