### PR TITLE
feat: Add PartialBlockchain::num_tracked_blocks()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `output_note_get_assets_info` procedure to the transaction kernel ([#1638](https://github.com/0xMiden/miden-base/pull/1638)).
 - Implemented new `from_unauthenticated_notes` constructor for `InputNotes` ([#1629](https://github.com/0xMiden/miden-base/pull/1629)).
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
+- Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
 
 ### Changes
 

--- a/crates/miden-objects/src/transaction/partial_blockchain.rs
+++ b/crates/miden-objects/src/transaction/partial_blockchain.rs
@@ -148,6 +148,11 @@ impl PartialBlockchain {
         )
     }
 
+    /// Returns the number of blocks tracked by this partial blockchain.
+    pub fn num_tracked_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
     /// Returns `true` if a block with the given number is present in this partial blockchain.
     ///
     /// Note that this only checks whether an entry with the block's number exists in the MMR.
@@ -201,7 +206,7 @@ impl PartialBlockchain {
     /// [`PartialBlockchain`].
     ///
     /// This does not change the commitment to the underlying MMR, but the current partial MMR
-    /// will no longer track the removed data.  
+    /// will no longer track the removed data.
     pub fn remove(&mut self, block_num: BlockNumber) {
         if self.blocks.remove(&block_num).is_some() {
             self.mmr.untrack(block_num.as_usize());

--- a/crates/miden-objects/src/transaction/partial_blockchain.rs
+++ b/crates/miden-objects/src/transaction/partial_blockchain.rs
@@ -460,14 +460,17 @@ mod tests {
                 .unwrap();
         }
         let mut chain = PartialBlockchain::new(partial_mmr, headers).unwrap();
+        assert_eq!(chain.num_tracked_blocks(), total_blocks as usize);
 
         chain.remove(BlockNumber::from(2));
         assert!(!chain.contains_block(2.into()));
         assert!(!chain.mmr().is_tracked(2));
+        assert_eq!(chain.num_tracked_blocks(), (total_blocks - 1) as usize);
 
         assert!(chain.contains_block(3.into()));
 
         chain.prune_to(..40.into());
+        assert_eq!(chain.num_tracked_blocks(), (total_blocks - 40) as usize);
 
         assert_eq!(chain.block_headers().count(), (total_blocks - remove_before) as usize);
         for block_num in remove_before..total_blocks {


### PR DESCRIPTION
## Context

We are updating Ntx Builder state to track chain tip via `PartialBlockchain`: https://github.com/0xMiden/miden-node/pull/1108.

The partial chain is pruned in order limit memory consumption and performance hit of clones. The ability to know the number of blocks tracked by the partial chain would help reduce logic in the Ntx builder stack.

## Changes
- Add `PartialBlockchain::num_tracked_blocks()`.
- Update prune unit test to validate new fn works as expected.