### PR TITLE
feat: extract `TransactionSummary` in stack order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [BREAKING] Split `TransactionHost` into `TransactionProverHost` and `TransactionExecutorHost` ([#1581](https://github.com/0xMiden/miden-base/pull/1581)).
 - [BREAKING] Remove pending account APIs on `MockChain` and introduce `MockChainBuilder` to simplify mock chain creation ([#1557](https://github.com/0xMiden/miden-base/pull/1557)).
 - [BREAKING] Renamed authentication components to include "auth" prefix for clarity ([#1575](https://github.com/0xMiden/miden-base/issues/1575)).
-- Add `TransactionEvent::Unauthorized` to enable aborting the transaction execution to get its transaction summary for signing purposes ([#1596](https://github.com/0xMiden/miden-base/pull/1596)).
+- Add `TransactionEvent::Unauthorized` to enable aborting the transaction execution to get its transaction summary for signing purposes ([#1596](https://github.com/0xMiden/miden-base/pull/1596), [#1634](https://github.com/0xMiden/miden-base/pull/1634)).
 - [BREAKING] Include account delta commitment in signing message for the `RpoFalcon512` family of account components ([#1624](https://github.com/0xMiden/miden-base/pull/1624)).
 - [BREAKING] Implemented `SequentialCommit` for `AccountDelta` and renamed `AccountDelta::commitment()` to `AccountDelta::to_commitment()` ([#1603](https://github.com/0xMiden/miden-base/pull/1603)).
 - Add robustness check to `create_swap_note`: error if `requested_asset` != `offered_asset` ([#1604](https://github.com/0xMiden/miden-base/pull/1604)).

--- a/crates/miden-lib/asm/miden/contracts/auth/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/auth/basic.masm
@@ -78,7 +78,14 @@ end
 #!
 #! Inputs:  [final_nonce]
 #! Outputs: [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
-proc.create_tx_summary
+#!
+#! Where:
+#! - SALT is used for replay protection and contains the final nonce of the account and the
+#!   block number of the transaction's reference block.
+#! - OUTPUT_NOTES_COMMITMENT is the commitment to the transaction's output notes.
+#! - INPUT_NOTES_COMMITMENT is the commitment to the transaction's inputs notes.
+#! - ACCOUNT_DELTA_COMMITMENT is the commitment to the transaction's account delta.
+export.create_tx_summary
     exec.account::compute_delta_commitment
     # => [ACCOUNT_DELTA_COMMITMENT, final_nonce]
 
@@ -100,7 +107,13 @@ end
 #!
 #! Inputs:  [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
 #! Outputs: [TX_SUMMARY_COMMITMENT]
-proc.hash_tx_summary
+#!
+#! Where:
+#! - SALT is an arbitrary word used for replay protection.
+#! - OUTPUT_NOTES_COMMITMENT is the commitment to the transaction's output notes.
+#! - INPUT_NOTES_COMMITMENT is the commitment to the transaction's inputs notes.
+#! - ACCOUNT_DELTA_COMMITMENT is the commitment to the transaction's account delta.
+export.hash_tx_summary
     swapdw
     # => [INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, SALT, OUTPUT_NOTES_COMMITMENT]
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1217,21 +1217,17 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let source_code = format!(
         "
-      use.miden::tx
-
+      #! Inputs:  [AUTH_ARGS, pad(16)]
+      #! Outputs: [pad(16)]
       export.auth__abort_tx
-          padw
-          # => [SALT]
+          dropw
+          # => [pad(16)]
 
-          exec.tx::get_output_notes_commitment
-          # => [OUTPUT_NOTES_COMMITMENT, SALT]
+          exec.::miden::account::incr_nonce
+          # => [final_nonce, pad(16)]
 
-          exec.tx::get_input_notes_commitment
-          # => [INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-          # TODO: Replace with account_delta::compute_commitment once available in `miden` lib.
-          padw
-          # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+          exec.::miden::contracts::auth::basic::create_tx_summary
+          # => [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
 
           emit.{abort_event}
       end
@@ -1269,16 +1265,22 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let tx_context = mock_chain.build_tx_context(account, &[input_note.id()], &[])?.build()?;
+    let ref_block_num = tx_context.tx_inputs().block_header().block_num().as_u32();
+    let final_nonce = tx_context.account().nonce().as_int() as u32 + 1;
     let input_notes = tx_context.input_notes().clone();
     let output_notes = OutputNotes::new(vec![OutputNote::Partial(output_note.into())])?;
 
     let error = tx_context.execute().unwrap_err();
 
     assert_matches!(error, TransactionExecutorError::Unauthorized(tx_summary) => {
-        assert!(tx_summary.account_delta().is_empty());
+        assert!(tx_summary.account_delta().vault().is_empty());
+        assert!(tx_summary.account_delta().storage().is_empty());
+        assert_eq!(tx_summary.account_delta().nonce_delta().as_int(), 1);
         assert_eq!(tx_summary.input_notes(), &input_notes);
         assert_eq!(tx_summary.output_notes(), &output_notes);
-        assert_eq!(tx_summary.salt(), Word::empty());
+        assert_eq!(tx_summary.salt(), Word::from(
+          [0, 0, ref_block_num, final_nonce]
+        ));
     });
 
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1217,7 +1217,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let source_code = format!(
         "
-      #! Inputs:  [AUTH_ARGS, pad(16)]
+      #! Inputs:  [AUTH_ARGS, pad(12)]
       #! Outputs: [pad(16)]
       export.auth__abort_tx
           dropw

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -556,10 +556,10 @@ where
     /// [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
     /// ```
     fn on_unauthorized(&self, process: &mut ProcessState) -> TransactionKernelError {
-        let account_delta_commitment = process.get_stack_word(0);
-        let input_notes_commitment = process.get_stack_word(1);
-        let output_notes_commitment = process.get_stack_word(2);
-        let salt = process.get_stack_word(3);
+        let account_delta_commitment = process.get_stack_word(3);
+        let input_notes_commitment = process.get_stack_word(2);
+        let output_notes_commitment = process.get_stack_word(1);
+        let salt = process.get_stack_word(0);
 
         TransactionKernelError::Unauthorized {
             account_delta_commitment,

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -553,7 +553,7 @@ where
     /// Expected stack state:
     ///
     /// ```text
-    /// [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+    /// [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT]
     /// ```
     fn on_unauthorized(&self, process: &mut ProcessState) -> TransactionKernelError {
         let account_delta_commitment = process.get_stack_word(3);


### PR DESCRIPTION
Extract `TransactionSummary` in stack order in `TransactionBaseHost::on_unauthorized`.

Makes `::miden::contracts::auth::basic::{create_tx_summary, hash_tx_summary}` public, since they may be useful for other uses and it enables calling this procedure in tests.

Updates the existing test to make use of `compute_delta_commitment` which is now available.

This matches the way the summary is constructed in the VM to avoid having to rearrange the words on the stack.

This came out of https://github.com/0xMiden/miden-base/pull/1624 and builds on top of that and another PR.