### PR TITLE
feat: add faucet storage accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
+- Added `FungibleFaucet` issuance accessors. ([#1660](https://github.com/0xMiden/miden-base/pull/1660)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
-- Added `FungibleFaucet` issuance accessors. ([#1660](https://github.com/0xMiden/miden-base/pull/1660)).
+- Added issuance accessor for fungible faucet accounts. ([#1660](https://github.com/0xMiden/miden-base/pull/1660)).
 
 ### Changes
 

--- a/crates/miden-lib/src/account/faucets/mod.rs
+++ b/crates/miden-lib/src/account/faucets/mod.rs
@@ -14,9 +14,12 @@ use super::{
     AuthScheme,
     interface::{AccountComponentInterface, AccountInterface},
 };
-use crate::account::{
-    auth::{AuthRpoFalcon512Acl, AuthRpoFalcon512AclConfig},
-    components::basic_fungible_faucet_library,
+use crate::{
+    account::{
+        auth::{AuthRpoFalcon512Acl, AuthRpoFalcon512AclConfig},
+        components::basic_fungible_faucet_library,
+    },
+    transaction::memory::FAUCET_STORAGE_DATA_SLOT,
 };
 
 // BASIC FUNGIBLE FAUCET ACCOUNT COMPONENT
@@ -219,6 +222,24 @@ impl TryFrom<&Account> for BasicFungibleFaucet {
 
 // FUNGIBLE FAUCET
 // ================================================================================================
+
+pub struct FungibleFaucet;
+
+impl FungibleFaucet {
+    const ISSUANCE_ELEMENT_INDEX: usize = 3;
+
+    pub fn get_issuance_from_slot(slot: &Word) -> Felt {
+        slot[Self::ISSUANCE_ELEMENT_INDEX]
+    }
+
+    pub fn get_issuance_from_account(account: &Account) -> Result<Felt, FungibleFaucetError> {
+        let slot = account
+            .storage()
+            .get_item(FAUCET_STORAGE_DATA_SLOT)
+            .map_err(|_| FungibleFaucetError::InvalidStorageOffset(FAUCET_STORAGE_DATA_SLOT))?;
+        Ok(Self::get_issuance_from_slot(&slot))
+    }
+}
 
 /// Creates a new faucet account with basic fungible faucet interface,
 /// account storage type, specified authentication scheme, and provided meta data (token symbol,

--- a/crates/miden-lib/src/account/faucets/mod.rs
+++ b/crates/miden-lib/src/account/faucets/mod.rs
@@ -223,7 +223,8 @@ impl TryFrom<&Account> for BasicFungibleFaucet {
 // FUNGIBLE FAUCET
 // ================================================================================================
 
-/// Extension trait for fungible faucet accounts. Provides methods to access the fungible faucet account's reserved storage slots.
+/// Extension trait for fungible faucet accounts. Provides methods to access the fungible faucet
+/// account's reserved storage slot.
 pub trait FungibleFaucetExt {
     const ISSUANCE_ELEMENT_INDEX: usize;
     const ISSUANCE_STORAGE_SLOT: u8;

--- a/crates/miden-lib/src/account/faucets/mod.rs
+++ b/crates/miden-lib/src/account/faucets/mod.rs
@@ -233,16 +233,16 @@ pub trait FungibleFaucetExt {
     ///
     /// # Errors
     /// Returns an error if the account is not a fungible faucet account.
-    fn get_issuance(&self) -> Result<Felt, FungibleFaucetError>;
+    fn get_token_issuance(&self) -> Result<Felt, FungibleFaucetError>;
 }
 
 impl FungibleFaucetExt for Account {
     const ISSUANCE_ELEMENT_INDEX: usize = 3;
     const ISSUANCE_STORAGE_SLOT: u8 = FAUCET_STORAGE_DATA_SLOT;
 
-    fn get_issuance(&self) -> Result<Felt, FungibleFaucetError> {
+    fn get_token_issuance(&self) -> Result<Felt, FungibleFaucetError> {
         if self.account_type() != AccountType::FungibleFaucet {
-            return Err(FungibleFaucetError::NonFungigleFaucetAccount);
+            return Err(FungibleFaucetError::NotAFungibleFaucetAccount);
         }
 
         let slot = self
@@ -322,8 +322,8 @@ pub enum FungibleFaucetError {
     InvalidTokenSymbol(#[source] TokenSymbolError),
     #[error("account creation failed")]
     AccountError(#[source] AccountError),
-    #[error("account is not a fungible faucet")]
-    NonFungigleFaucetAccount,
+    #[error("account is not a fungible faucet account")]
+    NotAFungibleFaucetAccount,
 }
 
 // TESTS

--- a/crates/miden-lib/src/account/faucets/mod.rs
+++ b/crates/miden-lib/src/account/faucets/mod.rs
@@ -233,14 +233,14 @@ pub trait FungibleFaucetExt {
     ///
     /// # Errors
     /// Returns an error if the account is not a fungible faucet account.
-    fn get_faucet_issuance(&self) -> Result<Felt, FungibleFaucetError>;
+    fn get_issuance(&self) -> Result<Felt, FungibleFaucetError>;
 }
 
 impl FungibleFaucetExt for Account {
     const ISSUANCE_ELEMENT_INDEX: usize = 3;
     const ISSUANCE_STORAGE_SLOT: u8 = FAUCET_STORAGE_DATA_SLOT;
 
-    fn get_faucet_issuance(&self) -> Result<Felt, FungibleFaucetError> {
+    fn get_issuance(&self) -> Result<Felt, FungibleFaucetError> {
         if self.account_type() != AccountType::FungibleFaucet {
             return Err(FungibleFaucetError::NonFungigleFaucetAccount);
         }

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -144,8 +144,6 @@ pub enum AccountError {
     /// this error type.
     #[error("assumption violated: {0}")]
     AssumptionViolated(String),
-    #[error("account is not a fungible faucet")]
-    NonFungigleFaucetAccount,
 }
 
 // ACCOUNT ID ERROR

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -144,6 +144,8 @@ pub enum AccountError {
     /// this error type.
     #[error("assumption violated: {0}")]
     AssumptionViolated(String),
+    #[error("account is not a fungible faucet")]
+    NonFungigleFaucetAccount,
 }
 
 // ACCOUNT ID ERROR

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -166,7 +166,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     // Check that the faucet reserved slot has been correctly initialized.
     // The already issued amount should be 100.
-    assert_eq!(faucet.get_issuance().unwrap(), Felt::new(100));
+    assert_eq!(faucet.get_token_issuance().unwrap(), Felt::new(100));
 
     // need to create a note with the fungible asset to be burned
     let note_script = "

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -166,7 +166,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     // Check that the faucet reserved slot has been correctly initialized.
     // The already issued amount should be 100.
-    assert_eq!(faucet.get_faucet_issuance().unwrap(), Felt::new(100));
+    assert_eq!(faucet.get_issuance().unwrap(), Felt::new(100));
 
     // need to create a note with the fungible asset to be burned
     let note_script = "

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -1,8 +1,9 @@
 extern crate alloc;
 
 use miden_lib::{
+    account::faucets::FungibleFaucetExt,
     errors::tx_kernel_errors::ERR_FUNGIBLE_ASSET_DISTRIBUTE_WOULD_CAUSE_MAX_SUPPLY_TO_BE_EXCEEDED,
-    transaction::{TransactionKernel, memory::FAUCET_STORAGE_DATA_SLOT},
+    transaction::TransactionKernel,
 };
 use miden_objects::{
     Felt, Word,
@@ -165,7 +166,7 @@ fn prove_faucet_contract_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     // Check that the faucet reserved slot has been correctly initialized.
     // The already issued amount should be 100.
-    assert_eq!(faucet.storage().get_item(FAUCET_STORAGE_DATA_SLOT).unwrap()[3], Felt::new(100));
+    assert_eq!(faucet.get_faucet_issuance().unwrap(), Felt::new(100));
 
     // need to create a note with the fungible asset to be burned
     let note_script = "


### PR DESCRIPTION
This was proposed in https://github.com/0xMiden/miden-faucet/pull/30#discussion_r2238035374

This PR adds a `FungibleFaucetExt` trait that provides methods to access the faucet issuance from the storage.