### PR TITLE
implement `SequentialCommit` for `AccountDelta`

### DIFF
--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -50,7 +50,7 @@ pub mod assembly {
 }
 
 pub mod crypto {
-    pub use miden_crypto::{dsa, hash, merkle, rand, utils};
+    pub use miden_crypto::{SequentialCommit, dsa, hash, merkle, rand, utils};
 }
 
 pub mod utils {

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -74,7 +74,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
 
     assert_eq!(executed_tx.account_delta().nonce_delta(), ZERO);
     assert!(executed_tx.account_delta().is_empty());
-    assert_eq!(executed_tx.account_delta().commitment(), Word::empty());
+    assert_eq!(executed_tx.account_delta().to_commitment(), Word::empty());
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -118,7 +118,7 @@ fn test_epilogue() -> anyhow::Result<()> {
         AccountVaultDelta::default(),
         ONE,
     )?
-    .commitment();
+    .to_commitment();
 
     let account_update_commitment =
         miden_objects::Hasher::merge(&[final_account.commitment(), account_delta_commitment]);

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -477,7 +477,7 @@ fn create_simple_account() -> anyhow::Result<()> {
     assert!(tx.account_delta().vault().is_empty());
     assert_eq!(tx.final_account().nonce(), Felt::new(1));
     // account commitment should not be the empty word
-    assert_ne!(tx.account_delta().commitment(), EMPTY_WORD);
+    assert_ne!(tx.account_delta().to_commitment(), EMPTY_WORD);
 
     Ok(())
 }

--- a/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
+++ b/crates/miden-testing/src/mock_chain/proven_tx_ext.rs
@@ -35,7 +35,7 @@ impl ProvenTransactionExt for ProvenTransaction {
             executed_tx.account_id(),
             executed_tx.initial_account().init_commitment(),
             executed_tx.final_account().commitment(),
-            executed_tx.account_delta().commitment(),
+            executed_tx.account_delta().to_commitment(),
             block_reference.block_num(),
             block_reference.commitment(),
             executed_tx.expiration_block_num(),

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -389,7 +389,7 @@ fn build_executed_transaction(
     let initial_account = tx_inputs.account();
     let final_account = &tx_outputs.account;
 
-    let host_delta_commitment = account_delta.commitment();
+    let host_delta_commitment = account_delta.to_commitment();
     if tx_outputs.account_delta_commitment != host_delta_commitment {
         return Err(TransactionExecutorError::InconsistentAccountDeltaCommitment {
             in_kernel_commitment: tx_outputs.account_delta_commitment,

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -132,7 +132,7 @@ impl TransactionProver for LocalTransactionProver {
 
         // erase private note information (convert private full notes to just headers)
         let output_notes: Vec<_> = tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
-        let account_delta_commitment = account_delta.commitment();
+        let account_delta_commitment = account_delta.to_commitment();
 
         let builder = ProvenTransactionBuilder::new(
             account.id(),


### PR DESCRIPTION
This PR implements `SequentialCommit` trait for `AccountDelta`. It also renames `AccountDelta::commitment()` to `AccountDelta::to_commitment()`. Since the method performs non-trivial amount of work, I think `to_commitment()` is more appropriate here.