### PR TITLE
feat: Add fn to check Account Id prefix existence in AccountTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
+- Added `AccountTree::has_leaf_for_account()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::contains_account_id_prefix()` and `AccountTree::id_prefix_to_smt_key()` (#1610).
+- Added `AccountTree::contains_account_id_prefix()` and `AccountTree::id_prefix_to_smt_key()` ([#1610](https://github.com/0xMiden/miden-base/pull/1610)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::has_account_prefix()` (#1610).
+- Added `AccountTree::contains_account_prefix()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::has_leaf_for_account()` (#1610).
+- Added `AccountTree::account_prefix_exists()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::contains_account_prefix()` (#1610).
+- Added `AccountTree::contains_account_prefix()` and `AccountTree::id_prefix_to_smt_key()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::contains_account_prefix()` and `AccountTree::id_prefix_to_smt_key()` (#1610).
+- Added `AccountTree::contains_account_id_prefix()` and `AccountTree::id_prefix_to_smt_key()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
-- Added `AccountTree::account_prefix_exists()` (#1610).
+- Added `AccountTree::has_account_prefix()` (#1610).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -128,6 +128,13 @@ impl AccountTree {
         self.smt.root()
     }
 
+    /// Returns true if the tree contains a leaf for the given account ID.
+    pub fn has_leaf_for_account(&self, account_id: AccountId) -> bool {
+        let key = Self::id_to_smt_key(account_id);
+        let is_empty = matches!(self.smt.get_leaf(&key), SmtLeaf::Empty(_));
+        !is_empty
+    }
+
     /// Returns the number of account IDs in this tree.
     pub fn num_accounts(&self) -> usize {
         // Because each ID's prefix is unique in the tree and occupies a single leaf, the number of
@@ -204,6 +211,12 @@ impl AccountTree {
         }
 
         Ok(AccountMutationSet::new(mutation_set))
+    }
+
+    /// Checks if the given account ID prefix exists in the tree.
+    pub fn exists(&mut self, account_id: AccountId) -> bool {
+        let key = Self::id_to_smt_key(account_id);
+        !self.smt.get_leaf(&key).is_empty()
     }
 
     // PUBLIC MUTATORS

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -213,12 +213,6 @@ impl AccountTree {
         Ok(AccountMutationSet::new(mutation_set))
     }
 
-    /// Checks if the given account ID prefix exists in the tree.
-    pub fn exists(&mut self, account_id: AccountId) -> bool {
-        let key = Self::id_to_smt_key(account_id);
-        !self.smt.get_leaf(&key).is_empty()
-    }
-
     // PUBLIC MUTATORS
     // --------------------------------------------------------------------------------------------
 

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -128,8 +128,8 @@ impl AccountTree {
         self.smt.root()
     }
 
-    /// Returns true if the tree contains a leaf for the given account ID.
-    pub fn has_leaf_for_account(&self, account_id: AccountId) -> bool {
+    /// Returns true if the tree contains a leaf for the given account ID prefix.
+    pub fn account_prefix_exists(&self, account_id: AccountId) -> bool {
         let key = Self::id_to_smt_key(account_id);
         let is_empty = matches!(self.smt.get_leaf(&key), SmtLeaf::Empty(_));
         !is_empty
@@ -501,13 +501,13 @@ pub(super) mod tests {
         assert_eq!(tree.num_accounts(), 1);
 
         // Validate the leaf for the inserted account exists.
-        assert!(tree.has_leaf_for_account(pair0.0));
+        assert!(tree.account_prefix_exists(pair0.0));
 
         // Validate the leaf for the uninserted account with same prefix exists.
-        assert!(tree.has_leaf_for_account(pair1.0));
+        assert!(tree.account_prefix_exists(pair1.0));
 
         // Validate the unrelated, uninserted account leaf does not exist.
         let id1 = AccountIdBuilder::new().build_with_seed([7; 32]);
-        assert!(!tree.has_leaf_for_account(id1));
+        assert!(!tree.account_prefix_exists(id1));
     }
 }

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -129,7 +129,7 @@ impl AccountTree {
     }
 
     /// Returns true if the tree contains a leaf for the given account ID prefix.
-    pub fn contains_account_prefix(&self, account_id_prefix: AccountIdPrefix) -> bool {
+    pub fn contains_account_id_prefix(&self, account_id_prefix: AccountIdPrefix) -> bool {
         let key = Self::id_prefix_to_smt_key(account_id_prefix);
         let is_empty = matches!(self.smt.get_leaf(&key), SmtLeaf::Empty(_));
         !is_empty
@@ -511,13 +511,13 @@ pub(super) mod tests {
         assert_eq!(tree.num_accounts(), 1);
 
         // Validate the leaf for the inserted account exists.
-        assert!(tree.contains_account_prefix(pair0.0.prefix()));
+        assert!(tree.contains_account_id_prefix(pair0.0.prefix()));
 
         // Validate the leaf for the uninserted account with same prefix exists.
-        assert!(tree.contains_account_prefix(pair1.0.prefix()));
+        assert!(tree.contains_account_id_prefix(pair1.0.prefix()));
 
         // Validate the unrelated, uninserted account leaf does not exist.
         let id1 = AccountIdBuilder::new().build_with_seed([7; 32]);
-        assert!(!tree.contains_account_prefix(id1.prefix()));
+        assert!(!tree.contains_account_id_prefix(id1.prefix()));
     }
 }

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -129,7 +129,7 @@ impl AccountTree {
     }
 
     /// Returns true if the tree contains a leaf for the given account ID prefix.
-    pub fn account_prefix_exists(&self, account_id: AccountId) -> bool {
+    pub fn has_account_prefix(&self, account_id: AccountId) -> bool {
         let key = Self::id_to_smt_key(account_id);
         let is_empty = matches!(self.smt.get_leaf(&key), SmtLeaf::Empty(_));
         !is_empty
@@ -494,20 +494,20 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn has_account_leaf() {
+    fn has_account_prefix() {
         // Create a tree with a single account.
         let [pair0, pair1] = setup_duplicate_prefix_ids();
         let tree = AccountTree::with_entries([(pair0.0, pair0.1)]).unwrap();
         assert_eq!(tree.num_accounts(), 1);
 
         // Validate the leaf for the inserted account exists.
-        assert!(tree.account_prefix_exists(pair0.0));
+        assert!(tree.has_account_prefix(pair0.0));
 
         // Validate the leaf for the uninserted account with same prefix exists.
-        assert!(tree.account_prefix_exists(pair1.0));
+        assert!(tree.has_account_prefix(pair1.0));
 
         // Validate the unrelated, uninserted account leaf does not exist.
         let id1 = AccountIdBuilder::new().build_with_seed([7; 32]);
-        assert!(!tree.account_prefix_exists(id1));
+        assert!(!tree.has_account_prefix(id1));
     }
 }

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -512,7 +512,7 @@ pub(super) mod tests {
         // Validate the account leaf with same prefix exists.
         assert!(tree.has_leaf_for_account(pair1.0));
 
-        // Validate the account leaf does not exist.
+        // Validate the unrelated, uninserted account leaf does not exist.
         let id1 = AccountIdBuilder::new().build_with_seed([7; 32]);
         assert!(!tree.has_leaf_for_account(id1));
     }

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -498,4 +498,22 @@ pub(super) mod tests {
             assert_eq!(witness.path(), &control_path);
         }
     }
+
+    #[test]
+    fn has_account_leaf() {
+        // Create a tree with a single account.
+        let [pair0, pair1] = setup_duplicate_prefix_ids();
+        let tree = AccountTree::with_entries([(pair0.0, pair0.1)]).unwrap();
+        assert_eq!(tree.num_accounts(), 1);
+
+        // Validate the account leaf exists.
+        assert!(tree.has_leaf_for_account(pair0.0));
+
+        // Validate the account leaf with same prefix exists.
+        assert!(tree.has_leaf_for_account(pair1.0));
+
+        // Validate the account leaf does not exist.
+        let id1 = AccountIdBuilder::new().build_with_seed([7; 32]);
+        assert!(!tree.has_leaf_for_account(id1));
+    }
 }

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -506,10 +506,10 @@ pub(super) mod tests {
         let tree = AccountTree::with_entries([(pair0.0, pair0.1)]).unwrap();
         assert_eq!(tree.num_accounts(), 1);
 
-        // Validate the account leaf exists.
+        // Validate the leaf for the inserted account exists.
         assert!(tree.has_leaf_for_account(pair0.0));
 
-        // Validate the account leaf with same prefix exists.
+        // Validate the leaf for the uninserted account with same prefix exists.
         assert!(tree.has_leaf_for_account(pair1.0));
 
         // Validate the unrelated, uninserted account leaf does not exist.

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -275,7 +275,7 @@ impl AccountTree {
     }
 
     /// Returns the SMT key of the given account ID prefix.
-    pub(super) fn id_prefix_to_smt_key(account_id: AccountIdPrefix) -> Word {
+    fn id_prefix_to_smt_key(account_id: AccountIdPrefix) -> Word {
         // We construct this in such a way that we're forced to use the constants, so that when
         // they're updated, the other usages of the constants are also updated.
         let mut key = Word::empty();


### PR DESCRIPTION
## Context

In https://github.com/0xMiden/miden-node/pull/1094 we need a way to check whether an account Id's prefix is present in the `AccountTree`.

## Changes
- Add `AccountTree::contains_account_id_prefix()` and  `AccountTree::id_prefix_to_smt_key()`.
- Add unit test showing duplicate prefixes cause collision.