### PR TITLE
chore: update miden-vm version in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ miden-tx              = { default-features = false, path = "crates/miden-tx", ve
 miden-tx-batch-prover = { default-features = false, path = "crates/miden-tx-batch-prover", version = "0.11" }
 
 # Miden dependencies
-assembly         = { default-features = false, package = "miden-assembly", version = "0.16.1" }
+assembly         = { default-features = false, package = "miden-assembly", version = "0.16.3" }
 miden-crypto     = { default-features = false, version = "0.15.5" }
-miden-prover     = { default-features = false, version = "0.16.1" }
-miden-stdlib     = { default-features = false, version = "0.16.1" }
-miden-utils-sync = { default-features = false, version = "0.16.1" }
-miden-verifier   = { default-features = false, version = "0.16.1" }
-vm-core          = { default-features = false, package = "miden-core", version = "0.16.1" }
-vm-processor     = { default-features = false, package = "miden-processor", version = "0.16.1" }
+miden-prover     = { default-features = false, version = "0.16.3" }
+miden-stdlib     = { default-features = false, version = "0.16.3" }
+miden-utils-sync = { default-features = false, version = "0.16.3" }
+miden-verifier   = { default-features = false, version = "0.16.3" }
+vm-core          = { default-features = false, package = "miden-core", version = "0.16.3" }
+vm-processor     = { default-features = false, package = "miden-processor", version = "0.16.3" }
 
 # External dependencies
 assert_matches = { default-features = false, version = "1.5" }


### PR DESCRIPTION
part of https://github.com/0xMiden/miden-node/pull/1093

The update was already introduced in the `Cargo.lock`.