### PR TITLE
Replace `kernel` with `$kernel` as the kernel namespace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [BREAKING] Incremented MSRV to 1.88.
 - Implement `WellKnownComponents` enum ([#1532](https://github.com/0xMiden/miden-base/pull/1532)).
 - Make `ExecutedTransaction` implement `Send` for easier consumption ([#1560](https://github.com/0xMiden/miden-base/pull/1560)).
-- [BREAKING] Upgrade Miden VM to `0.16`, `miden-crypto` to `0.15` and `winterfell` crates to `0.13` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
+- [BREAKING] Upgrade Miden VM to `0.16`, `miden-crypto` to `0.15` and `winterfell` crates to `0.13` ([#1564](https://github.com/0xMiden/miden-base/pull/1564), [#1594](https://github.com/0xMiden/miden-base/pull/1594)).
 - [BREAKING] `Digest` was removed in favor of `Word` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{NoteInclusionProof, AccountWitness}::inner_nodes` to `authenticated_nodes` ([#1564](https://github.com/0xMiden/miden-base/pull/1564)).
 - [BREAKING] Renamed `{TransactionId, NoteId, Nullifier}::inner` -> `as_word` ([#1571](https://github.com/0xMiden/miden-base/pull/1571)).

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1,13 +1,13 @@
 use.std::sys
 
-use.kernel::account
-use.kernel::account_id
-use.kernel::asset_vault
-use.kernel::constants
-use.kernel::faucet
-use.kernel::memory
-use.kernel::note
-use.kernel::tx
+use.$kernel::account
+use.$kernel::account_id
+use.$kernel::asset_vault
+use.$kernel::constants
+use.$kernel::faucet
+use.$kernel::memory
+use.$kernel::note
+use.$kernel::tx
 
 # NOTE
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -3,12 +3,12 @@ use.std::collections::smt
 use.std::crypto::hashes::rpo
 use.std::mem
 
-use.kernel::account_id
-use.kernel::asset_vault
-use.kernel::asset
-use.kernel::account_delta
-use.kernel::constants
-use.kernel::memory
+use.$kernel::account_id
+use.$kernel::asset_vault
+use.$kernel::asset
+use.$kernel::account_delta
+use.$kernel::constants
+use.$kernel::memory
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -1,9 +1,9 @@
-use.kernel::memory
-use.kernel::link_map
-use.kernel::constants
-use.kernel::account
-use.kernel::asset
-use.kernel::asset_vault
+use.$kernel::memory
+use.$kernel::link_map
+use.$kernel::constants
+use.$kernel::account
+use.$kernel::asset
+use.$kernel::asset_vault
 use.std::crypto::hashes::rpo
 use.std::math::u64
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset.masm
@@ -1,5 +1,5 @@
-use.kernel::account
-use.kernel::account_id
+use.$kernel::account
+use.$kernel::account_id
 
 # ERRORS
 # =================================================================================================
@@ -28,7 +28,7 @@ const.ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN="the origin of the non-fungibl
 #!
 #! Where:
 #! - fungible_asset_max_amount is the maximum amount of a fungible asset.
-export.::kernel::util::asset::get_fungible_asset_max_amount
+export.::$kernel::util::asset::get_fungible_asset_max_amount
 
 # PROCEDURES
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -1,8 +1,8 @@
 use.std::collections::smt
 
-use.kernel::account_id
-use.kernel::asset
-use.kernel::memory
+use.$kernel::account_id
+use.$kernel::asset
+use.$kernel::memory
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/constants.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/constants.masm
@@ -51,7 +51,7 @@ end
 #!
 #! Where:
 #! - max_inputs_per_note is the max inputs per note.
-export.::kernel::util::note::get_max_inputs_per_note
+export.::$kernel::util::note::get_max_inputs_per_note
 
 #! Returns the max allowed number of assets per note.
 #!

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -1,10 +1,10 @@
-use.kernel::account
-use.kernel::account_delta
-use.kernel::asset_vault
-use.kernel::constants
-use.kernel::memory
-use.kernel::note
-use.kernel::tx
+use.$kernel::account
+use.$kernel::account_delta
+use.$kernel::asset_vault
+use.$kernel::constants
+use.$kernel::memory
+use.$kernel::note
+use.$kernel::tx
 
 use.std::crypto::hashes::rpo
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/faucet.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/faucet.masm
@@ -1,10 +1,10 @@
 use.std::collections::smt
 
-use.kernel::account
-use.kernel::account_id
-use.kernel::asset
-use.kernel::asset_vault
-use.kernel::memory
+use.$kernel::account
+use.$kernel::account_id
+use.$kernel::asset
+use.$kernel::asset_vault
+use.$kernel::memory
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
@@ -1,5 +1,5 @@
 use.std::collections::smt
-use.kernel::memory
+use.$kernel::memory
 
 # A link map is a map data structure based on a sorted linked list.
 #

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -1,5 +1,5 @@
-use.kernel::account
-use.kernel::constants
+use.$kernel::account
+use.$kernel::constants
 use.std::mem
 
 # ERRORS

--- a/crates/miden-lib/asm/kernels/transaction/lib/note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/note.masm
@@ -1,7 +1,7 @@
 use.std::crypto::hashes::rpo
 
-use.kernel::constants
-use.kernel::memory
+use.$kernel::constants
+use.$kernel::memory
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -2,11 +2,11 @@ use.std::mem
 use.std::collections::mmr
 use.std::crypto::hashes::rpo
 
-use.kernel::account
-use.kernel::account_id
-use.kernel::asset_vault
-use.kernel::constants
-use.kernel::memory
+use.$kernel::account
+use.$kernel::account_id
+use.$kernel::asset_vault
+use.$kernel::constants
+use.$kernel::memory
 
 # CONSTS
 # =================================================================================================
@@ -687,7 +687,7 @@ proc.process_note_inputs_length
     # => [inputs_len, note_ptr]
 
     # validate the input length
-    dup exec.::kernel::util::note::get_max_inputs_per_note lte
+    dup exec.::$kernel::util::note::get_max_inputs_per_note lte
     assert.err=ERR_PROLOGUE_NUMBER_OF_NOTE_INPUTS_EXCEEDED_LIMIT
     # => [inputs_len, note_ptr]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -1,8 +1,8 @@
-use.kernel::account
-use.kernel::asset
-use.kernel::constants
-use.kernel::memory
-use.kernel::note
+use.$kernel::account
+use.$kernel::asset
+use.$kernel::constants
+use.$kernel::memory
+use.$kernel::note
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -1,9 +1,9 @@
 use.std::utils
 
-use.kernel::epilogue
-use.kernel::memory
-use.kernel::note
-use.kernel::prologue
+use.$kernel::epilogue
+use.$kernel::memory
+use.$kernel::note
+use.$kernel::prologue
 
 # EVENTS
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/tx_script_main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/tx_script_main.masm
@@ -1,7 +1,7 @@
 use.std::utils
 
-use.kernel::memory
-use.kernel::prologue
+use.$kernel::memory
+use.$kernel::prologue
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/build.rs
+++ b/crates/miden-lib/build.rs
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
 /// - src/transaction/procedures/kernel_v0.rs -> contains the kernel procedures table.
 fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> {
     let shared_utils_path = Path::new(ASM_DIR).join(SHARED_UTILS_DIR);
-    let kernel_namespace = LibraryNamespace::new("kernel").expect("namespace should be valid");
+    let kernel_namespace = LibraryNamespace::Kernel; //::new("kernel").expect("namespace should be valid");
 
     let mut assembler = build_assembler(None)?;
     // add the shared util modules to the kernel lib under the kernel::util namespace
@@ -147,12 +147,12 @@ fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> 
 
     // Add the lib/ directory manually so we can set our custom kernel namespace, whereas
     // assemble_kernel_from_dir always picks the $kernel namespace.
-    assembler
-        .compile_and_statically_link_from_dir(kernel_namespace.clone(), source_dir.join("lib"))?;
+    // assembler
+    //     .compile_and_statically_link_from_dir(kernel_namespace.clone(), source_dir.join("lib"))?;
 
     // assemble the kernel library and write it to the "tx_kernel.masl" file
-    let kernel_lib =
-        assembler.assemble_kernel_from_dir(source_dir.join("api.masm"), None::<&str>)?;
+    let kernel_lib = assembler
+        .assemble_kernel_from_dir(source_dir.join("api.masm"), Some(source_dir.join("lib")))?;
 
     // generate `kernel_v0.rs` file
     generate_kernel_proc_hash_file(kernel_lib.clone())?;
@@ -458,7 +458,7 @@ fn copy_directory<T: AsRef<Path>, R: AsRef<Path>>(src: T, dst: R) -> Result<()> 
 /// This is required to include the shared modules as APIs of the `kernel` and `miden` libraries.
 ///
 /// This is done to make it possible to import the modules in the `shared_modules` folder directly,
-/// i.e. "use.kernel::account_id".
+/// i.e. "use.$kernel::account_id".
 fn copy_shared_modules<T: AsRef<Path>>(source_dir: T) -> Result<()> {
     // source is expected to be an `OUT_DIR/asm` folder
     let shared_modules_dir = source_dir.as_ref().join(SHARED_MODULES_DIR);

--- a/crates/miden-lib/build.rs
+++ b/crates/miden-lib/build.rs
@@ -139,16 +139,11 @@ fn main() -> Result<()> {
 /// - src/transaction/procedures/kernel_v0.rs -> contains the kernel procedures table.
 fn compile_tx_kernel(source_dir: &Path, target_dir: &Path) -> Result<Assembler> {
     let shared_utils_path = Path::new(ASM_DIR).join(SHARED_UTILS_DIR);
-    let kernel_namespace = LibraryNamespace::Kernel; //::new("kernel").expect("namespace should be valid");
+    let kernel_namespace = LibraryNamespace::Kernel;
 
     let mut assembler = build_assembler(None)?;
     // add the shared util modules to the kernel lib under the kernel::util namespace
     assembler.compile_and_statically_link_from_dir(kernel_namespace.clone(), &shared_utils_path)?;
-
-    // Add the lib/ directory manually so we can set our custom kernel namespace, whereas
-    // assemble_kernel_from_dir always picks the $kernel namespace.
-    // assembler
-    //     .compile_and_statically_link_from_dir(kernel_namespace.clone(), source_dir.join("lib"))?;
 
     // assemble the kernel library and write it to the "tx_kernel.masl" file
     let kernel_lib = assembler

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -137,8 +137,8 @@ pub fn compute_current_commitment() -> miette::Result<()> {
 pub fn test_get_code() -> miette::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
     let code = "
-        use.kernel::prologue
-        use.kernel::account
+        use.$kernel::prologue
+        use.$kernel::account
         begin
             exec.prologue::prepare_transaction
             exec.account::get_code_commitment
@@ -184,7 +184,7 @@ pub fn test_account_type() -> miette::Result<()> {
 
             let code = format!(
                 "
-                use.kernel::account_id
+                use.$kernel::account_id
 
                 begin
                     exec.account_id::{procedure}
@@ -255,7 +255,7 @@ pub fn test_account_validate_id() -> miette::Result<()> {
         let suffix = Felt::try_from((account_id % (1u128 << 64)) as u64).unwrap();
 
         let code = "
-            use.kernel::account_id
+            use.$kernel::account_id
 
             begin
                 exec.account_id::validate
@@ -307,7 +307,7 @@ fn test_is_faucet_procedure() -> miette::Result<()> {
 
         let code = format!(
             "
-            use.kernel::account_id
+            use.$kernel::account_id
 
             begin
                 push.{prefix}
@@ -346,8 +346,8 @@ fn test_get_item() -> miette::Result<()> {
 
         let code = format!(
             "
-            use.kernel::account
-            use.kernel::prologue
+            use.$kernel::account
+            use.$kernel::prologue
 
             begin
                 exec.prologue::prepare_transaction
@@ -390,7 +390,7 @@ fn test_get_map_item() -> miette::Result<()> {
     for (key, value) in STORAGE_LEAVES_2 {
         let code = format!(
             "
-            use.kernel::prologue
+            use.$kernel::prologue
 
             begin
                 exec.prologue::prepare_transaction
@@ -451,8 +451,8 @@ fn test_get_storage_slot_type() -> miette::Result<()> {
 
         let code = format!(
             "
-            use.kernel::account
-            use.kernel::prologue
+            use.$kernel::account
+            use.$kernel::prologue
 
             begin
                 exec.prologue::prepare_transaction
@@ -494,8 +494,8 @@ fn test_set_item() -> miette::Result<()> {
 
     let code = format!(
         "
-        use.kernel::account
-        use.kernel::prologue
+        use.$kernel::account
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction
@@ -549,7 +549,7 @@ fn test_set_map_item() -> miette::Result<()> {
         use.std::sys
 
         use.test::account
-        use.kernel::prologue
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction
@@ -750,7 +750,7 @@ fn test_account_component_storage_offset() -> miette::Result<()> {
 fn create_account_with_empty_storage_slots() -> anyhow::Result<()> {
     // transaction code which only increases the nonce to make the transaction non-empty
     let default_tx_code = "
-        use.kernel::account 
+        use.$kernel::account 
         
         begin 
             push.1 exec.account::incr_nonce 
@@ -895,7 +895,7 @@ fn test_get_vault_root() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::account
-        use.kernel::prologue
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction
@@ -939,8 +939,8 @@ fn test_authenticate_and_track_procedure() -> miette::Result<()> {
 
         let code = format!(
             "
-            use.kernel::account
-            use.kernel::prologue
+            use.$kernel::account
+            use.$kernel::prologue
 
             begin
                 exec.prologue::prepare_transaction

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -24,7 +24,7 @@ fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::asset
 
         begin
@@ -68,7 +68,7 @@ fn test_create_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::asset
 
         begin
@@ -106,7 +106,7 @@ fn test_validate_non_fungible_asset() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::asset
+        use.$kernel::asset
 
         begin
             push.{asset} 

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -35,7 +35,7 @@ fn test_get_balance() -> anyhow::Result<()> {
     let faucet_id: AccountId = ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap();
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::account
 
         begin
@@ -71,7 +71,7 @@ fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap();
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::account
 
         begin
@@ -105,7 +105,7 @@ fn test_has_non_fungible_asset() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::account
 
         begin
@@ -146,7 +146,7 @@ fn test_add_fungible_asset_success() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -196,7 +196,7 @@ fn test_add_non_fungible_asset_fail_overflow() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -230,7 +230,7 @@ fn test_add_non_fungible_asset_success() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -275,7 +275,7 @@ fn test_add_non_fungible_asset_fail_duplicate() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -315,7 +315,7 @@ fn test_remove_fungible_asset_success_no_balance_remaining() -> anyhow::Result<(
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -363,7 +363,7 @@ fn test_remove_fungible_asset_fail_remove_too_much() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -402,7 +402,7 @@ fn test_remove_fungible_asset_success_balance_remaining() -> anyhow::Result<()> 
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -454,7 +454,7 @@ fn test_remove_inexisting_non_fungible_asset_fails() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -493,7 +493,7 @@ fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -69,9 +69,9 @@ fn test_epilogue() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
-        use.kernel::account
-        use.kernel::epilogue
+        use.$kernel::prologue
+        use.$kernel::account
+        use.$kernel::epilogue
 
         {output_notes_data_procedure}
 
@@ -171,8 +171,8 @@ fn test_compute_output_note_id() -> anyhow::Result<()> {
     for (note, i) in tx_context.expected_output_notes().iter().zip(0u32..) {
         let code = format!(
             "
-            use.kernel::prologue
-            use.kernel::epilogue
+            use.$kernel::prologue
+            use.$kernel::epilogue
 
             {output_notes_data_procedure}
 
@@ -258,9 +258,9 @@ fn test_epilogue_asset_preservation_violation_too_few_input() -> anyhow::Result<
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
-        use.kernel::epilogue
+        use.$kernel::epilogue
 
         {output_notes_data_procedure}
 
@@ -341,9 +341,9 @@ fn test_epilogue_asset_preservation_violation_too_many_fungible_input() -> anyho
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
-        use.kernel::epilogue
+        use.$kernel::epilogue
 
         {output_notes_data_procedure}
 
@@ -373,10 +373,10 @@ fn test_block_expiration_height_monotonically_decreases() -> anyhow::Result<()> 
 
     let test_pairs: [(u64, u64); 3] = [(9, 12), (18, 3), (20, 20)];
     let code_template = "
-        use.kernel::prologue
-        use.kernel::tx
-        use.kernel::epilogue
-        use.kernel::account
+        use.$kernel::prologue
+        use.$kernel::tx
+        use.$kernel::epilogue
+        use.$kernel::account
 
         begin
             exec.prologue::prepare_transaction
@@ -421,7 +421,7 @@ fn test_invalid_expiration_deltas() -> anyhow::Result<()> {
 
     let test_values = [0u64, u16::MAX as u64 + 1, u32::MAX as u64];
     let code_template = "
-        use.kernel::tx
+        use.$kernel::tx
 
         begin
             push.{value_1}
@@ -447,10 +447,10 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let code_template = "
-    use.kernel::prologue
-    use.kernel::epilogue
-    use.kernel::tx
-    use.kernel::account
+    use.$kernel::prologue
+    use.$kernel::epilogue
+    use.$kernel::tx
+    use.$kernel::account
 
     begin
         exec.prologue::prepare_transaction
@@ -483,10 +483,10 @@ fn test_epilogue_increment_nonce_success() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
-        use.kernel::epilogue
-        use.kernel::memory
+        use.$kernel::epilogue
+        use.$kernel::memory
 
         begin
             exec.prologue::prepare_transaction
@@ -531,9 +531,9 @@ fn test_epilogue_increment_nonce_violation() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
-        use.kernel::epilogue
+        use.$kernel::epilogue
 
         {output_notes_data_procedure}
 
@@ -589,9 +589,9 @@ fn test_epilogue_empty_transaction_with_empty_output_note() -> anyhow::Result<()
     let tx_script_source = format!(
         r#"
         use.miden::tx
-        use.kernel::prologue
-        use.kernel::epilogue
-        use.kernel::note
+        use.$kernel::prologue
+        use.$kernel::epilogue
+        use.$kernel::note
 
         begin
             exec.prologue::prepare_transaction

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -47,9 +47,9 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     let code = format!(
         r#"
         use.test::account
-        use.kernel::asset_vault
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::asset_vault
+        use.$kernel::memory
+        use.$kernel::prologue
 
         begin
             # mint asset
@@ -103,7 +103,7 @@ fn test_mint_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -132,7 +132,7 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)?;
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -166,7 +166,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -208,10 +208,10 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
         r#"
         use.std::collections::smt
 
-        use.kernel::account
-        use.kernel::asset_vault
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::account
+        use.$kernel::asset_vault
+        use.$kernel::memory
+        use.$kernel::prologue
         use.test::account->test_account
 
         begin
@@ -261,7 +261,7 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()>
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -290,7 +290,7 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -324,7 +324,7 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<(
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -369,9 +369,9 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
     let code = format!(
         r#"
         use.test::account
-        use.kernel::asset_vault
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::asset_vault
+        use.$kernel::memory
+        use.$kernel::prologue
 
         begin
             # burn asset
@@ -428,7 +428,7 @@ fn test_burn_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -463,7 +463,7 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -498,7 +498,7 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -538,10 +538,10 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-        use.kernel::account
-        use.kernel::asset_vault
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::account
+        use.$kernel::asset_vault
+        use.$kernel::memory
+        use.$kernel::prologue
         use.test::account->test_account
 
         begin
@@ -614,7 +614,7 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -644,7 +644,7 @@ fn test_burn_non_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()>
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -683,7 +683,7 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -724,7 +724,7 @@ fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::faucet
 
         begin
@@ -772,7 +772,7 @@ fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::faucet
 
         begin

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -110,7 +110,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         "
         use.std::sys
         
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::tx
 
         begin
@@ -160,7 +160,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         "
         use.std::sys
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::tx
 
         begin
@@ -216,7 +216,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         "
         use.std::sys
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::tx
 
         begin
@@ -377,7 +377,7 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
         "
         use.std::sys
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::tx
 
         begin
@@ -1232,7 +1232,7 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
         "
       use.std::sys
 
-      use.kernel::prologue
+      use.$kernel::prologue
       use.miden::tx
 
       begin

--- a/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
@@ -32,7 +32,7 @@ fn insertion() -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-      use.kernel::link_map
+      use.$kernel::link_map
 
       const.MAP_PTR={map_ptr}
 
@@ -415,7 +415,7 @@ fn execute_comparison_test(operation: Ordering) -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-        use.kernel::link_map
+        use.$kernel::link_map
 
         begin
           {test_code}
@@ -605,7 +605,7 @@ fn execute_link_map_test(operations: Vec<TestOperation>) -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-      use.kernel::link_map
+      use.$kernel::link_map
       begin
           {test_code}
       end

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -47,8 +47,8 @@ fn test_get_sender_no_sender() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
     // calling get_sender should return sender
     let code = "
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::memory
+        use.$kernel::prologue
         use.miden::note
 
         begin
@@ -86,8 +86,8 @@ fn test_get_sender() -> anyhow::Result<()> {
 
     // calling get_sender should return sender
     let code = "
-        use.kernel::prologue
-        use.kernel::note->note_internal
+        use.$kernel::prologue
+        use.$kernel::note->note_internal
         use.miden::note
 
         begin
@@ -144,8 +144,8 @@ fn test_get_vault_data() -> anyhow::Result<()> {
         "
         use.std::sys
 
-        use.kernel::prologue
-        use.kernel::note
+        use.$kernel::prologue
+        use.$kernel::note
 
         begin
             exec.prologue::prepare_transaction
@@ -235,8 +235,8 @@ fn test_get_assets() -> anyhow::Result<()> {
         "
         use.std::sys
 
-        use.kernel::prologue
-        use.kernel::note->note_internal
+        use.$kernel::prologue
+        use.$kernel::note->note_internal
         use.miden::note
 
         proc.process_note_0
@@ -358,8 +358,8 @@ fn test_get_inputs() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
-        use.kernel::note->note_internal
+        use.$kernel::prologue
+        use.$kernel::note->note_internal
         use.miden::note
 
         begin
@@ -456,7 +456,7 @@ fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
         .build()?;
 
     let tx_code = "
-            use.kernel::prologue
+            use.$kernel::prologue
             use.miden::note
 
             begin
@@ -498,8 +498,8 @@ fn test_note_setup() -> anyhow::Result<()> {
     };
 
     let code = "
-        use.kernel::prologue
-        use.kernel::note
+        use.$kernel::prologue
+        use.$kernel::note
 
         begin
             exec.prologue::prepare_transaction
@@ -553,9 +553,9 @@ fn test_note_script_and_note_args() -> miette::Result<()> {
     };
 
     let code = "
-        use.kernel::prologue
-        use.kernel::memory
-        use.kernel::note
+        use.$kernel::prologue
+        use.$kernel::memory
+        use.$kernel::note
 
         begin
             exec.prologue::prepare_transaction
@@ -630,7 +630,7 @@ fn test_get_note_serial_number() -> anyhow::Result<()> {
 
     // calling get_serial_number should return the serial number of the note
     let code = "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.miden::note
 
         begin
@@ -766,7 +766,7 @@ fn test_get_current_script_root() -> anyhow::Result<()> {
 
     // calling get_script_root should return script root
     let code = "
-    use.kernel::prologue
+    use.$kernel::prologue
     use.miden::note
 
     begin
@@ -816,8 +816,8 @@ fn test_build_note_metadata() -> miette::Result<()> {
     for (iteration, test_metadata) in [test_metadata1, test_metadata2].into_iter().enumerate() {
         let code = format!(
             "
-        use.kernel::prologue
-        use.kernel::tx
+        use.$kernel::prologue
+        use.$kernel::tx
 
         begin
           exec.prologue::prepare_transaction

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -78,7 +78,7 @@ fn test_transaction_prologue() -> anyhow::Result<()> {
     };
 
     let code = "
-        use.kernel::prologue
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction
@@ -500,7 +500,7 @@ pub fn create_account_test(
         .unwrap();
 
     let code = "
-  use.kernel::prologue
+  use.$kernel::prologue
 
   begin
       exec.prologue::prepare_transaction
@@ -665,7 +665,7 @@ pub fn create_account_invalid_seed() -> anyhow::Result<()> {
         .build()?;
 
     let code = "
-      use.kernel::prologue
+      use.$kernel::prologue
 
       begin
           exec.prologue::prepare_transaction
@@ -683,8 +683,8 @@ pub fn create_account_invalid_seed() -> anyhow::Result<()> {
 fn test_get_blk_version() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
     let code = "
-    use.kernel::memory
-    use.kernel::prologue
+    use.$kernel::memory
+    use.$kernel::prologue
 
     begin
         exec.prologue::prepare_transaction
@@ -706,8 +706,8 @@ fn test_get_blk_version() -> anyhow::Result<()> {
 fn test_get_blk_timestamp() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
     let code = "
-    use.kernel::memory
-    use.kernel::prologue
+    use.$kernel::memory
+    use.$kernel::prologue
 
     begin
         exec.prologue::prepare_transaction

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -141,7 +141,7 @@ fn test_create_note() -> anyhow::Result<()> {
         "
         use.miden::tx
         
-        use.kernel::prologue
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction
@@ -236,7 +236,7 @@ fn note_creation_script(tag: Felt) -> String {
     format!(
         "
             use.miden::tx
-            use.kernel::prologue
+            use.$kernel::prologue
     
             begin
                 exec.prologue::prepare_transaction
@@ -267,9 +267,9 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::tx
-        use.kernel::constants
-        use.kernel::memory
-        use.kernel::prologue
+        use.$kernel::constants
+        use.$kernel::memory
+        use.$kernel::prologue
 
         begin
             exec.constants::get_max_num_output_notes
@@ -391,7 +391,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
 
         use.miden::tx
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -502,7 +502,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
         "
         use.miden::tx
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -577,7 +577,7 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
         "
         use.miden::tx
 
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
 
         begin
@@ -662,7 +662,7 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.kernel::prologue
+        use.$kernel::prologue
         use.test::account
         use.miden::tx
 
@@ -739,7 +739,7 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::tx
-        use.kernel::prologue
+        use.$kernel::prologue
 
         proc.build_recipient_hash
             exec.tx::build_recipient_hash
@@ -813,7 +813,7 @@ fn test_block_procedures() -> anyhow::Result<()> {
 
     let code = "
         use.miden::tx
-        use.kernel::prologue
+        use.$kernel::prologue
 
         begin
             exec.prologue::prepare_transaction

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -45,7 +45,7 @@ pub type MockAuthenticator = BasicAuthenticator<ChaCha20Rng>;
 /// let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
 ///
 /// let code = "
-/// use.kernel::prologue
+/// use.$kernel::prologue
 /// use.test::account
 ///
 /// begin


### PR DESCRIPTION
Replace `kernel` with `$kernel` (the default kernel namespace) as the kernel namespace to stay in line with assembler conventions.

Follow up to #1564, specifically https://github.com/0xMiden/miden-base/pull/1564#discussion_r2208586458.
