### PR TITLE
Implement `ToInputNoteCommitments` trait for Note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added arguments to the auth procedure ([#1501](https://github.com/0xMiden/miden-base/pull/1501)).
 - [BREAKING] Refactored `SWAP` note & added option to select the visibility of the associated payback note ([#1539](https://github.com/0xMiden/miden-base/pull/1539)).
 - Added `account_compute_delta_commitment`, `input_note_get_assets_info`, `tx_get_num_input_notes`, and `tx_get_num_output_notes` procedures to the transaction kernel ([#1609](https://github.com/0xMiden/miden-base/pull/1609)).
+- Implemented `ToInputNoteCommitments` trait for the `Note` structure ().
 
 
 ### Changes

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -4,7 +4,10 @@ use miden_crypto::{
 };
 use vm_processor::DeserializationError;
 
-use crate::{Felt, Hasher, NoteError, WORD_SIZE, ZERO, account::AccountId};
+use crate::{
+    Felt, Hasher, NoteError, WORD_SIZE, ZERO, account::AccountId,
+    transaction::ToInputNoteCommitments,
+};
 
 mod assets;
 pub use assets::NoteAssets;
@@ -170,6 +173,29 @@ impl Note {
 impl AsRef<NoteRecipient> for Note {
     fn as_ref(&self) -> &NoteRecipient {
         self.recipient()
+    }
+}
+
+// TO INPUT NOTE COMMITMENTS
+// ================================================================================================
+
+impl ToInputNoteCommitments for Note {
+    fn nullifier(&self) -> Nullifier {
+        self.nullifier()
+    }
+
+    fn note_commitment(&self) -> Option<Word> {
+        Some(self.commitment())
+    }
+}
+
+impl ToInputNoteCommitments for &Note {
+    fn nullifier(&self) -> Nullifier {
+        (*self).nullifier()
+    }
+
+    fn note_commitment(&self) -> Option<Word> {
+        Some((*self).commitment())
     }
 }
 


### PR DESCRIPTION
This tiny PR implements the `ToInputNoteCommitments` trait for the `Note` struct. 

This will make it much more convenient to create an `InputNotes` struct using not only `Vec<InputNote>`, but also `Vec<Note>`, which was the case in the `miden-node`.

Closes: #1565.