### PR TITLE
feat: implement serialization for `MockChain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [BREAKING] Make the naming of the transaction script arguments consistent ([#1632](https://github.com/0xMiden/miden-base/pull/1632)).
 - [BREAKING] Move `TransactionProverHost` and `TransactionExecutorHost` from dynamic dispatch to generics ([#1037](https://github.com/0xMiden/miden-node/issues/1037))
 - [BREAKING] Changed `PartialStorage` and `PartialVault` to use `PartialSmt` instead of separate merkle proofs ([#1590](https://github.com/0xMiden/miden-base/pull/1590)).
-
+- Implemented serialization for `MockChain` ([#1642](https://github.com/0xMiden/miden-base/pull/1642)).
 
 ## 0.10.0 (2025-07-08)
 
@@ -50,7 +50,7 @@
 - Add `with_auth_component` to `AccountBuilder` ([#1480](https://github.com/0xMiden/miden-base/pull/1480)).
 - Added `ScriptBuilder` to streamline building note & transaction scripts ([#1507](https://github.com/0xMiden/miden-base/pull/1507)).
 - Added procedure `was_procedure_called` to `miden::account` library module ([#1521](https://github.com/0xMiden/miden-base/pull/1521)).
-- Enabled loading MASM source files into `TransactionKernel::assembler` for better errors ([#1527]((https://github.com/0xMiden/miden-base/pull/1527))).
+- Enabled loading MASM source files into `TransactionKernel::assembler` for better errors ([#1527](<(https://github.com/0xMiden/miden-base/pull/1527)>)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Add `with_auth_component` to `AccountBuilder` ([#1480](https://github.com/0xMiden/miden-base/pull/1480)).
 - Added `ScriptBuilder` to streamline building note & transaction scripts ([#1507](https://github.com/0xMiden/miden-base/pull/1507)).
 - Added procedure `was_procedure_called` to `miden::account` library module ([#1521](https://github.com/0xMiden/miden-base/pull/1521)).
-- Enabled loading MASM source files into `TransactionKernel::assembler` for better errors ([#1527](<(https://github.com/0xMiden/miden-base/pull/1527)>)).
+- Enabled loading MASM source files into `TransactionKernel::assembler` for better errors ([#1527](https://github.com/0xMiden/miden-base/pull/1527)).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c58d9b9ae3867b5b5111876165c23008e934871bd3ea46a8919ea10a1ab04e8"
+checksum = "e4329275a11c7d8328b14a7129b21d40183056dcd0d871c3069be6e550d6ca40"
 dependencies = [
  "blake3",
  "cc",

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -1,5 +1,6 @@
 use miden_crypto::merkle::{MerkleError, MutationSet, Smt, SmtLeaf};
-use vm_processor::SMT_DEPTH;
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::{DeserializationError, SMT_DEPTH};
 
 use crate::{
     Felt, Word,
@@ -300,6 +301,22 @@ impl AccountTree {
 impl Default for AccountTree {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for AccountTree {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.smt.write_into(target);
+    }
+}
+
+impl Deserializable for AccountTree {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let smt = Smt::read_from(source)?;
+        Ok(Self { smt })
     }
 }
 

--- a/crates/miden-objects/src/block/blockchain.rs
+++ b/crates/miden-objects/src/block/blockchain.rs
@@ -1,6 +1,8 @@
 use alloc::collections::BTreeSet;
 
 use miden_crypto::merkle::{Forest, Mmr, MmrError, MmrPeaks, MmrProof, PartialMmr};
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_processor::DeserializationError;
 
 use crate::{Word, block::BlockNumber};
 
@@ -164,5 +166,21 @@ impl Blockchain {
 impl Default for Blockchain {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for Blockchain {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.mmr.write_into(target);
+    }
+}
+
+impl Deserializable for Blockchain {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let chain = Mmr::read_from(source)?;
+        Ok(Self::from_mmr_unchecked(chain))
     }
 }

--- a/crates/miden-objects/src/block/nullifier_tree.rs
+++ b/crates/miden-objects/src/block/nullifier_tree.rs
@@ -1,3 +1,5 @@
+use alloc::{string::ToString, vec::Vec};
+
 use vm_core::{
     EMPTY_WORD,
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
@@ -202,14 +204,15 @@ impl Default for NullifierTree {
 
 impl Serializable for NullifierTree {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.smt.write_into(target);
+        self.entries().collect::<Vec<_>>().write_into(target);
     }
 }
 
 impl Deserializable for NullifierTree {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let smt = Smt::read_from(source)?;
-        Ok(Self { smt })
+        let entries = Vec::<(Nullifier, BlockNumber)>::read_from(source)?;
+        Self::with_entries(entries)
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 

--- a/crates/miden-objects/src/block/nullifier_tree.rs
+++ b/crates/miden-objects/src/block/nullifier_tree.rs
@@ -1,4 +1,8 @@
-use vm_core::EMPTY_WORD;
+use vm_core::{
+    EMPTY_WORD,
+    utils::{ByteReader, ByteWriter, Deserializable, Serializable},
+};
+use vm_processor::DeserializationError;
 
 use crate::{
     Word,
@@ -190,6 +194,22 @@ impl NullifierTree {
 impl Default for NullifierTree {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for NullifierTree {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.smt.write_into(target);
+    }
+}
+
+impl Deserializable for NullifierTree {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let smt = Smt::read_from(source)?;
+        Ok(Self { smt })
     }
 }
 

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -7,10 +7,7 @@ use alloc::{
 
 use anyhow::Context;
 use miden_block_prover::{LocalBlockProver, ProvenBlockError};
-use miden_lib::{
-    account::auth,
-    note::{create_p2id_note, create_p2ide_note},
-};
+use miden_lib::note::{create_p2id_note, create_p2ide_note};
 use miden_objects::{
     MAX_BATCHES_PER_BLOCK, MAX_OUTPUT_NOTES_PER_BATCH, NoteError,
     account::{Account, AccountId, AuthSecretKey, StorageSlot, delta::AccountUpdateDetails},

--- a/crates/miden-testing/src/mock_chain/note.rs
+++ b/crates/miden-testing/src/mock_chain/note.rs
@@ -11,7 +11,7 @@ use winterfell::ByteWriter;
 
 /// Represents a note that is stored in the mock chain.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MockChainNote {
     /// Details for a private note only include its [`NoteMetadata`] and [`NoteInclusionProof`].
     /// Other details needed to consume the note are expected to be stored locally, off-chain.

--- a/crates/miden-testing/src/mock_chain/note.rs
+++ b/crates/miden-testing/src/mock_chain/note.rs
@@ -2,6 +2,9 @@ use miden_objects::{
     note::{Note, NoteId, NoteInclusionProof, NoteMetadata},
     transaction::InputNote,
 };
+use miden_tx::utils::{ByteReader, Deserializable, Serializable};
+use vm_processor::DeserializationError;
+use winterfell::ByteWriter;
 
 // MOCK CHAIN NOTE
 // ================================================================================================
@@ -60,6 +63,47 @@ impl TryFrom<MockChainNote> for InputNote {
                 "private notes in the mock chain cannot be converted into input notes due to missing details"
             )),
             MockChainNote::Public(note, proof) => Ok(InputNote::Authenticated { note, proof }),
+        }
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for MockChainNote {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            MockChainNote::Private(id, metadata, proof) => {
+                0u8.write_into(target);
+                id.write_into(target);
+                metadata.write_into(target);
+                proof.write_into(target);
+            },
+            MockChainNote::Public(note, proof) => {
+                1u8.write_into(target);
+                note.write_into(target);
+                proof.write_into(target);
+            },
+        }
+    }
+}
+
+impl Deserializable for MockChainNote {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let note_type = u8::read_from(source)?;
+        match note_type {
+            0 => {
+                let id = NoteId::read_from(source)?;
+                let metadata = NoteMetadata::read_from(source)?;
+                let proof = NoteInclusionProof::read_from(source)?;
+                Ok(MockChainNote::Private(id, metadata, proof))
+            },
+            1 => {
+                let note = Note::read_from(source)?;
+                let proof = NoteInclusionProof::read_from(source)?;
+                Ok(MockChainNote::Public(note, proof))
+            },
+            _ => Err(DeserializationError::InvalidValue(format!("Unknown note type: {note_type}"))),
         }
     }
 }

--- a/crates/miden-tx/src/auth/tx_authenticator.rs
+++ b/crates/miden-tx/src/auth/tx_authenticator.rs
@@ -158,6 +158,10 @@ impl<R: Rng> BasicAuthenticator<R> {
             rng: Arc::new(RwLock::new(rng)),
         }
     }
+
+    pub fn keys(&self) -> &BTreeMap<Word, AuthSecretKey> {
+        &self.keys
+    }
 }
 
 impl<R: Rng> TransactionAuthenticator for BasicAuthenticator<R> {

--- a/crates/miden-tx/src/auth/tx_authenticator.rs
+++ b/crates/miden-tx/src/auth/tx_authenticator.rs
@@ -159,6 +159,8 @@ impl<R: Rng> BasicAuthenticator<R> {
         }
     }
 
+    /// Returns a reference to the keys map. Map keys represent the public keys, and values
+    /// represent the secret keys that the authenticator would use to sign messages.
     pub fn keys(&self) -> &BTreeMap<Word, AuthSecretKey> {
         &self.keys
     }


### PR DESCRIPTION
This PR implements serialization for `MockChain`. This is needed for [this miden-client issue](https://github.com/0xMiden/miden-client/issues/1064) where users want a way to persist a `MockChain` (among other things).

This PR depends on a [this separate `miden-crypto` PR](https://github.com/0xMiden/crypto/pull/466) that implements serialization for `Mmr`.