### PR TITLE
chore: rename `TransactionEvent::FalconSigToStack` to `TransactionEvent::AuthRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add robustness check to `create_swap_note`: error if `requested_asset` != `offered_asset` ([#1604](https://github.com/0xMiden/miden-base/pull/1604)).
 - Add `TransactionEvent::Unauthorized` to enable aborting the transaction execution to get its transaction summary for signing purposes ([#1596](https://github.com/0xMiden/miden-base/pull/1596)).
 - [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037))
+- [BREAKING] Rename `TransactionEvent::FalconSigToStack` to `TransactionEvent::AuthRequest` ([#1626](https://github.com/0xMiden/miden-base/pull/1626)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -5,8 +5,8 @@ use.std::crypto::dsa::rpo_falcon512
 # CONSTANTS
 # =================================================================================================
 
-# Event to place the falcon signature of a provided message and public key on the advice stack.
-const.FALCON_SIG_TO_STACK=131087
+# The event to request an authentication signature.
+const.AUTH_REQUEST=131087
 
 # The slot in this component's storage layout where the public key is stored.
 const.PUBLIC_KEY_SLOT=0
@@ -51,7 +51,7 @@ export.auth__tx_rpo_falcon512
     # Verify the signature against the public key and the message. The procedure gets as inputs the
     # hash of the public key and the hash of the message via the operand stack. The signature is
     # provided via the advice stack. The signature is valid if and only if the procedure returns.
-    emit.FALCON_SIG_TO_STACK
+    emit.AUTH_REQUEST
     exec.rpo_falcon512::verify
     # => [pad(16)]
 end

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -31,7 +31,7 @@ const NOTE_AFTER_CREATED: u32 = 0x2_000c; // 131084
 const NOTE_BEFORE_ADD_ASSET: u32 = 0x2_000d; // 131085
 const NOTE_AFTER_ADD_ASSET: u32 = 0x2_000e; // 131086
 
-const FALCON_SIG_TO_STACK: u32 = 0x2_000f; // 131087
+const AUTH_REQUEST: u32 = 0x2_000f; // 131087
 
 const PROLOGUE_START: u32 = 0x2_0010; // 131088
 const PROLOGUE_END: u32 = 0x2_0011; // 131089
@@ -86,7 +86,7 @@ pub enum TransactionEvent {
     NoteBeforeAddAsset = NOTE_BEFORE_ADD_ASSET,
     NoteAfterAddAsset = NOTE_AFTER_ADD_ASSET,
 
-    FalconSigToStack = FALCON_SIG_TO_STACK,
+    AuthRequest = AUTH_REQUEST,
 
     PrologueStart = PROLOGUE_START,
     PrologueEnd = PROLOGUE_END,
@@ -165,7 +165,7 @@ impl TryFrom<u32> for TransactionEvent {
             NOTE_BEFORE_ADD_ASSET => Ok(TransactionEvent::NoteBeforeAddAsset),
             NOTE_AFTER_ADD_ASSET => Ok(TransactionEvent::NoteAfterAddAsset),
 
-            FALCON_SIG_TO_STACK => Ok(TransactionEvent::FalconSigToStack),
+            AUTH_REQUEST => Ok(TransactionEvent::AuthRequest),
 
             PROLOGUE_START => Ok(TransactionEvent::PrologueStart),
             PROLOGUE_END => Ok(TransactionEvent::PrologueEnd),

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -116,7 +116,7 @@ impl TransactionEvent {
     /// Returns `true` if the event is privileged, i.e. it is only allowed to be emitted from the
     /// root context of the VM, which is where the transaction kernel executes.
     pub fn is_privileged(&self) -> bool {
-        let is_unprivileged = matches!(self, Self::FalconSigToStack | Self::Unauthorized);
+        let is_unprivileged = matches!(self, Self::AuthRequest | Self::Unauthorized);
         !is_unprivileged
     }
 }

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -97,7 +97,7 @@ where
     // ADVICE INJECTOR HANDLERS
     // --------------------------------------------------------------------------------------------
 
-    /// Pushes a signature to the advice stack as a response to the `FalconSigToStack` injector.
+    /// Pushes a signature to the advice stack as a response to the `AuthRequest` event.
     ///
     /// The signature is fetched from the advice map or otherwise requested from the host's
     /// authenticator.

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -175,7 +175,7 @@ where
         match transaction_event {
             // Override the base host's on signature requested implementation, which would not call
             // the authenticator.
-            TransactionEvent::FalconSigToStack => {
+            TransactionEvent::AuthRequest => {
                 self.on_signature_requested(process)
                     .map_err(|err| ExecutionError::event_error(Box::new(err), err_ctx))?;
             },

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -298,7 +298,7 @@ where
         Ok(())
     }
 
-    /// Pushes a signature to the advice stack as a response to the `FalconSigToStack` injector.
+    /// Pushes a signature to the advice stack as a response to the `AuthRequest` event.
     ///
     /// The signature is fetched from the advice map and if it is not present, an error is returned.
     pub fn on_signature_requested(

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -231,7 +231,7 @@ where
             TransactionEvent::NoteBeforeAddAsset => self.on_note_before_add_asset(process),
             TransactionEvent::NoteAfterAddAsset => Ok(()),
 
-            TransactionEvent::FalconSigToStack => self.on_signature_requested(process),
+            TransactionEvent::AuthRequest => self.on_signature_requested(process),
 
             TransactionEvent::PrologueStart => {
                 self.tx_progress.start_prologue(process.clk());


### PR DESCRIPTION
Rename `TransactionEvent::FalconSigToStack` to `TransactionEvent::AuthRequest`.

Note: I went with `AuthRequest` instead of `AuthRequested` since most event names use present tense (but it's not consistent, so up for discussion).

I'll do the arbitrary signature event in another PR since it should probably build on top of https://github.com/0xMiden/miden-base/pull/1616.

part of https://github.com/0xMiden/miden-base/issues/1593