### PR TITLE
feat: Implement `compute_fee`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `input_note_get_recipient`, `output_note_get_recipient`, `input_note_get_metadata`, `output_note_get_metadata` procedures to the transaction kernel ([#1648](https://github.com/0xMiden/miden-base/pull/1648)).
 - Added `input_notes::get_assets` and `output_notes::get_assets` procedures to `miden` library ([#1648](https://github.com/0xMiden/miden-base/pull/1648)).
 - Added issuance accessor for fungible faucet accounts. ([#1660](https://github.com/0xMiden/miden-base/pull/1660)).
+- Add `FeeParameters` to `BlockHeader` and implement `compute_fee` ([#1652](https://github.com/0xMiden/miden-base/pull/1652), [#1654](https://github.com/0xMiden/miden-base/pull/1654)).
 
 ### Changes
 

--- a/bin/bench-tx/bench-tx.json
+++ b/bin/bench-tx/bench-tx.json
@@ -1,21 +1,23 @@
 {
   "simple": {
-    "prologue": 4503,
-    "notes_processing": 2235,
+    "prologue": 4167,
+    "notes_processing": 2540,
     "note_execution": {
-      "0xccc0bb4ef7e27c1fd6ada71b87574e1b48f996b328b5f5d80eb526e6c288e0a6": 755,
-      "0xd6936c529c79d21ddc287db672f07b150b8c06cd8b2b8d9c2c66b1bedb4a67fd": 1439
+      "0x7fe47b84889353de93aea4bfeaa8da5da0036ea7a84dfc5ff5765ec51440896f": 1266,
+      "0xbf1c92f4f0b35b51d3f3e8f7ba19abf7718a7e087627df0d17987af8a1cb872a": 1233
     },
     "tx_script_processing": 45,
-    "epilogue": 2846
+    "epilogue": 1525,
+    "after_compute_fee_cycles": 1143
   },
   "p2id": {
-    "prologue": 2710,
-    "notes_processing": 1570,
+    "prologue": 2755,
+    "notes_processing": 1572,
     "note_execution": {
-      "0xbabb602b1c5a2cf2292cb98b4cd505bf6d21689cdfd235de90a80982d4139e76": 1537
+      "0x7ff44c53fefcd88ee714511b6d2976189549fec4b26695ee5e2b5293f50a845a": 1539
     },
-    "tx_script_processing": 60886,
-    "epilogue": 857
+    "tx_script_processing": 45,
+    "epilogue": 62233,
+    "after_compute_fee_cycles": 891
   }
 }

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -13,13 +13,13 @@ use miden_objects::{
         account_component::IncrNonceAuthComponent,
         account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     },
-    transaction::{TransactionMeasurements, TransactionScript},
+    transaction::TransactionMeasurements,
 };
 use miden_testing::{TransactionContextBuilder, utils::create_p2any_note};
 
 mod utils;
 use utils::{
-    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_SENDER, DEFAULT_AUTH_SCRIPT,
+    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_SENDER,
     get_account_with_basic_authenticated_wallet, get_new_pk_and_authenticator,
     write_bench_results_to_json,
 };
@@ -117,12 +117,8 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     )
     .unwrap();
 
-    let tx_script_target =
-        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, TransactionKernel::assembler()).unwrap();
-
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])
-        .tx_script(tx_script_target)
         .authenticator(Some(falcon_auth))
         .build()?;
 

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -34,7 +34,7 @@ pub struct MeasurementsPrinter {
     note_execution: BTreeMap<String, usize>,
     tx_script_processing: usize,
     epilogue: usize,
-    after_compute_fee_cycles: usize,
+    after_tx_fee_computed_cycles: usize,
 }
 
 impl From<TransactionMeasurements> for MeasurementsPrinter {
@@ -51,7 +51,7 @@ impl From<TransactionMeasurements> for MeasurementsPrinter {
             note_execution: note_execution_map,
             tx_script_processing: tx_measurements.tx_script_processing,
             epilogue: tx_measurements.epilogue,
-            after_compute_fee_cycles: tx_measurements.after_compute_fee_cycles,
+            after_tx_fee_computed_cycles: tx_measurements.after_tx_fee_computed_cycles,
         }
     }
 }

--- a/bin/bench-tx/src/utils.rs
+++ b/bin/bench-tx/src/utils.rs
@@ -24,14 +24,6 @@ use super::{Benchmark, Path};
 pub const ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET: u128 = 0x00aa00000000bc200000bc000000de00;
 pub const ACCOUNT_ID_SENDER: u128 = 0x00fa00000000bb800000cc000000de00;
 
-pub const DEFAULT_AUTH_SCRIPT: &str = "
-    begin
-        padw padw padw padw
-        call.::miden::contracts::auth::basic::auth__tx_rpo_falcon512
-        dropw dropw dropw dropw
-    end
-";
-
 // MEASUREMENTS PRINTER
 // ================================================================================================
 
@@ -42,19 +34,24 @@ pub struct MeasurementsPrinter {
     note_execution: BTreeMap<String, usize>,
     tx_script_processing: usize,
     epilogue: usize,
+    after_compute_fee_cycles: usize,
 }
 
 impl From<TransactionMeasurements> for MeasurementsPrinter {
-    fn from(value: TransactionMeasurements) -> Self {
-        let note_execution_map =
-            value.note_execution.iter().map(|(id, len)| (id.to_hex(), *len)).collect();
+    fn from(tx_measurements: TransactionMeasurements) -> Self {
+        let note_execution_map = tx_measurements
+            .note_execution
+            .iter()
+            .map(|(id, len)| (id.to_hex(), *len))
+            .collect();
 
         MeasurementsPrinter {
-            prologue: value.prologue,
-            notes_processing: value.notes_processing,
+            prologue: tx_measurements.prologue,
+            notes_processing: tx_measurements.notes_processing,
             note_execution: note_execution_map,
-            tx_script_processing: value.tx_script_processing,
-            epilogue: value.epilogue,
+            tx_script_processing: tx_measurements.tx_script_processing,
+            epilogue: tx_measurements.epilogue,
+            after_compute_fee_cycles: tx_measurements.after_compute_fee_cycles,
         }
     }
 }
@@ -74,7 +71,7 @@ pub fn get_account_with_basic_authenticated_wallet(
         .storage_mode(storage_mode)
         .with_assets(assets)
         .with_component(BasicWallet)
-        .with_component(AuthRpoFalcon512::new(public_key))
+        .with_auth_component(AuthRpoFalcon512::new(public_key))
         .build_existing()
         .unwrap()
 }

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -228,8 +228,7 @@ proc.compute_fee
     add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
     # => [num_tx_cycles]
 
-    # take log2 which is proportional
-    # ilog2 will round down, but we need to round up, so we add 1.
+    # ilog2 will round down, but we need to round up, so we add 1 afterwards.
     # technically we don't need to do this if num_tx_cycles is already a power of two, but
     # because we're estimating part of the cycle count anyway, this is not a correctness
     # concern currently.

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -19,6 +19,18 @@ const.ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY="executed transaction neither c
 
 const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been called from outside the epilogue"
 
+# CONSTANTS
+# =================================================================================================
+
+# Event emitted to signal that the compute free procedure has finished executing.
+const.EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE=131101
+
+# The number of cycles the epilogue is estimated to take after compute_fee has been executed.
+# This is _estimated_ using the transaction measurements on ExecutedTransaction.
+# This should be replaced with a way to _calculate_ the number of cycles that the epilogue will incur
+# after compute_fee.
+const.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES=1200
+
 # OUTPUT NOTES PROCEDURES
 # =================================================================================================
 
@@ -204,8 +216,13 @@ end
 proc.compute_fee
     # get the number of cycles the transaction has taken to execute up this point
     clk
-    # TODO: Add epilogue estimation
     # => [num_current_cycles]
+
+    emit.EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE
+
+    # estimate the number of cycles the transaction will take
+    add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
+    # => [num_tx_cycles]
 
     ilog2
     # => [num_estimated_verification_cycles]
@@ -242,6 +259,11 @@ export.finalize_transaction
 
     # execute the account authentication procedure
     exec.execute_auth_procedure
+    # => []
+
+    # compute the fee the tx needs to pay
+    # ignored for now
+    exec.compute_fee drop
     # => []
 
     # get the initial account commitment

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -23,7 +23,7 @@ const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been call
 # =================================================================================================
 
 # Event emitted to signal that the compute_fee procedure has obtained the current number of cycles.
-const.EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE=131101
+const.EPILOGUE_AFTER_TX_FEE_COMPUTED=131097
 
 # The number of cycles the epilogue is estimated to take after compute_fee has been executed.
 # This is _estimated_ using the transaction measurements on ExecutedTransaction.
@@ -218,7 +218,7 @@ proc.compute_fee
     clk
     # => [num_current_cycles]
 
-    emit.EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE
+    emit.EPILOGUE_AFTER_TX_FEE_COMPUTED
 
     # estimate the number of cycles the transaction will take
     add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -211,6 +211,10 @@ end
 
 #! Computes the fee required for the current transaction.
 #!
+#! The number of cycles a transaction will take to verify depends logarithmically on the number of
+#! cycles that were proven. We estimate this by taking log2 of the estimated number of cycles the
+#! transaction will take to execute, rounded up to the next power of two.
+#!
 #! Inputs:  []
 #! Outputs: [fee_amount]
 proc.compute_fee
@@ -224,7 +228,12 @@ proc.compute_fee
     add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
     # => [num_tx_cycles]
 
-    ilog2
+    # take log2 which is proportional
+    # ilog2 will round down, but we need to round up, so we add 1.
+    # technically we don't need to do this if num_tx_cycles is already a power of two, but
+    # because we're estimating part of the cycle count anyway, this is not a correctness
+    # concern currently.
+    ilog2 add.1
     # => [num_estimated_verification_cycles]
 
     exec.memory::get_verification_base_fee

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -22,7 +22,7 @@ const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been call
 # CONSTANTS
 # =================================================================================================
 
-# Event emitted to signal that the compute free procedure has finished executing.
+# Event emitted to signal that the compute_fee procedure has obtained the current number of cycles.
 const.EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE=131101
 
 # The number of cycles the epilogue is estimated to take after compute_fee has been executed.

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -194,6 +194,29 @@ proc.execute_auth_procedure
     dropw dropw dropw dropw
 end
 
+# FEE PROCEDURES
+# =================================================================================================
+
+#! Computes the fee required for the current transaction.
+#!
+#! Inputs:  []
+#! Outputs: [fee_amount]
+proc.compute_fee
+    # get the number of cycles the transaction has taken to execute up this point
+    clk
+    # TODO: Add epilogue estimation
+    # => [num_current_cycles]
+
+    ilog2
+    # => [num_estimated_verification_cycles]
+
+    exec.memory::get_verification_base_fee
+    # => [verification_base_fee, num_estimated_verification_cycles]
+
+    mul
+    # => [verification_cost]
+end
+
 # TRANSACTION EPILOGUE PROCEDURE
 # =================================================================================================
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
@@ -166,10 +166,10 @@ const.GET_OPERATION_ABSENT_AT_HEAD=1
 # =================================================================================================
 
 # Event emitted when an entry is set.
-const.LINK_MAP_SET_EVENT=131098
+const.LINK_MAP_SET_EVENT=131099
 
 # Event emitted when an entry is fetched.
-const.LINK_MAP_GET_EVENT=131099
+const.LINK_MAP_GET_EVENT=131100
 
 # LINK MAP PROCEDURES
 # =================================================================================================

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -31,7 +31,7 @@ const.TX_SCRIPT_PROCESSING_END=131095
 # Event emitted to signal that an execution of the transaction epilogue has started.
 const.EPILOGUE_START=131096
 # Event emitted to signal that an execution of the transaction epilogue has ended.
-const.EPILOGUE_END=131097
+const.EPILOGUE_END=131098
 
 # MAIN
 # =================================================================================================

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -184,7 +184,9 @@ impl TryFrom<u32> for TransactionEvent {
             TX_SCRIPT_PROCESSING_END => Ok(TransactionEvent::TxScriptProcessingEnd),
 
             EPILOGUE_START => Ok(TransactionEvent::EpilogueStart),
-            EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE => Ok(TransactionEvent::EpilogueAfterComputeFeeProcedure),
+            EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE => {
+                Ok(TransactionEvent::EpilogueAfterComputeFeeProcedure)
+            },
             EPILOGUE_END => Ok(TransactionEvent::EpilogueEnd),
 
             LINK_MAP_SET_EVENT => Ok(TransactionEvent::LinkMapSetEvent),

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -46,15 +46,13 @@ const TX_SCRIPT_PROCESSING_START: u32 = 0x2_0016; // 131094
 const TX_SCRIPT_PROCESSING_END: u32 = 0x2_0017; // 131095
 
 const EPILOGUE_START: u32 = 0x2_0018; // 131096
-const EPILOGUE_END: u32 = 0x2_0019; // 131097
+const EPILOGUE_AFTER_TX_FEE_COMPUTED: u32 = 0x2_0019; // 131097
+const EPILOGUE_END: u32 = 0x2_001a; // 131098
 
-const LINK_MAP_SET_EVENT: u32 = 0x2_001a; // 131098
-const LINK_MAP_GET_EVENT: u32 = 0x2_001b; // 131099
+const LINK_MAP_SET_EVENT: u32 = 0x2_001b; // 131099
+const LINK_MAP_GET_EVENT: u32 = 0x2_001c; // 131100
 
-const UNAUTHORIZED_EVENT: u32 = 0x2_001c; // 131100
-
-// TODO: Move between epilogue start/end.
-const EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE: u32 = 0x2001d; // 131101
+const UNAUTHORIZED_EVENT: u32 = 0x2_001d; // 131101
 
 /// Events which may be emitted by a transaction kernel.
 ///
@@ -104,7 +102,7 @@ pub enum TransactionEvent {
     TxScriptProcessingEnd = TX_SCRIPT_PROCESSING_END,
 
     EpilogueStart = EPILOGUE_START,
-    EpilogueAfterComputeFeeProcedure = EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE,
+    EpilogueAfterTxFeeComputed = EPILOGUE_AFTER_TX_FEE_COMPUTED,
     EpilogueEnd = EPILOGUE_END,
 
     LinkMapSetEvent = LINK_MAP_SET_EVENT,
@@ -184,9 +182,7 @@ impl TryFrom<u32> for TransactionEvent {
             TX_SCRIPT_PROCESSING_END => Ok(TransactionEvent::TxScriptProcessingEnd),
 
             EPILOGUE_START => Ok(TransactionEvent::EpilogueStart),
-            EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE => {
-                Ok(TransactionEvent::EpilogueAfterComputeFeeProcedure)
-            },
+            EPILOGUE_AFTER_TX_FEE_COMPUTED => Ok(TransactionEvent::EpilogueAfterTxFeeComputed),
             EPILOGUE_END => Ok(TransactionEvent::EpilogueEnd),
 
             LINK_MAP_SET_EVENT => Ok(TransactionEvent::LinkMapSetEvent),

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -53,6 +53,9 @@ const LINK_MAP_GET_EVENT: u32 = 0x2_001b; // 131099
 
 const UNAUTHORIZED_EVENT: u32 = 0x2_001c; // 131100
 
+// TODO: Move between epilogue start/end.
+const EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE: u32 = 0x2001d; // 131101
+
 /// Events which may be emitted by a transaction kernel.
 ///
 /// The events are emitted via the `emit.<event_id>` instruction. The event ID is a 32-bit
@@ -101,6 +104,7 @@ pub enum TransactionEvent {
     TxScriptProcessingEnd = TX_SCRIPT_PROCESSING_END,
 
     EpilogueStart = EPILOGUE_START,
+    EpilogueAfterComputeFeeProcedure = EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE,
     EpilogueEnd = EPILOGUE_END,
 
     LinkMapSetEvent = LINK_MAP_SET_EVENT,
@@ -180,6 +184,7 @@ impl TryFrom<u32> for TransactionEvent {
             TX_SCRIPT_PROCESSING_END => Ok(TransactionEvent::TxScriptProcessingEnd),
 
             EPILOGUE_START => Ok(TransactionEvent::EpilogueStart),
+            EPILOGUE_AFTER_COMPUTE_FEE_PROCEDURE => Ok(TransactionEvent::EpilogueAfterComputeFeeProcedure),
             EPILOGUE_END => Ok(TransactionEvent::EpilogueEnd),
 
             LINK_MAP_SET_EVENT => Ok(TransactionEvent::LinkMapSetEvent),

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -28,13 +28,13 @@ pub const KERNEL0_PROCEDURES: [Word; 46] = [
     // account_get_map_item
     word!("0xc726fda47785fd7252c329ed9cbf9de1408a1340690c5671c5c986072c10721a"),
     // account_set_map_item
-    word!("0x9e0d4da12f3f27269fa032101623ea667d2ee03ac3a957539bfa8259de67b38f"),
+    word!("0x60ed9893db416d702253bd08010a055223f65225234a76f106221cffc85d9a83"),
     // account_get_vault_root
     word!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    word!("0x46a64ae46f9b2350a3924901722c1a6d65e06da3bfd9e569d1dcde507cdc78bf"),
+    word!("0xb9f40c63c4862d316aed0c4de060d5917411f8f9a7a21eebe0de4ca2924ba82b"),
     // account_remove_asset
-    word!("0x99219887439af58fd5243879259bee37b1d8b6e9cdc7ab19dbcab5ea348cca6c"),
+    word!("0x8c9756d671b3d50362678b2485c9a50312a77f61a9777e7b5fbdaa4aa89d76a2"),
     // account_get_balance
     word!("0xc3385953bc66def5211f53a3c44de8facfb4060abbb1c9708859c314268989e8"),
     // account_has_non_fungible_asset
@@ -44,9 +44,9 @@ pub const KERNEL0_PROCEDURES: [Word; 46] = [
     // account_was_procedure_called
     word!("0xe85f7a761f0d90e4d880239c4c1f349125d5a53db1e058a51c462b9442117ab6"),
     // faucet_mint_asset
-    word!("0x5fa98b2eced9242d90a88d7206f73c31b6121fc596333cab1670f131c8215952"),
+    word!("0x6c072b4ec652537c422f300954fbe55c2e272f8e4e30426a15cccaf9281f8519"),
     // faucet_burn_asset
-    word!("0x48a159453fc092e4e5f5693e5ff8581c9fbacd62e5d3514039e7eabf94a2f5b2"),
+    word!("0x395504c9941d3547ca14e014e6850c72a5cf1cb4bf81e27521ef90f6a50e5bb6"),
     // faucet_get_total_fungible_asset_issuance
     word!("0xcb8d62a7570d84250540a5acbadf2911942d343a29e737df6f0f0ee632eafd43"),
     // faucet_is_non_fungible_asset_issued

--- a/crates/miden-objects/src/transaction/executed_tx.rs
+++ b/crates/miden-objects/src/transaction/executed_tx.rs
@@ -216,7 +216,8 @@ pub struct TransactionMeasurements {
     pub note_execution: Vec<(NoteId, usize)>,
     pub tx_script_processing: usize,
     pub epilogue: usize,
-    /// The number of cycles the epilogue took to execute after compute_fee was called.
+    /// The number of cycles the epilogue took to execute after compute_fee determined the cycle
+    /// count.
     ///
     /// This is used to estimate the total number of cycles the transaction takes for use in
     /// compute_fee itself.

--- a/crates/miden-objects/src/transaction/executed_tx.rs
+++ b/crates/miden-objects/src/transaction/executed_tx.rs
@@ -216,6 +216,11 @@ pub struct TransactionMeasurements {
     pub note_execution: Vec<(NoteId, usize)>,
     pub tx_script_processing: usize,
     pub epilogue: usize,
+    /// The number of cycles the epilogue took to execute after compute_fee was called.
+    ///
+    /// This is used to estimate the total number of cycles the transaction takes for use in
+    /// compute_fee itself.
+    pub after_compute_fee_cycles: usize,
 }
 
 impl TransactionMeasurements {
@@ -239,6 +244,7 @@ impl Serializable for TransactionMeasurements {
         self.note_execution.write_into(target);
         self.tx_script_processing.write_into(target);
         self.epilogue.write_into(target);
+        self.after_compute_fee_cycles.write_into(target);
     }
 }
 
@@ -249,6 +255,7 @@ impl Deserializable for TransactionMeasurements {
         let note_execution = Vec::<(NoteId, usize)>::read_from(source)?;
         let tx_script_processing = usize::read_from(source)?;
         let epilogue = usize::read_from(source)?;
+        let after_compute_fee_cycles = usize::read_from(source)?;
 
         Ok(Self {
             prologue,
@@ -256,6 +263,7 @@ impl Deserializable for TransactionMeasurements {
             note_execution,
             tx_script_processing,
             epilogue,
+            after_compute_fee_cycles,
         })
     }
 }

--- a/crates/miden-objects/src/transaction/executed_tx.rs
+++ b/crates/miden-objects/src/transaction/executed_tx.rs
@@ -221,7 +221,7 @@ pub struct TransactionMeasurements {
     ///
     /// This is used to estimate the total number of cycles the transaction takes for use in
     /// compute_fee itself.
-    pub after_compute_fee_cycles: usize,
+    pub after_tx_fee_computed_cycles: usize,
 }
 
 impl TransactionMeasurements {
@@ -245,7 +245,7 @@ impl Serializable for TransactionMeasurements {
         self.note_execution.write_into(target);
         self.tx_script_processing.write_into(target);
         self.epilogue.write_into(target);
-        self.after_compute_fee_cycles.write_into(target);
+        self.after_tx_fee_computed_cycles.write_into(target);
     }
 }
 
@@ -256,7 +256,7 @@ impl Deserializable for TransactionMeasurements {
         let note_execution = Vec::<(NoteId, usize)>::read_from(source)?;
         let tx_script_processing = usize::read_from(source)?;
         let epilogue = usize::read_from(source)?;
-        let after_compute_fee_cycles = usize::read_from(source)?;
+        let after_tx_fee_computed_cycles = usize::read_from(source)?;
 
         Ok(Self {
             prologue,
@@ -264,7 +264,7 @@ impl Deserializable for TransactionMeasurements {
             note_execution,
             tx_script_processing,
             epilogue,
-            after_compute_fee_cycles,
+            after_tx_fee_computed_cycles,
         })
     }
 }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -250,8 +250,8 @@ where
                 self.tx_progress.start_epilogue(process.clk());
                 Ok(())
             }
-            TransactionEvent::EpilogueAfterComputeFeeProcedure => {
-                self.tx_progress.epilogue_after_compute_fee_procedure(process.clk());
+            TransactionEvent::EpilogueAfterTxFeeComputed => {
+                self.tx_progress.epilogue_after_tx_fee_computed(process.clk());
                 Ok(())
             }
             TransactionEvent::EpilogueEnd => {

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -250,6 +250,10 @@ where
                 self.tx_progress.start_epilogue(process.clk());
                 Ok(())
             }
+            TransactionEvent::EpilogueAfterComputeFeeProcedure => {
+                self.tx_progress.epilogue_after_compute_fee_procedure(process.clk());
+                Ok(())
+            }
             TransactionEvent::EpilogueEnd => {
                 self.tx_progress.end_epilogue(process.clk());
                 Ok(())

--- a/crates/miden-tx/src/host/tx_progress.rs
+++ b/crates/miden-tx/src/host/tx_progress.rs
@@ -19,7 +19,7 @@ pub struct TransactionProgress {
     ///
     /// This is used to estimate the total number of cycles the transaction takes for use in
     /// compute_fee itself.
-    epilogue_after_compute_fee_procedure: Option<RowIndex>,
+    epilogue_after_tx_fee_computed: Option<RowIndex>,
 }
 
 impl TransactionProgress {
@@ -34,7 +34,7 @@ impl TransactionProgress {
             note_execution: Vec::new(),
             tx_script_processing: CycleInterval::default(),
             epilogue: CycleInterval::default(),
-            epilogue_after_compute_fee_procedure: None,
+            epilogue_after_tx_fee_computed: None,
         }
     }
 
@@ -102,8 +102,8 @@ impl TransactionProgress {
         self.epilogue.set_start(cycle);
     }
 
-    pub fn epilogue_after_compute_fee_procedure(&mut self, cycle: RowIndex) {
-        self.epilogue_after_compute_fee_procedure = Some(cycle);
+    pub fn epilogue_after_tx_fee_computed(&mut self, cycle: RowIndex) {
+        self.epilogue_after_tx_fee_computed = Some(cycle);
     }
 
     pub fn end_epilogue(&mut self, cycle: RowIndex) {
@@ -133,11 +133,11 @@ impl From<TransactionProgress> for TransactionMeasurements {
 
         let epilogue = tx_progress.epilogue().len();
 
-        let after_compute_fee_cycles = if let Some(after_compute_fee_procedure) =
-            tx_progress.epilogue_after_compute_fee_procedure
+        let after_tx_fee_computed_cycles = if let Some(epilogue_after_tx_fee_computed) =
+            tx_progress.epilogue_after_tx_fee_computed
         {
             tx_progress.epilogue().end().expect("epilogue end should be set")
-                - after_compute_fee_procedure
+                - epilogue_after_tx_fee_computed
         } else {
             0
         };
@@ -148,7 +148,7 @@ impl From<TransactionProgress> for TransactionMeasurements {
             note_execution,
             tx_script_processing,
             epilogue,
-            after_compute_fee_cycles,
+            after_tx_fee_computed_cycles,
         }
     }
 }


### PR DESCRIPTION
Implements a basic `compute_fee` procedure in the tx kernel epilogue.

This builds on top of #1652.

Most of the PR is actually about updating the `TransactionProgress` and `TransactionMeasurements` (and fixing the tx benchmark) to get an estimation for how long the epilogue takes after `clk` in `compute_fee` was called. This is a crude estimation and will most likely have to be corrected up when we start testing this. The estimation is a hardcoded value and does not take into account the variable length of account storage and code or the number of input and output notes, which affect the cycle count.

It would be ideal if we could _calculate_ the number of cycles all procedures after `compute_fee` in the epilogue take, by providing inputs like storage size, number of account procedures and number of input and output notes. We would have to put this under test to make sure that whenever it gets outdated, a test fails and we can update accordingly. I think it may even be good to do this sooner than later because I don't see a way to estimate this number of cycles without grossly over- or underestimating it.