### PR TITLE
fix: use async for miden-prover

### DIFF
--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-async      = ["winter-maybe-async/async"]
+async      = ["miden-prover/async", "winter-maybe-async/async"]
 concurrent = ["miden-prover/concurrent", "std"]
 default    = ["std"]
 std        = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]


### PR DESCRIPTION
This PR adds a small change to the `async` feature in `miden-tx` which was not building correctly.

I don't get why it didn't pop up in the `make build-async` command but the error can be replicated in `next` by only building that package with the command `cargo build --release --features async -p miden-tx`. Should I add this check to the makefile so it is used in the CI? It does seem a bit ad-hoc and like it should be covered by `make build-async`.

This will also return other errors which are related to the use of the `testing` feature, I couldn't find an easy fix for this so I'll be creating a [separate issue](https://github.com/0xMiden/miden-base/issues/1588) but it is currently non-blocking for updating the client and node (we can temporarily use the `testing` feature when building `miden-tx`).