### PR TITLE
chore: optimize `mem_loadw` -> `mem_load` when possible

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -589,8 +589,9 @@ end
 #!
 #! Where:
 #! - timestamp is the timestamp of the reference block for this transaction.
+const.BLOCK_METADATA_TIMESTAMP_PTR=BLOCK_METADATA_PTR+2
 export.get_blk_timestamp
-    push.BLOCK_METADATA_PTR add.2 mem_load
+    mem_load.BLOCK_METADATA_TIMESTAMP_PTR
 end
 
 #! Returns the chain commitment of the transaction reference block.

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -579,7 +579,7 @@ end
 #! Where:
 #! - version is the protocol version of the transaction reference block.
 export.get_blk_version
-    padw mem_loadw.BLOCK_METADATA_PTR drop drop swap drop
+    push.BLOCK_METADATA_PTR add.1 mem_load
 end
 
 #! Returns the block timestamp of the reference block for this transaction.
@@ -590,7 +590,7 @@ end
 #! Where:
 #! - timestamp is the timestamp of the reference block for this transaction.
 export.get_blk_timestamp
-    padw mem_loadw.BLOCK_METADATA_PTR drop movdn.2 drop drop
+    push.BLOCK_METADATA_PTR add.2 mem_load
 end
 
 #! Returns the chain commitment of the transaction reference block.
@@ -933,10 +933,9 @@ end
 #! Where:
 #! - acct_nonce is the account nonce.
 export.get_acct_nonce
-    padw
     exec.get_current_account_data_ptr push.ACCT_ID_AND_NONCE_OFFSET add
-    mem_loadw
-    movdn.3 drop drop drop
+    add.3
+    mem_load
 end
 
 #! Sets the account nonce.

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -578,8 +578,9 @@ end
 #!
 #! Where:
 #! - version is the protocol version of the transaction reference block.
+const.BLOCK_METADATA_VERSION_PTR=BLOCK_METADATA_PTR+1
 export.get_blk_version
-    push.BLOCK_METADATA_PTR add.1 mem_load
+    mem_load.BLOCK_METADATA_VERSION_PTR
 end
 
 #! Returns the block timestamp of the reference block for this transaction.
@@ -933,9 +934,9 @@ end
 #!
 #! Where:
 #! - acct_nonce is the account nonce.
+const.ACCT_NONCE_PTR=ACCT_ID_AND_NONCE_OFFSET+3
 export.get_acct_nonce
-    exec.get_current_account_data_ptr push.ACCT_ID_AND_NONCE_OFFSET add
-    add.3
+    exec.get_current_account_data_ptr add.ACCT_NONCE_PTR
     mem_load
 end
 

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -72,7 +72,7 @@ pub const KERNEL0_PROCEDURES: [Word; 37] = [
     // tx_get_block_number
     word!("0x297797dff54b8108dd2df254b95d43895d3f917ab10399efc62adaf861c905ae"),
     // tx_get_block_timestamp
-    word!("0x03fd4a4035c058dce55009aeca2ba3461f63d8606841fc0949d79ea8f6db90a8"),
+    word!("0x7903185b847517debb6c2072364e3e757b99ee623e97c2bd0a4661316c5c5418"),
     // tx_start_foreign_context
     word!("0xa18344624bf0dd93c674e4b3823292a3e1ddf0e09f7fa805f0dbe92b452fd98d"),
     // tx_end_foreign_context

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -14,9 +14,9 @@ pub const KERNEL0_PROCEDURES: [Word; 37] = [
     // account_get_id
     word!("0x1a5583b3a4011d0ca83ac9633fc12b0c6ec2cba03ee8c5f380ac69fc4f767075"),
     // account_get_nonce
-    word!("0xf1dfe3621b9147803b6668352915be7fb7f85df476c9d18052272270a854fa75"),
+    word!("0x0791e175c7627fe2155216f0497e715a5ff77cfc99e67d80f90737e1882296bf"),
     // account_incr_nonce
-    word!("0xbe7d41cea0590663d7683e9937b53b4f46afdbd1890f76b7e4ea92bee04d0ecf"),
+    word!("0x3c4fa853804b60d411f255549d955a3929963362dcae39b5f0310252d38c521f"),
     // account_get_code_commitment
     word!("0x3dd7c93691699c00d70ee2687f568e38869d81402b1dba25f2d6c2b463b91f77"),
     // account_get_storage_commitment
@@ -72,7 +72,7 @@ pub const KERNEL0_PROCEDURES: [Word; 37] = [
     // tx_get_block_number
     word!("0x297797dff54b8108dd2df254b95d43895d3f917ab10399efc62adaf861c905ae"),
     // tx_get_block_timestamp
-    word!("0x786863e6dbcd5026619afd3831b7dcbf824cda54950b0e0724ebf9d9370ec723"),
+    word!("0x03fd4a4035c058dce55009aeca2ba3461f63d8606841fc0949d79ea8f6db90a8"),
     // tx_start_foreign_context
     word!("0xa18344624bf0dd93c674e4b3823292a3e1ddf0e09f7fa805f0dbe92b452fd98d"),
     // tx_end_foreign_context

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -14,9 +14,9 @@ pub const KERNEL0_PROCEDURES: [Word; 37] = [
     // account_get_id
     word!("0x1a5583b3a4011d0ca83ac9633fc12b0c6ec2cba03ee8c5f380ac69fc4f767075"),
     // account_get_nonce
-    word!("0x0791e175c7627fe2155216f0497e715a5ff77cfc99e67d80f90737e1882296bf"),
+    word!("0xb19ece9509e73580a93f6516ddbc62c87e70cee6e97eea4af8c46dcee5b42384"),
     // account_incr_nonce
-    word!("0x3c4fa853804b60d411f255549d955a3929963362dcae39b5f0310252d38c521f"),
+    word!("0x2c0cd4bd5cdadb8ee911b034c91f81be5205cf6691c7a5760bdf8d05a00832dc"),
     // account_get_code_commitment
     word!("0x3dd7c93691699c00d70ee2687f568e38869d81402b1dba25f2d6c2b463b91f77"),
     // account_get_storage_commitment


### PR DESCRIPTION
instead of `padw mem_loadw` and some sequence of `drop / swap`s, we can use `mem_load` directly

closes #1132 