### PR TITLE
chore: make `ERR_ACCOUNT_PROC_NOT_AUTH_PROC` more verbose

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -29,7 +29,7 @@ const.ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE="account procedure is not part o
 
 const.ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS="provided procedure index is out of bounds"
 
-const.ERR_ACCOUNT_PROC_NOT_AUTH_PROC="account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
+const.ERR_ACCOUNT_PROC_NOT_AUTH_PROC="account procedure is not the authentication procedure; some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
 
 const.ERR_ACCOUNT_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS="provided storage slot index is out of bounds"
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -29,7 +29,7 @@ const.ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE="account procedure is not part o
 
 const.ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS="provided procedure index is out of bounds"
 
-const.ERR_ACCOUNT_PROC_NOT_AUTH_PROC="account procedure is not the authentication procedure"
+const.ERR_ACCOUNT_PROC_NOT_AUTH_PROC="account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
 
 const.ERR_ACCOUNT_STORAGE_SLOT_INDEX_OUT_OF_BOUNDS="provided storage slot index is out of bounds"
 

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -38,8 +38,8 @@ pub const ERR_ACCOUNT_NONCE_CAN_ONLY_BE_INCREMENTED_ONCE: MasmError = MasmError:
 pub const ERR_ACCOUNT_NONCE_DID_NOT_INCREASE_AFTER_STATE_CHANGE: MasmError = MasmError::from_static_str("account nonce did not increase after a state changing transaction");
 /// Error Message: "provided procedure index is out of bounds"
 pub const ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS: MasmError = MasmError::from_static_str("provided procedure index is out of bounds");
-/// Error Message: "account procedure is not the authentication procedure"
-pub const ERR_ACCOUNT_PROC_NOT_AUTH_PROC: MasmError = MasmError::from_static_str("account procedure is not the authentication procedure");
+/// Error Message: "account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
+pub const ERR_ACCOUNT_PROC_NOT_AUTH_PROC: MasmError = MasmError::from_static_str("account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure");
 /// Error Message: "account procedure is not part of the account code"
 pub const ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE: MasmError = MasmError::from_static_str("account procedure is not part of the account code");
 /// Error Message: "failed to read an account map item from a non-map storage slot"

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -38,8 +38,8 @@ pub const ERR_ACCOUNT_NONCE_CAN_ONLY_BE_INCREMENTED_ONCE: MasmError = MasmError:
 pub const ERR_ACCOUNT_NONCE_DID_NOT_INCREASE_AFTER_STATE_CHANGE: MasmError = MasmError::from_static_str("account nonce did not increase after a state changing transaction");
 /// Error Message: "provided procedure index is out of bounds"
 pub const ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS: MasmError = MasmError::from_static_str("provided procedure index is out of bounds");
-/// Error Message: "account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
-pub const ERR_ACCOUNT_PROC_NOT_AUTH_PROC: MasmError = MasmError::from_static_str("account procedure is not the authentication procedure. Some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure");
+/// Error Message: "account procedure is not the authentication procedure; some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure"
+pub const ERR_ACCOUNT_PROC_NOT_AUTH_PROC: MasmError = MasmError::from_static_str("account procedure is not the authentication procedure; some procedures (e.g. `incr_nonce`) can be called only from the authentication procedure");
 /// Error Message: "account procedure is not part of the account code"
 pub const ERR_ACCOUNT_PROC_NOT_PART_OF_ACCOUNT_CODE: MasmError = MasmError::from_static_str("account procedure is not part of the account code");
 /// Error Message: "failed to read an account map item from a non-map storage slot"


### PR DESCRIPTION
I'm not sure about putting URLs into the error message, but in any case the doc aren't there yet to link against (but we could reference [docs/src/account/code.md#Authentication](https://github.com/0xMiden/miden-base/pull/1523/files#diff-80b077c708d8bbc3d399da4d65af90159e107ea453cb533925e1032fb5ebc9a5) once that PR is ready)

closes #1644