### PR TITLE
feat: Pass `SignatureData` to `TransactionAuthenticator`; no more blind signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `account_compute_delta_commitment`, `input_note_get_assets_info`, `tx_get_num_input_notes`, and `tx_get_num_output_notes` procedures to the transaction kernel ([#1609](https://github.com/0xMiden/miden-base/pull/1609)).
 - Implemented new `from_unauthenticated_notes` constructor for `InputNotes` ([#1629](https://github.com/0xMiden/miden-base/pull/1629)).
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
+- Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 
 ### Changes
 

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -50,13 +50,13 @@ export.auth__tx_rpo_falcon512
 
     exec.create_tx_summary
     # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, pad(16)]
+    exec.adv_insert_hqword
 
     # the commitment to the tx summary is the message that is signed
     exec.hash_tx_summary
     # => [MESSAGE, pad(16)]
     push.COMMITMENTS_END_PTR movdn.4 push.SALT_PTR movdn.4
     # => [MESSAGE, salt_ptr, commitments_end_ptr]
-    adv.insert_mem
 
     # Fetch public key from storage.
     # ---------------------------------------------------------------------------------------------
@@ -84,6 +84,40 @@ export.auth__tx_rpo_falcon512
     # AS => []
 end
 
+#! Inputs:  [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
+#! Outputs: [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
+proc.adv_insert_hqword.16
+    loc_storew.0
+    movdnw.3
+    loc_storew.4
+    movdnw.3
+    loc_storew.8
+    movdnw.3
+    loc_storew.12
+    movdnw.3
+    # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
+
+    exec.hash_tx_summary
+    # => [MESSAGE]
+
+    locaddr.0
+    dup add.16
+    # => [mem_addr_end, mem_addr_start, MESSAGE]
+
+    movdn.5 movdn.4
+    # => [MESSAGE, mem_addr_start, mem_addr_end]
+
+    adv.insert_mem
+    drop drop
+    # => [<4 stack elements>]
+
+    loc_loadw.12
+    padw loc_loadw.8
+    padw loc_loadw.4
+    padw loc_loadw.0
+    # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
+end
+
 #! Creates the transaction summary and returns it in the order in which it will be hashed.
 #!
 #! Inputs:  [final_nonce]
@@ -98,15 +132,12 @@ end
 export.create_tx_summary
     exec.account::compute_delta_commitment
     # => [ACCOUNT_DELTA_COMMITMENT, final_nonce]
-    mem_storew.ACCOUNT_DELTA_COMMITMENT_PTR
 
     exec.tx::get_input_notes_commitment
     # => [INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
-    mem_storew.INPUT_NOTES_COMMITMENT_PTR
 
     exec.tx::get_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
-    mem_storew.OUTPUT_NOTES_COMMITMENT_PTR
 
     push.0.0 exec.tx::get_block_number
     # => [[ref_block_num, 0, 0], OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
@@ -114,7 +145,6 @@ export.create_tx_summary
     movup.15
     # => [[final_nonce, ref_block_num, 0, 0], OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
     # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
-    mem_storew.SALT_PTR
 end
 
 #! Hashes the provided transaction summary and returns its commitment.

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -12,12 +12,6 @@ const.AUTH_REQUEST=131087
 # The slot in this component's storage layout where the public key is stored.
 const.PUBLIC_KEY_SLOT=0
 
-const.SALT_PTR=0
-const.OUTPUT_NOTES_COMMITMENT_PTR=4
-const.INPUT_NOTES_COMMITMENT_PTR=8
-const.ACCOUNT_DELTA_COMMITMENT_PTR=12
-const.COMMITMENTS_END_PTR=16
-
 #! Authenticate a transaction using the Falcon signature scheme.
 #!
 #! It first increments the nonce of the account, independent of whether the account's state has
@@ -55,15 +49,13 @@ export.auth__tx_rpo_falcon512
     # the commitment to the tx summary is the message that is signed
     exec.hash_tx_summary
     # => [MESSAGE, pad(16)]
-    push.COMMITMENTS_END_PTR movdn.4 push.SALT_PTR movdn.4
-    # => [MESSAGE, salt_ptr, commitments_end_ptr]
 
     # Fetch public key from storage.
     # ---------------------------------------------------------------------------------------------
 
     # Get public key from account storage at pos 0 and verify signature
     push.PUBLIC_KEY_SLOT exec.account::get_item
-    # OS => [PUB_KEY, MESSAGE, salt_ptr, commitments_end_ptr, pad(16)]
+    # OS => [PUB_KEY, MESSAGE, pad(16)]
     # AS => []
 
     # Fetch signature from advice provider and verify.
@@ -72,15 +64,14 @@ export.auth__tx_rpo_falcon512
     # emit the authentication request event that pushes a signature for the message to the advice
     # stack
     emit.AUTH_REQUEST
-    # OS => [PUB_KEY, MESSAGE, salt_ptr, commitments_end_ptr, pad(16)]
+    # OS => [PUB_KEY, MESSAGE, pad(16)]
     # AS => [SIGNATURE]
 
     # Verify the signature against the public key and the message. The procedure gets as inputs the
     # hash of the public key and the message via the operand stack. The signature is provided via
     # the advice stack. The signature is valid if and only if the procedure returns.
     exec.rpo_falcon512::verify
-    # OS => [salt_ptr, commitments_end_ptr, pad(16)]
-    drop drop
+    # OS => [pad(16)]
     # AS => []
 end
 

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -55,7 +55,7 @@ export.auth__tx_rpo_falcon512
     exec.hash_tx_summary
     # => [MESSAGE, pad(16)]
     push.COMMITMENTS_END_PTR movdn.4 push.SALT_PTR movdn.4
-    # => [MESSAGE, SALT_PTR, COMMITMENTS_END_PTR]
+    # => [MESSAGE, salt_ptr, commitments_end_ptr]
     adv.insert_mem
 
     # Fetch public key from storage.

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -12,6 +12,12 @@ const.AUTH_REQUEST=131087
 # The slot in this component's storage layout where the public key is stored.
 const.PUBLIC_KEY_SLOT=0
 
+const.SALT_PTR=0
+const.OUTPUT_NOTES_COMMITMENT_PTR=4
+const.INPUT_NOTES_COMMITMENT_PTR=8
+const.ACCOUNT_DELTA_COMMITMENT_PTR=12
+const.COMMITMENTS_END_PTR=16
+
 #! Authenticate a transaction using the Falcon signature scheme.
 #!
 #! It first increments the nonce of the account, independent of whether the account's state has
@@ -48,13 +54,16 @@ export.auth__tx_rpo_falcon512
     # the commitment to the tx summary is the message that is signed
     exec.hash_tx_summary
     # => [MESSAGE, pad(16)]
+    push.COMMITMENTS_END_PTR movdn.4 push.SALT_PTR movdn.4
+    # => [MESSAGE, SALT_PTR, COMMITMENTS_END_PTR]
+    adv.insert_mem
 
     # Fetch public key from storage.
     # ---------------------------------------------------------------------------------------------
 
     # Get public key from account storage at pos 0 and verify signature
     push.PUBLIC_KEY_SLOT exec.account::get_item
-    # OS => [PUB_KEY, MESSAGE, pad(16)]
+    # OS => [PUB_KEY, MESSAGE, SALT_PTR, COMMITMENTS_END_PTR, pad(16)]
     # AS => []
 
     # Fetch signature from advice provider and verify.
@@ -70,7 +79,8 @@ export.auth__tx_rpo_falcon512
     # hash of the public key and the message via the operand stack. The signature is provided via
     # the advice stack. The signature is valid if and only if the procedure returns.
     exec.rpo_falcon512::verify
-    # OS => [pad(16)]
+    # OS => [SALT_PTR, COMMITMENTS_END_PTR, pad(16)]
+    drop drop
     # AS => []
 end
 
@@ -88,12 +98,15 @@ end
 export.create_tx_summary
     exec.account::compute_delta_commitment
     # => [ACCOUNT_DELTA_COMMITMENT, final_nonce]
+    mem_storew.ACCOUNT_DELTA_COMMITMENT_PTR
 
     exec.tx::get_input_notes_commitment
     # => [INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
+    mem_storew.INPUT_NOTES_COMMITMENT_PTR
 
     exec.tx::get_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
+    mem_storew.OUTPUT_NOTES_COMMITMENT_PTR
 
     push.0.0 exec.tx::get_block_number
     # => [[ref_block_num, 0, 0], OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, final_nonce]
@@ -101,6 +114,7 @@ export.create_tx_summary
     movup.15
     # => [[final_nonce, ref_block_num, 0, 0], OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
     # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
+    mem_storew.SALT_PTR
 end
 
 #! Hashes the provided transaction summary and returns its commitment.

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -63,7 +63,7 @@ export.auth__tx_rpo_falcon512
 
     # Get public key from account storage at pos 0 and verify signature
     push.PUBLIC_KEY_SLOT exec.account::get_item
-    # OS => [PUB_KEY, MESSAGE, SALT_PTR, COMMITMENTS_END_PTR, pad(16)]
+    # OS => [PUB_KEY, MESSAGE, salt_ptr, commitments_end_ptr, pad(16)]
     # AS => []
 
     # Fetch signature from advice provider and verify.
@@ -72,14 +72,14 @@ export.auth__tx_rpo_falcon512
     # emit the authentication request event that pushes a signature for the message to the advice
     # stack
     emit.AUTH_REQUEST
-    # OS => [PUB_KEY, MESSAGE, pad(16)]
+    # OS => [PUB_KEY, MESSAGE, salt_ptr, commitments_end_ptr, pad(16)]
     # AS => [SIGNATURE]
 
     # Verify the signature against the public key and the message. The procedure gets as inputs the
     # hash of the public key and the message via the operand stack. The signature is provided via
     # the advice stack. The signature is valid if and only if the procedure returns.
     exec.rpo_falcon512::verify
-    # OS => [SALT_PTR, COMMITMENTS_END_PTR, pad(16)]
+    # OS => [salt_ptr, commitments_end_ptr, pad(16)]
     drop drop
     # AS => []
 end

--- a/crates/miden-lib/src/errors/transaction_errors.rs
+++ b/crates/miden-lib/src/errors/transaction_errors.rs
@@ -27,8 +27,8 @@ pub enum TransactionKernelError {
     MissingAuthenticator,
     #[error("failed to generate signature")]
     SignatureGenerationFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
-    #[error("transaction summary commitments not found in advice provider")]
-    TransactionSummaryCommitmentsNotFound(#[source] Box<dyn Error + Send + Sync + 'static>),
+    #[error("transaction summary commitments malformed")]
+    TransactionSummaryError(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
     MalformedAssetInEventHandler {
         handler: &'static str,

--- a/crates/miden-lib/src/errors/transaction_errors.rs
+++ b/crates/miden-lib/src/errors/transaction_errors.rs
@@ -27,7 +27,7 @@ pub enum TransactionKernelError {
     MissingAuthenticator,
     #[error("failed to generate signature")]
     SignatureGenerationFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
-    #[error("transaction summary commitments malformed")]
+    #[error("failed to construct transaction summary")]
     TransactionSummaryError(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
     MalformedAssetInEventHandler {

--- a/crates/miden-lib/src/errors/transaction_errors.rs
+++ b/crates/miden-lib/src/errors/transaction_errors.rs
@@ -28,7 +28,7 @@ pub enum TransactionKernelError {
     #[error("failed to generate signature")]
     SignatureGenerationFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("failed to construct transaction summary")]
-    TransactionSummaryError(#[source] Box<dyn Error + Send + Sync + 'static>),
+    TransactionSummaryConstructionFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
     MalformedAssetInEventHandler {
         handler: &'static str,

--- a/crates/miden-lib/src/errors/transaction_errors.rs
+++ b/crates/miden-lib/src/errors/transaction_errors.rs
@@ -27,6 +27,8 @@ pub enum TransactionKernelError {
     MissingAuthenticator,
     #[error("failed to generate signature")]
     SignatureGenerationFailed(#[source] Box<dyn Error + Send + Sync + 'static>),
+    #[error("transaction summary commitments not found in advice provider")]
+    TransactionSummaryCommitmentsNotFound(#[source] Box<dyn Error + Send + Sync + 'static>),
     #[error("asset data extracted from the stack by event handler `{handler}` is not well formed")]
     MalformedAssetInEventHandler {
         handler: &'static str,

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -125,13 +125,12 @@ where
             // - commitments[4..8]:  OUTPUT_NOTES_COMMITMENT
             // - commitments[8..12]: INPUT_NOTES_COMMITMENT
             // - commitments[12..16]: ACCOUNT_DELTA_COMMITMENT
-            let commitments = process
-                .advice_provider()
-                .get_mapped_values(&msg)
-                .map_err(|err| TransactionKernelError::TransactionSummaryError(Box::new(err)))?;
+            let commitments = process.advice_provider().get_mapped_values(&msg).map_err(|err| {
+                TransactionKernelError::TransactionSummaryConstructionFailed(Box::new(err))
+            })?;
 
             if commitments.len() != 16 {
-                return Err(TransactionKernelError::TransactionSummaryError(
+                return Err(TransactionKernelError::TransactionSummaryConstructionFailed(
                     "Expected 4 words for transaction summary commitments".into(),
                 ));
             }
@@ -156,10 +155,12 @@ where
                 input_notes_commitment,
                 account_delta_commitment,
             )
-            .map_err(|err| TransactionKernelError::TransactionSummaryError(Box::new(err)))?;
+            .map_err(|err| {
+                TransactionKernelError::TransactionSummaryConstructionFailed(Box::new(err))
+            })?;
 
             if msg != tx_summary.to_commitment() {
-                return Err(TransactionKernelError::TransactionSummaryError(
+                return Err(TransactionKernelError::TransactionSummaryConstructionFailed(
                     "transaction summary doesn't commit to the expected message".into(),
                 ));
             }

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -127,10 +127,10 @@ where
                 ));
             }
 
-            let salt = extract_word(&commitments, 0);
-            let output_notes_commitment = extract_word(&commitments, 4);
-            let input_notes_commitment = extract_word(&commitments, 8);
-            let account_delta_commitment = extract_word(&commitments, 12);
+            let salt = extract_word(commitments, 0);
+            let output_notes_commitment = extract_word(commitments, 4);
+            let input_notes_commitment = extract_word(commitments, 8);
+            let account_delta_commitment = extract_word(commitments, 12);
             let tx_summary = build_tx_summary(
                 self.base_host(),
                 salt,

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -109,9 +109,9 @@ where
         process: &mut ProcessState,
     ) -> Result<(), TransactionKernelError> {
         let pub_key = process.get_stack_word(0);
-        let message = process.get_stack_word(1);
+        let msg = process.get_stack_word(1);
 
-        let signature_key = Hasher::merge(&[pub_key, message]);
+        let signature_key = Hasher::merge(&[pub_key, msg]);
 
         let signature = if let Ok(signature) =
             process.advice_provider().get_mapped_values(&signature_key)
@@ -129,7 +129,7 @@ where
             #[cfg(debug_assertions)]
             {
                 let tx_summary_commitment = tx_summary.to_commitment();
-                assert_eq!(message, tx_summary_commitment);
+                assert_eq!(msg, tx_summary_commitment);
             }
             let authenticator =
                 self.authenticator.ok_or(TransactionKernelError::MissingAuthenticator)?;

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -137,7 +137,11 @@ where
             let tx_summary = build_tx_summary(self.base_host(), salt)
                 .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;
 
-            debug_assert_eq!(msg, tx_summary.to_commitment());
+            debug_assert_eq!(
+                msg,
+                tx_summary.to_commitment(),
+                "transaction summary doesn't commit to the expected message"
+            );
 
             let authenticator =
                 self.authenticator.ok_or(TransactionKernelError::MissingAuthenticator)?;

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -135,19 +135,10 @@ where
                 ));
             }
 
-            let extract_word = |start: usize| -> Word {
-                Word::from([
-                    commitments[start],
-                    commitments[start + 1],
-                    commitments[start + 2],
-                    commitments[start + 3],
-                ])
-            };
-
-            let salt = extract_word(0);
-            let output_notes_commitment = extract_word(4);
-            let input_notes_commitment = extract_word(8);
-            let account_delta_commitment = extract_word(12);
+            let salt = extract_word(&commitments, 0);
+            let output_notes_commitment = extract_word(&commitments, 4);
+            let input_notes_commitment = extract_word(&commitments, 8);
+            let account_delta_commitment = extract_word(&commitments, 12);
             let tx_summary = build_tx_summary(
                 self.base_host(),
                 salt,
@@ -238,4 +229,17 @@ where
 
         Ok(())
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Extracts a word from a slice of field elements.
+fn extract_word(commitments: &[Felt], start: usize) -> Word {
+    Word::from([
+        commitments[start],
+        commitments[start + 1],
+        commitments[start + 2],
+        commitments[start + 3],
+    ])
 }

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -118,10 +118,15 @@ where
         {
             signature.to_vec()
         } else {
-            let salt = process
-                .get_mem_word(process.ctx(), 0)
-                .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?
-                .unwrap();
+            let commitments = process
+                .advice_provider()
+                .get_mapped_values(&msg)
+                .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;
+
+            let salt = Word::from(
+                &<[Felt; 4]>::try_from(&commitments[0..4])
+                    .expect("salt not found in advice providers"),
+            );
 
             let tx_summary = build_tx_summary(self.base_host(), salt)
                 .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -158,11 +158,11 @@ where
             )
             .map_err(|err| TransactionKernelError::TransactionSummaryError(Box::new(err)))?;
 
-            debug_assert_eq!(
-                msg,
-                tx_summary.to_commitment(),
-                "transaction summary doesn't commit to the expected message"
-            );
+            if msg != tx_summary.to_commitment() {
+                return Err(TransactionKernelError::TransactionSummaryError(
+                    "transaction summary doesn't commit to the expected message".into(),
+                ));
+            }
 
             let authenticator =
                 self.authenticator.ok_or(TransactionKernelError::MissingAuthenticator)?;

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -115,7 +115,7 @@ where
         let output_notes_commitment = process.get_stack_word(4);
         let salt = process.get_stack_word(5);
 
-        let tx_summary = build_tx_summary(self, salt)
+        let tx_summary = build_tx_summary(self.base_host(), salt)
             .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;
 
         // TODO only in debug mode?

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -126,11 +126,8 @@ where
             let tx_summary = build_tx_summary(self.base_host(), salt)
                 .map_err(|err| TransactionKernelError::SignatureGenerationFailed(Box::new(err)))?;
 
-            #[cfg(debug_assertions)]
-            {
-                let tx_summary_commitment = tx_summary.to_commitment();
-                assert_eq!(msg, tx_summary_commitment);
-            }
+            debug_assert_eq!(msg, tx_summary.to_commitment());
+
             let authenticator =
                 self.authenticator.ok_or(TransactionKernelError::MissingAuthenticator)?;
 

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -131,7 +131,7 @@ where
 
             if commitments.len() != 16 {
                 return Err(TransactionKernelError::TransactionSummaryConstructionFailed(
-                    "Expected 4 words for transaction summary commitments".into(),
+                    "expected 4 words for transaction summary commitments".into(),
                 ));
             }
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -536,7 +536,7 @@ fn map_execution_error<STORE: DataStore, AUTH: TransactionAuthenticator>(
 
 /// Builds a [`TransactionSummary`] by extracting the account delta and input/output notes from the
 /// host and validating them against the provided commitments.
-fn build_tx_summary<STORE: DataStore, AUTH: TransactionAuthenticator>(
+fn build_tx_summary<STORE: MastForestStore, AUTH: TransactionAuthenticator>(
     host: &TransactionExecutorHost<STORE, AUTH>,
     salt: Word,
 ) -> Result<TransactionSummary, TransactionExecutorError> {

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -539,7 +539,7 @@ fn map_execution_error<STORE: DataStore>(
 
 /// Builds a [`TransactionSummary`] by extracting the account delta and input/output notes from the
 /// host and validating them against the provided commitments.
-fn build_tx_summary<STORE: MastForestStore>(
+pub(crate) fn build_tx_summary<STORE: MastForestStore>(
     host: &TransactionBaseHost<STORE>,
     salt: Word,
 ) -> Result<TransactionSummary, TransactionExecutorError> {

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -18,7 +18,10 @@ pub use vm_processor::{ExecutionOptions, MastForestStore};
 use winter_maybe_async::{maybe_async, maybe_await};
 
 use super::TransactionExecutorError;
-use crate::{auth::TransactionAuthenticator, host::ScriptMastForestStore};
+use crate::{
+    auth::TransactionAuthenticator,
+    host::{ScriptMastForestStore, TransactionBaseHost},
+};
 
 mod exec_host;
 pub use exec_host::TransactionExecutorHost;
@@ -188,7 +191,7 @@ where
             self.exec_options,
             source_manager,
         )
-        .map_err(|err| map_execution_error(err, &host))?;
+        .map_err(|err| map_execution_error(err, &host.base_host()))?;
         let (stack_outputs, advice_provider) = trace.into_outputs();
 
         // The stack is not necessary since it is being reconstructed when re-executing.
@@ -496,9 +499,9 @@ fn validate_num_cycles(num_cycles: u32) -> Result<(), TransactionExecutorError> 
 ///   account delta and input/output notes.
 /// - Otherwise, the execution error is wrapped in
 ///   [`TransactionExecutorError::TransactionProgramExecutionFailed`].
-fn map_execution_error<STORE: DataStore, AUTH: TransactionAuthenticator>(
+fn map_execution_error<STORE: DataStore>(
     exec_err: ExecutionError,
-    host: &TransactionExecutorHost<STORE, AUTH>,
+    host: &TransactionBaseHost<STORE>,
 ) -> TransactionExecutorError {
     match exec_err {
         ExecutionError::EventError { ref error, .. } => {
@@ -536,13 +539,13 @@ fn map_execution_error<STORE: DataStore, AUTH: TransactionAuthenticator>(
 
 /// Builds a [`TransactionSummary`] by extracting the account delta and input/output notes from the
 /// host and validating them against the provided commitments.
-fn build_tx_summary<STORE: MastForestStore, AUTH: TransactionAuthenticator>(
-    host: &TransactionExecutorHost<STORE, AUTH>,
+fn build_tx_summary<STORE: MastForestStore>(
+    host: &TransactionBaseHost<STORE>,
     salt: Word,
 ) -> Result<TransactionSummary, TransactionExecutorError> {
-    let account_delta = host.base_host().build_account_delta();
-    let input_notes = host.base_host().input_notes();
-    let output_notes = host.base_host().build_output_notes();
+    let account_delta = host.build_account_delta();
+    let input_notes = host.input_notes();
+    let output_notes = host.build_output_notes();
     let output_notes = OutputNotes::new(output_notes)
         .map_err(TransactionExecutorError::TransactionOutputConstructionFailed)?;
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -536,7 +536,7 @@ fn map_execution_error<STORE: DataStore>(
 
 /// Builds a [`TransactionSummary`] by extracting the account delta and input/output notes from the
 /// host and validating them against the provided commitments.
-pub(crate) fn build_tx_summary<STORE: MastForestStore>(
+fn build_tx_summary<STORE: MastForestStore>(
     host: &TransactionBaseHost<STORE>,
     salt: Word,
     output_notes_commitment: Word,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -191,7 +191,7 @@ where
             self.exec_options,
             source_manager,
         )
-        .map_err(|err| map_execution_error(err, &host.base_host()))?;
+        .map_err(|err| map_execution_error(err, host.base_host()))?;
         let (stack_outputs, advice_provider) = trace.into_outputs();
 
         // The stack is not necessary since it is being reconstructed when re-executing.


### PR DESCRIPTION
builds on https://github.com/0xMiden/miden-base/pull/1615 and https://github.com/0xMiden/miden-base/pull/1616, and by extension https://github.com/0xMiden/miden-base/pull/1596.

requires some changes to `basic.masm` to work, but since we are changing the message to be signed as part of https://github.com/0xMiden/miden-base/issues/1534, I haven't touched that part yet. Basically, the emit event expects this to be the stack now:
```
# => [PUB_KEY, MESSAGE, ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, [0, 0, 0, new_nonce]]
emit.FALCON_SIG_TO_STACK
exec.rpo_falcon512::verify

dropw dropw dropw dropw
```

(the stack words can be rearranged for efficiency if needed)

blocked by #1534 