### PR TITLE
Make transaction script arguments name consistent 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,14 @@
 - Replaced `MerklePath` with `SparseMerklePath` in `NoteInclusionProof` ([#1572](https://github.com/0xMiden/miden-base/pull/1572)) .
 - [BREAKING] Split `TransactionHost` into `TransactionProverHost` and `TransactionExecutorHost` ([#1581](https://github.com/0xMiden/miden-base/pull/1581)).
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
-- [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575))
+- [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575)).
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
 - Added `AccountTree::contains_account_id_prefix()` and `AccountTree::id_prefix_to_smt_key()` ([#1610](https://github.com/0xMiden/miden-base/pull/1610)).
 - [BREAKING] Change `account::incr_nonce` to always increment the nonce by one and disallow incrementing more than once ([#1608](https://github.com/0xMiden/miden-base/pull/1608)).
 - Add robustness check to `create_swap_note`: error if `requested_asset` != `offered_asset` ([#1604](https://github.com/0xMiden/miden-base/pull/1604)).
 - Add `TransactionEvent::Unauthorized` to enable aborting the transaction execution to get its transaction summary for signing purposes ([#1596](https://github.com/0xMiden/miden-base/pull/1596)).
-- [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037))
-- [BREAKING] Make the naming of the transaction script arguments consistent ([]()).
+- [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037)).
+- [BREAKING] Make the naming of the transaction script arguments consistent ([#1632](https://github.com/0xMiden/miden-base/pull/1632)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add robustness check to `create_swap_note`: error if `requested_asset` != `offered_asset` ([#1604](https://github.com/0xMiden/miden-base/pull/1604)).
 - Add `TransactionEvent::Unauthorized` to enable aborting the transaction execution to get its transaction summary for signing purposes ([#1596](https://github.com/0xMiden/miden-base/pull/1596)).
 - [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037))
+- [BREAKING] Make the naming of the transaction script arguments consistent ([]()).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -78,8 +78,8 @@ const.INIT_NONCE_PTR=416
 # The memory address at which the transaction script mast root is stored.
 const.TX_SCRIPT_ROOT_PTR=420
 
-# The memory address at which the key of the transaction script arguments is stored.
-const.TX_SCRIPT_ARGS_KEY_PTR=424
+# The memory address at which the transaction script arguments are stored.
+const.TX_SCRIPT_ARGS_PTR=424
 
 # The memory address at which the auth procedure arguments are stored.
 const.AUTH_ARGS_PTR=428
@@ -510,28 +510,28 @@ export.set_tx_script_root
     mem_storew.TX_SCRIPT_ROOT_PTR
 end
 
-#! Returns the transaction script arguments key.
+#! Returns the transaction script arguments.
 #!
 #! Inputs:  []
-#! Outputs: [TX_SCRIPT_ARGS_KEY]
+#! Outputs: [TX_SCRIPT_ARGS]
 #!
 #! Where:
-#! - TX_SCRIPT_ARGS_KEY is the key which could be used to obtain the transaction script arguments 
-#!   from the advice map.
-export.get_tx_script_args_key
-    padw mem_loadw.TX_SCRIPT_ARGS_KEY_PTR
+#! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain 
+#!   some values associated with it from the advice map.
+export.get_tx_script_args
+    padw mem_loadw.TX_SCRIPT_ARGS_PTR
 end
 
-#! Sets the transaction script arguments key.
+#! Sets the transaction script arguments.
 #!
-#! Inputs:  [TX_SCRIPT_ARGS_KEY]
-#! Outputs: [TX_SCRIPT_ARGS_KEY]
+#! Inputs:  [TX_SCRIPT_ARGS]
+#! Outputs: [TX_SCRIPT_ARGS]
 #!
 #! Where:
-#! - TX_SCRIPT_ARGS_KEY is the key which could be used to obtain the transaction script arguments 
-#!   from the advice map.
-export.set_tx_script_args_key
-    mem_storew.TX_SCRIPT_ARGS_KEY_PTR
+#! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain 
+#!   some values associated with it from the advice map.
+export.set_tx_script_args
+    mem_storew.TX_SCRIPT_ARGS_PTR
 end
 
 #! Returns the auth procedure arguments.

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1094,15 +1094,15 @@ end
 #!
 #! Inputs:
 #!   Operand stack: []
-#!   Advice stack: [TX_SCRIPT_ROOT, TX_SCRIPT_ARGS_KEY]
+#!   Advice stack: [TX_SCRIPT_ROOT, TX_SCRIPT_ARGS]
 #! Outputs:
 #!   Operand stack: []
 #!   Advice stack: []
 #!
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction's script root.
-#! - TX_SCRIPT_ARGS_KEY is the commitment of the transaction script args used to obtain them from
-#!   the advice map.
+#! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain 
+#!   some values associated with it from the advice map.
 proc.process_tx_script_data
     # read the transaction script root from the advice stack
     padw adv_loadw
@@ -1112,12 +1112,12 @@ proc.process_tx_script_data
     exec.memory::set_tx_script_root
     # => [TX_SCRIPT_ROOT]
 
-    # read the transaction script args key from the advice stack (overwrites TX_SCRIPT_ROOT)
+    # read the transaction script args from the advice stack (overwrites TX_SCRIPT_ROOT)
     adv_loadw
-    # => [TX_SCRIPT_ARGS_KEY]
+    # => [TX_SCRIPT_ARGS]
 
-    # store the transaction script args key in memory
-    exec.memory::set_tx_script_args_key dropw
+    # store the transaction script args in memory
+    exec.memory::set_tx_script_args dropw
     # => []
 end
 
@@ -1177,7 +1177,7 @@ end
 #!     ACCOUNT_CODE_COMMITMENT,
 #!     number_of_input_notes,
 #!     TX_SCRIPT_ROOT,
-#!     TX_SCRIPT_ARGS_KEY,
+#!     TX_SCRIPT_ARGS,
 #!     AUTH_ARGS,
 #!   ]
 #!   Advice map: {
@@ -1221,6 +1221,7 @@ end
 #! - ACCOUNT_STORAGE_SLOT_DATA is the vector of the account's storage slot data.
 #! - number_of_input_notes is the number of input notes.
 #! - TX_SCRIPT_ROOT is the transaction's script root.
+#! - TX_SCRIPT_ARGS are the arguments provided to the stack, see prologue::process_tx_script_data.
 #! - MMR_PEAKS is the MMR peak data, see process_chain_data.
 #! - NOTE_DATA is the input notes' details, for format see prologue::process_input_note.
 #!

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -136,8 +136,8 @@ proc.main.1
 
     if.true
         # load the transaction script arguments onto the stack
-        exec.memory::get_tx_script_args_key movup.4
-        # => [tx_script_root_ptr, TX_SCRIPT_ARGS_KEY]
+        exec.memory::get_tx_script_args movup.4
+        # => [tx_script_root_ptr, TX_SCRIPT_ARGS]
 
         # execute the transaction script
         dyncall

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -103,7 +103,7 @@ impl TransactionAdviceInputs {
     ///     ACCOUNT_CODE_COMMITMENT,
     ///     number_of_input_notes,
     ///     TX_SCRIPT_ROOT,
-    ///     TX_SCRIPT_ARGS_KEY,
+    ///     TX_SCRIPT_ARGS,
     ///     AUTH_ARGS,
     /// ]
     fn build_stack(
@@ -145,12 +145,12 @@ impl TransactionAdviceInputs {
         self.extend_stack(account.storage().commitment());
         self.extend_stack(account.code().commitment());
 
-        // --- number of notes, script root and args key ----------------------
+        // --- number of notes, script root and args --------------------------
         self.extend_stack([Felt::from(tx_inputs.input_notes().num_notes())]);
         self.extend_stack(tx_args.tx_script().map_or(Word::empty(), |script| script.root()));
         self.extend_stack(tx_args.tx_script_args());
 
-        // --- auth procedure args -------------------------------------------
+        // --- auth procedure args --------------------------------------------
         self.extend_stack(tx_args.auth_args());
     }
 

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -132,8 +132,8 @@ pub const INIT_NONCE_PTR: MemoryAddress = 416;
 /// The memory address at which the transaction script mast root is store
 pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 420;
 
-/// The memory address at which the key of the transaction script arguments is stored.
-pub const TX_SCRIPT_ARGS_KEY: MemoryAddress = 424;
+/// The memory address at which the transaction script arguments are stored.
+pub const TX_SCRIPT_ARGS: MemoryAddress = 424;
 
 /// The memory address at which the key of the auth procedure arguments is stored.
 pub const AUTH_ARGS_PTR: MemoryAddress = 428;

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -22,10 +22,10 @@ use crate::{
 ///
 /// - Transaction script: a program that is executed in a transaction after all input notes scripts
 ///   have been executed.
-/// - Transaction script argument: a [`Word`], which will be pushed to the operand stack before the
-///   transaction script execution. If this argument is not specified, the [`EMPTY_WORD`] would be
-///   used as a default value. If the [AdviceInputs] are propagated with some user defined map
-///   entries, this script argument could be used as a key to access the corresponding value.
+/// - Transaction script arguments: a [`Word`], which will be pushed to the operand stack before the
+///   transaction script execution. If these arguments are not specified, the [`EMPTY_WORD`] would
+///   be used as a default value. If the [AdviceInputs] are propagated with some user defined map
+///   entries, this script arguments word could be used as a key to access the corresponding value.
 /// - Note arguments: data put onto the stack right before a note script is executed. These are
 ///   different from note inputs, as the user executing the transaction can specify arbitrary note
 ///   args.
@@ -74,12 +74,12 @@ impl TransactionArgs {
     }
 
     /// Returns new [TransactionArgs] instantiated with the provided transaction script and its
-    /// argument.
+    /// arguments.
     ///
-    /// If the transaction script and argument are already set, they will be overwritten with the
+    /// If the transaction script and arguments are already set, they will be overwritten with the
     /// newly provided ones.
     #[must_use]
-    pub fn with_tx_script_and_arg(
+    pub fn with_tx_script_and_args(
         mut self,
         tx_script: TransactionScript,
         tx_script_args: Word,
@@ -114,10 +114,10 @@ impl TransactionArgs {
         self.tx_script.as_ref()
     }
 
-    /// Returns the transaction script argument, or [`EMPTY_WORD`] if the argument was not
+    /// Returns the transaction script arguments, or [`EMPTY_WORD`] if the arguments were not
     /// specified.
     ///
-    /// This argument could be potentially used as a key to access the advice map during the
+    /// These arguments could be potentially used as a key to access the advice map during the
     /// transaction script execution. Notice that the corresponding map entry should be provided
     /// separately during the creation with the [`TransactionArgs::new`] or using the
     /// [`TransactionArgs::extend_advice_map`] method.

--- a/crates/miden-objects/src/transaction/tx_witness.rs
+++ b/crates/miden-objects/src/transaction/tx_witness.rs
@@ -14,7 +14,7 @@ use crate::utils::serde::{ByteReader, Deserializable, DeserializationError, Seri
 /// - Transaction inputs which contain information about the initial state of the account, input
 ///   notes, block header etc.
 /// - Optional transaction arguments which may contain a transaction script, note arguments,
-///   transaction script argument and any additional advice data to initialize the advice provider
+///   transaction script arguments and any additional advice data to initialize the advice provider
 ///   with prior to transaction execution.
 /// - Advice witness which contains all data requested by the VM from the advice provider while
 ///   executing the transaction program.

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1384,18 +1384,18 @@ fn test_tx_script_args() -> anyhow::Result<()> {
         use.miden::account
 
         begin
-            # => [TX_SCRIPT_ARG]
-            # `TX_SCRIPT_ARG` value is a user provided word, which could be used during the
+            # => [TX_SCRIPT_ARGS]
+            # `TX_SCRIPT_ARGS` value is a user provided word, which could be used during the
             # transaction execution. In this example it is a `[1, 2, 3, 4]` word.
 
             # assert the correctness of the argument
-            dupw push.1.2.3.4 assert_eqw.err="provided transaction argument doesn't match the expected one"
-            # => [TX_SCRIPT_ARG]
+            dupw push.1.2.3.4 assert_eqw.err="provided transaction arguments don't match the expected ones"
+            # => [TX_SCRIPT_ARGS]
 
-            # since we provided an advice map entry with the transaction script argument as a key,
+            # since we provided an advice map entry with the transaction script arguments as a key,
             # we can obtain the value of this entry
             adv.push_mapval adv_push.4
-            # => [[map_entry_values], TX_SCRIPT_ARG]
+            # => [[map_entry_values], TX_SCRIPT_ARGS]
 
             # assert the correctness of the map entry values
             push.5.6.7.8 assert_eqw.err="obtained advice map value doesn't match the expected one"

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -225,7 +225,7 @@ impl TransactionContextBuilder {
         self
     }
 
-    /// Set the transaction script argument
+    /// Set the transaction script arguments
     pub fn tx_script_args(mut self, tx_script_args: Word) -> Self {
         self.tx_script_args = tx_script_args;
         self
@@ -300,7 +300,7 @@ impl TransactionContextBuilder {
             .with_note_args(self.note_args);
 
         let mut tx_args = if let Some(tx_script) = self.tx_script {
-            tx_args.with_tx_script_and_arg(tx_script, self.tx_script_args)
+            tx_args.with_tx_script_and_args(tx_script, self.tx_script_args)
         } else {
             tx_args
         };


### PR DESCRIPTION
This small PR renames different "versions" of the transaction script arguments name used across the repo. 

The only version we want to use is `tx_script_args`/`TX_SCRIPT_ARGS`. Comments were also updated to use the full `transaction script arguments` version.

Closes: #1578.