### PR TITLE
feat: auth procedure should only be called from epilogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added `AccountTree::contains_account_id_prefix()` and `AccountTree::id_prefix_to_smt_key()` ([#1610](https://github.com/0xMiden/miden-base/pull/1610)).
 - [BREAKING] Change `account::incr_nonce` to always increment the nonce by one and disallow incrementing more than once ([#1608](https://github.com/0xMiden/miden-base/pull/1608)).
 - Add robustness check to `create_swap_note`: error if `requested_asset` != `offered_asset` ([#1604](https://github.com/0xMiden/miden-base/pull/1604)).
+- [BREAKING] Disallow calling the auth procedure explicitly (from outside the epilogue) ([#1622](https://github.com/0xMiden/miden-base/pull/1622)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -732,7 +732,7 @@ export.assert_auth_procedure
     push.0
     # => [index, PROC_ROOT]
 
-    # track calls made from the auth procedure
+    # set was_called for the the auth procedure to true
     dup exec.set_was_procedure_called
     # => [index, PROC_ROOT]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -732,6 +732,10 @@ export.assert_auth_procedure
     push.0
     # => [index, PROC_ROOT]
 
+    # track calls made from the auth procedure
+    dup exec.set_was_procedure_called
+    # => [index, PROC_ROOT]
+
     # get procedure info (PROC_ROOT, storage_offset, storage_size) from memory stored at index
     exec.get_procedure_root
     # => [MEM_PROC_ROOT, PROC_ROOT]

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -184,7 +184,7 @@ proc.execute_auth_procedure
     # if auth procedure was called already, it must have been called by a user, which is disallowed
     exec.account::was_procedure_called
     # => [was_auth_called, auth_procedure_ptr, AUTH_ARGS, pad(12)]
-    eq.0 assert.err=ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT
+    assertz.err=ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT
 
     # execute the auth procedure
     dyncall

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -17,6 +17,8 @@ const.ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME="total number of as
 
 const.ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY="executed transaction neither changed the account state, nor consumed any notes"
 
+const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been called from outside the epilogue"
+
 # OUTPUT NOTES PROCEDURES
 # =================================================================================================
 
@@ -175,6 +177,14 @@ proc.execute_auth_procedure
     # auth procedure is at index 0 within the account procedures section.
     push.0 exec.memory::get_acct_procedure_ptr
     # => [auth_procedure_ptr, AUTH_ARGS, pad(12)]
+
+    padw dup.4 mem_loadw
+    # => [AUTH_PROC_ROOT, auth_procedure_ptr, AUTH_ARGS, pad(12)]
+
+    # if auth procedure was called already, it must have been called by a user, which is disallowed
+    exec.account::was_procedure_called
+    # => [was_auth_called, auth_procedure_ptr, AUTH_ARGS, pad(12)]
+    eq.0 assert.err=ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT
 
     # execute the auth procedure
     dyncall

--- a/crates/miden-lib/src/errors/note_script_errors.rs
+++ b/crates/miden-lib/src/errors/note_script_errors.rs
@@ -10,6 +10,9 @@ use crate::errors::MasmError;
 // NOTE SCRIPT ERRORS
 // ================================================================================================
 
+/// Error Message: "auth procedure had been called from outside the epilogue"
+pub const ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT: MasmError = MasmError::from_static_str("auth procedure had been called from outside the epilogue");
+
 /// Error Message: "failed to reclaim P2IDE note because the reclaiming account is not the sender"
 pub const ERR_P2IDE_RECLAIM_ACCT_IS_NOT_SENDER: MasmError = MasmError::from_static_str("failed to reclaim P2IDE note because the reclaiming account is not the sender");
 /// Error Message: "P2IDE reclaim is disabled"

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -16,7 +16,7 @@ pub const KERNEL0_PROCEDURES: [Word; 41] = [
     // account_get_nonce
     word!("0xb19ece9509e73580a93f6516ddbc62c87e70cee6e97eea4af8c46dcee5b42384"),
     // account_incr_nonce
-    word!("0x30c2c631c063e9c821ca929aa892f78ceb68a20358a35bac2865df544fe778ee"),
+    word!("0xafb13b2a0b8e8c3fd7ce33917adba49d113a268a676f3c95e05816af69cf7d7a"),
     // account_get_code_commitment
     word!("0x3dd7c93691699c00d70ee2687f568e38869d81402b1dba25f2d6c2b463b91f77"),
     // account_get_storage_commitment

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -166,7 +166,13 @@ impl From<NoopAuthComponent> for AccountComponent {
     }
 }
 
-/// TODO: Add documentation once #1501 is ready.
+/// Creates a mock authentication [`AccountComponent`] for testing purposes.
+///
+/// The component defines an `auth__conditional` procedure that conditionally suceeds and
+/// conditionally increments the nonce based on the authentication arguments.
+///
+/// The auth procedure expects the first three arguments as [99, 98, 97] to succeed.
+/// In case it succeeds, it conditionally increments the nonce based on the fourth argument.
 pub struct ConditionalAuthComponent {
     pub library: Library,
 }

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -76,7 +76,7 @@ impl From<AccountMockComponent> for AccountComponent {
 ///
 /// The component defines an `auth__basic` procedure that always increments the nonce by 1.
 pub struct IncrNonceAuthComponent {
-    library: Library,
+    pub library: Library,
 }
 
 impl IncrNonceAuthComponent {
@@ -146,7 +146,7 @@ static CONDITIONAL_AUTH_CODE: LazyLock<String> = LazyLock::new(|| {
 ///
 /// The component defines an `auth__noop` procedure that does nothing (always succeeds).
 pub struct NoopAuthComponent {
-    library: Library,
+    pub library: Library,
 }
 
 impl NoopAuthComponent {
@@ -168,7 +168,7 @@ impl From<NoopAuthComponent> for AccountComponent {
 
 /// TODO: Add documentation once #1501 is ready.
 pub struct ConditionalAuthComponent {
-    library: Library,
+    pub library: Library,
 }
 
 impl ConditionalAuthComponent {

--- a/crates/miden-objects/src/testing/account_component.rs
+++ b/crates/miden-objects/src/testing/account_component.rs
@@ -168,7 +168,7 @@ impl From<NoopAuthComponent> for AccountComponent {
 
 /// Creates a mock authentication [`AccountComponent`] for testing purposes.
 ///
-/// The component defines an `auth__conditional` procedure that conditionally suceeds and
+/// The component defines an `auth__conditional` procedure that conditionally succeeds and
 /// conditionally increments the nonce based on the authentication arguments.
 ///
 /// The auth procedure expects the first three arguments as [99, 98, 97] to succeed.

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use miden_lib::{errors::MasmError, transaction::TransactionKernel};
+use miden_lib::{account::wallets::BasicWallet, errors::MasmError, transaction::TransactionKernel};
 use miden_objects::{
     account::Account,
     testing::{
@@ -13,6 +13,9 @@ use super::{Felt, ONE};
 use crate::{TransactionContextBuilder, assert_execution_error};
 
 pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);
+
+// Import the new error constant
+use miden_lib::errors::note_script_errors::ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT;
 
 /// Tests that authentication arguments are correctly passed to the auth procedure.
 ///

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -1,7 +1,11 @@
 use anyhow::Context;
-use miden_lib::{account::wallets::BasicWallet, errors::MasmError, transaction::TransactionKernel};
+use miden_lib::{
+    account::wallets::BasicWallet,
+    errors::{MasmError, note_script_errors::ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT},
+    transaction::TransactionKernel,
+};
 use miden_objects::{
-    account::Account,
+    account::{Account, AccountBuilder},
     testing::{
         account_component::{ConditionalAuthComponent, ERR_WRONG_ARGS_MSG},
         account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
@@ -10,12 +14,9 @@ use miden_objects::{
 use miden_tx::TransactionExecutorError;
 
 use super::{Felt, ONE};
-use crate::{TransactionContextBuilder, assert_execution_error};
+use crate::{Auth, TransactionContextBuilder, assert_execution_error};
 
 pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);
-
-// Import the new error constant
-use miden_lib::errors::note_script_errors::ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT;
 
 /// Tests that authentication arguments are correctly passed to the auth procedure.
 ///
@@ -87,10 +88,6 @@ fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
 /// Tests that attempting to call the auth procedure manually from user code fails.
 #[test]
 fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
-    use miden_objects::account::AccountBuilder;
-
-    use crate::Auth;
-
     let (auth_component, _) = Auth::IncrNonce.build_component();
 
     let account = AccountBuilder::new([42; 32])


### PR DESCRIPTION
closes #1503

Uses the tracked procedures to figure out if, right before invoking the auth procedure of the account, the auth procedure has already been called or not.

It also fixes the lack of tracking for the auth procedure, similar to how "normal" account procedures are tracked in `authenticate_and_track_procedure`.