### PR TITLE
Removed `TransactionScript::compile` & `NoteScript::compile` methods in favor of `ScriptBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
+- Refactored to remove `TransactionScript::compile` & `NoteScript::compile` methods where possible to instead use `ScriptBuilder`. 
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
-- Refactored to remove `TransactionScript::compile` & `NoteScript::compile` methods where possible to instead use `ScriptBuilder` ([#1665](https://github.com/0xMiden/miden-base/pull/1665)).
+- Removed `TransactionScript::compile` & `NoteScript::compile` methods in favor of `ScriptBuilder` ([#1665](https://github.com/0xMiden/miden-base/pull/1665)).
 - Add `FeeParameters` to `BlockHeader` ([#1652](https://github.com/0xMiden/miden-base/pull/1652)).
 - Added `input_note_get_recipient`, `output_note_get_recipient`, `input_note_get_metadata`, `output_note_get_metadata` procedures to the transaction kernel ([#1648](https://github.com/0xMiden/miden-base/pull/1648)).
 - Added `input_notes::get_assets` and `output_notes::get_assets` procedures to `miden` library ([#1648](https://github.com/0xMiden/miden-base/pull/1648)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [BREAKING] Refactor `TransactionAuthenticator` to support arbitrary data signing ([#1616](https://github.com/0xMiden/miden-base/pull/1616)).
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
-- Refactored to remove `TransactionScript::compile` & `NoteScript::compile` methods where possible to instead use `ScriptBuilder`. 
+- Refactored to remove `TransactionScript::compile` & `NoteScript::compile` methods where possible to instead use `ScriptBuilder` ([#1665](https://github.com/0xMiden/miden-base/pull/1665)).
 
 ### Changes
 

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{fs::File, io::Write, path::Path};
 
 use anyhow::Context;
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel, utils::ScriptBuilder};
+use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{
     Felt, FieldElement, Word,
     account::{Account, AccountId, AccountStorageMode, AccountType},

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -117,8 +117,7 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     )
     .unwrap();
 
-    let tx_script_target =
-        ScriptBuilder::new(false).compile_tx_script(DEFAULT_AUTH_SCRIPT).unwrap();
+    let tx_script_target = ScriptBuilder::default().compile_tx_script(DEFAULT_AUTH_SCRIPT).unwrap();
 
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -117,7 +117,7 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     )
     .unwrap();
 
-    let tx_script_target = ScriptBuilder::default().compile_tx_script(DEFAULT_AUTH_SCRIPT).unwrap();
+    let tx_script_target = ScriptBuilder::default().compile_tx_script(DEFAULT_AUTH_SCRIPT)?;
 
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{fs::File, io::Write, path::Path};
 
 use anyhow::Context;
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
+use miden_lib::{note::create_p2id_note, transaction::TransactionKernel, utils::ScriptBuilder};
 use miden_objects::{
     Felt, FieldElement, Word,
     account::{Account, AccountId, AccountStorageMode, AccountType},
@@ -13,7 +13,7 @@ use miden_objects::{
         account_component::IncrNonceAuthComponent,
         account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     },
-    transaction::{TransactionMeasurements, TransactionScript},
+    transaction::TransactionMeasurements,
 };
 use miden_testing::{TransactionContextBuilder, utils::create_p2any_note};
 
@@ -118,7 +118,7 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     .unwrap();
 
     let tx_script_target =
-        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, TransactionKernel::assembler()).unwrap();
+        ScriptBuilder::new(false).compile_tx_script(DEFAULT_AUTH_SCRIPT).unwrap();
 
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{fs::File, io::Write, path::Path};
 
 use anyhow::Context;
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
+use miden_lib::{note::create_p2id_note, transaction::TransactionKernel, utils::ScriptBuilder};
 use miden_objects::{
     Felt, FieldElement, Word,
     account::{Account, AccountId, AccountStorageMode, AccountType},
@@ -13,7 +13,7 @@ use miden_objects::{
         account_component::IncrNonceAuthComponent,
         account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     },
-    transaction::{TransactionMeasurements, TransactionScript},
+    transaction::TransactionMeasurements,
 };
 use miden_testing::{TransactionContextBuilder, utils::create_p2any_note};
 
@@ -117,8 +117,7 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     )
     .unwrap();
 
-    let tx_script_target =
-        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, TransactionKernel::assembler()).unwrap();
+    let tx_script_target = ScriptBuilder::default().compile_tx_script(DEFAULT_AUTH_SCRIPT).unwrap();
 
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])

--- a/bin/bench-tx/src/main.rs
+++ b/bin/bench-tx/src/main.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{fs::File, io::Write, path::Path};
 
 use anyhow::Context;
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel, utils::ScriptBuilder};
+use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
 use miden_objects::{
     Felt, FieldElement, Word,
     account::{Account, AccountId, AccountStorageMode, AccountType},
@@ -13,7 +13,7 @@ use miden_objects::{
         account_component::IncrNonceAuthComponent,
         account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     },
-    transaction::TransactionMeasurements,
+    transaction::{TransactionMeasurements, TransactionScript},
 };
 use miden_testing::{TransactionContextBuilder, utils::create_p2any_note};
 
@@ -117,7 +117,8 @@ pub fn benchmark_p2id() -> anyhow::Result<TransactionMeasurements> {
     )
     .unwrap();
 
-    let tx_script_target = ScriptBuilder::default().compile_tx_script(DEFAULT_AUTH_SCRIPT)?;
+    let tx_script_target =
+        TransactionScript::compile(DEFAULT_AUTH_SCRIPT, TransactionKernel::assembler()).unwrap();
 
     let tx_context = TransactionContextBuilder::new(target_account.clone())
         .extend_input_notes(vec![note])

--- a/crates/miden-lib/src/account/interface/mod.rs
+++ b/crates/miden-lib/src/account/interface/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
 
 use miden_objects::{
-    TransactionScriptError, Word,
+    Word,
     account::{Account, AccountCode, AccountId, AccountIdPrefix, AccountType},
     assembly::mast::{MastForest, MastNode, MastNodeId},
     crypto::dsa::rpo_falcon512,
@@ -16,8 +16,9 @@ use crate::{
         basic_fungible_faucet_library, basic_wallet_library, rpo_falcon_512_library,
         rpo_falcon_512_procedure_acl_library,
     },
+    errors::ScriptBuilderError,
     note::well_known_note::WellKnownNote,
-    transaction::TransactionKernel,
+    utils::ScriptBuilder,
 };
 
 #[cfg(test)]
@@ -213,8 +214,8 @@ impl AccountInterface {
             note_creation_source,
         );
 
-        let assembler = TransactionKernel::assembler().with_debug_mode(in_debug_mode);
-        let tx_script = TransactionScript::compile(script, assembler)
+        let tx_script = ScriptBuilder::new(in_debug_mode)
+            .compile_tx_script(script)
             .map_err(AccountInterfaceError::InvalidTransactionScript)?;
 
         Ok(tx_script)
@@ -397,7 +398,7 @@ pub enum AccountInterfaceError {
     #[error("note created by the basic fungible faucet doesn't contain exactly one asset")]
     FaucetNoteWithoutAsset,
     #[error("invalid transaction script")]
-    InvalidTransactionScript(#[source] TransactionScriptError),
+    InvalidTransactionScript(#[source] ScriptBuilderError),
     #[error("invalid sender account: {0}")]
     InvalidSenderAccount(AccountId),
     #[error("{} interface does not support the generation of the standard send_note script", interface.name())]

--- a/crates/miden-lib/src/account/interface/test.rs
+++ b/crates/miden-lib/src/account/interface/test.rs
@@ -279,8 +279,7 @@ fn test_basic_wallet_custom_notes() {
             end
         end
     ";
-    let note_script =
-        ScriptBuilder::new(false).compile_note_script(compatible_source_code).unwrap();
+    let note_script = ScriptBuilder::default().compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -309,7 +308,7 @@ fn test_basic_wallet_custom_notes() {
         end
     ";
     let note_script =
-        ScriptBuilder::new(false).compile_note_script(incompatible_source_code).unwrap();
+        ScriptBuilder::default().compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -369,8 +368,7 @@ fn test_basic_fungible_faucet_custom_notes() {
             end
         end
     ";
-    let note_script =
-        ScriptBuilder::new(false).compile_note_script(compatible_source_code).unwrap();
+    let note_script = ScriptBuilder::default().compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -401,7 +399,7 @@ fn test_basic_fungible_faucet_custom_notes() {
         end
     ";
     let note_script =
-        ScriptBuilder::new(false).compile_note_script(incompatible_source_code).unwrap();
+        ScriptBuilder::default().compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -483,7 +481,7 @@ fn test_custom_account_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(false)
+    let note_script = ScriptBuilder::default()
         .with_dynamically_linked_library(account_component.library())
         .unwrap()
         .compile_note_script(compatible_source_code)
@@ -510,7 +508,7 @@ fn test_custom_account_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(false)
+    let note_script = ScriptBuilder::default()
         .with_dynamically_linked_library(account_component.library())
         .unwrap()
         .compile_note_script(incompatible_source_code)
@@ -604,7 +602,7 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(false)
+    let note_script = ScriptBuilder::default()
         .with_dynamically_linked_library(custom_component.library())
         .unwrap()
         .compile_note_script(compatible_source_code)
@@ -643,7 +641,7 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(false)
+    let note_script = ScriptBuilder::default()
         .with_dynamically_linked_library(custom_component.library())
         .unwrap()
         .compile_note_script(incompatible_source_code)

--- a/crates/miden-lib/src/account/interface/test.rs
+++ b/crates/miden-lib/src/account/interface/test.rs
@@ -279,7 +279,8 @@ fn test_basic_wallet_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(true).compile_note_script(compatible_source_code).unwrap();
+    let note_script =
+        ScriptBuilder::new(false).compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -308,7 +309,7 @@ fn test_basic_wallet_custom_notes() {
         end
     ";
     let note_script =
-        ScriptBuilder::new(true).compile_note_script(incompatible_source_code).unwrap();
+        ScriptBuilder::new(false).compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -368,7 +369,8 @@ fn test_basic_fungible_faucet_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(true).compile_note_script(compatible_source_code).unwrap();
+    let note_script =
+        ScriptBuilder::new(false).compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -399,7 +401,7 @@ fn test_basic_fungible_faucet_custom_notes() {
         end
     ";
     let note_script =
-        ScriptBuilder::new(true).compile_note_script(incompatible_source_code).unwrap();
+        ScriptBuilder::new(false).compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -602,7 +604,7 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(true)
+    let note_script = ScriptBuilder::new(false)
         .with_dynamically_linked_library(custom_component.library())
         .unwrap()
         .compile_note_script(compatible_source_code)
@@ -641,7 +643,7 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = ScriptBuilder::new(true)
+    let note_script = ScriptBuilder::new(false)
         .with_dynamically_linked_library(custom_component.library())
         .unwrap()
         .compile_note_script(incompatible_source_code)

--- a/crates/miden-lib/src/account/interface/test.rs
+++ b/crates/miden-lib/src/account/interface/test.rs
@@ -11,8 +11,8 @@ use miden_objects::{
         rand::{FeltRng, RpoRandomCoin},
     },
     note::{
-        Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteScript,
-        NoteTag, NoteType,
+        Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteTag,
+        NoteType,
     },
     testing::account_id::{
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
@@ -29,6 +29,7 @@ use crate::{
     },
     note::{create_p2id_note, create_p2ide_note, create_swap_note},
     transaction::TransactionKernel,
+    utils::ScriptBuilder,
 };
 
 // DEFAULT NOTES
@@ -278,9 +279,7 @@ fn test_basic_wallet_custom_notes() {
             end
         end
     ";
-    let note_script =
-        NoteScript::compile(compatible_source_code, TransactionKernel::testing_assembler())
-            .unwrap();
+    let note_script = ScriptBuilder::new(true).compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -309,8 +308,7 @@ fn test_basic_wallet_custom_notes() {
         end
     ";
     let note_script =
-        NoteScript::compile(incompatible_source_code, TransactionKernel::testing_assembler())
-            .unwrap();
+        ScriptBuilder::new(true).compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -370,9 +368,7 @@ fn test_basic_fungible_faucet_custom_notes() {
             end
         end
     ";
-    let note_script =
-        NoteScript::compile(compatible_source_code, TransactionKernel::testing_assembler())
-            .unwrap();
+    let note_script = ScriptBuilder::new(true).compile_note_script(compatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -403,8 +399,7 @@ fn test_basic_fungible_faucet_custom_notes() {
         end
     ";
     let note_script =
-        NoteScript::compile(incompatible_source_code, TransactionKernel::testing_assembler())
-            .unwrap();
+        ScriptBuilder::new(true).compile_note_script(incompatible_source_code).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -486,13 +481,11 @@ fn test_custom_account_custom_notes() {
             end
         end
     ";
-    let note_script = NoteScript::compile(
-        compatible_source_code,
-        TransactionKernel::testing_assembler()
-            .with_dynamic_library(account_component.library())
-            .unwrap(),
-    )
-    .unwrap();
+    let note_script = ScriptBuilder::new(false)
+        .with_dynamically_linked_library(account_component.library())
+        .unwrap()
+        .compile_note_script(compatible_source_code)
+        .unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -515,13 +508,11 @@ fn test_custom_account_custom_notes() {
             end
         end
     ";
-    let note_script = NoteScript::compile(
-        incompatible_source_code,
-        TransactionKernel::testing_assembler()
-            .with_dynamic_library(account_component.library())
-            .unwrap(),
-    )
-    .unwrap();
+    let note_script = ScriptBuilder::new(false)
+        .with_dynamically_linked_library(account_component.library())
+        .unwrap()
+        .compile_note_script(incompatible_source_code)
+        .unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault, metadata, recipient);
     assert_eq!(
@@ -611,13 +602,11 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = NoteScript::compile(
-        compatible_source_code,
-        TransactionKernel::testing_assembler()
-            .with_dynamic_library(custom_component.library())
-            .unwrap(),
-    )
-    .unwrap();
+    let note_script = ScriptBuilder::new(true)
+        .with_dynamically_linked_library(custom_component.library())
+        .unwrap()
+        .compile_note_script(compatible_source_code)
+        .unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let compatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(
@@ -652,13 +641,11 @@ fn test_custom_account_multiple_components_custom_notes() {
             end
         end
     ";
-    let note_script = NoteScript::compile(
-        incompatible_source_code,
-        TransactionKernel::testing_assembler()
-            .with_dynamic_library(custom_component.library())
-            .unwrap(),
-    )
-    .unwrap();
+    let note_script = ScriptBuilder::new(true)
+        .with_dynamically_linked_library(custom_component.library())
+        .unwrap()
+        .compile_note_script(incompatible_source_code)
+        .unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
     let incompatible_custom_note = Note::new(vault.clone(), metadata, recipient);
     assert_eq!(

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -273,6 +273,32 @@ impl ScriptBuilder {
         })?;
         Ok(NoteScript::new(program))
     }
+
+    // TESTING CONVENIENCE FUNCTIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a ScriptBuilder with the kernel library for testing scenarios.
+    ///
+    /// This is equivalent to using `TransactionKernel::testing_assembler()` and is intended
+    /// to replace scripts that were built with that assembler.
+    #[cfg(any(feature = "testing", test))]
+    pub fn with_kernel_library() -> Result<Self, ScriptBuilderError> {
+        let kernel_library = TransactionKernel::kernel_as_library();
+        Self::default().with_dynamically_linked_library(&kernel_library)
+    }
+
+    /// Creates a ScriptBuilder with both kernel and mock account libraries for testing scenarios.
+    ///
+    /// This is equivalent to using `TransactionKernel::testing_assembler_with_mock_account()`
+    /// and is intended to replace scripts that were built with that assembler.
+    #[cfg(any(feature = "testing", test))]
+    pub fn with_mock_account_library() -> Result<Self, ScriptBuilderError> {
+        let builder = Self::with_kernel_library()?;
+        let mock_account_library =
+            miden_objects::account::AccountCode::mock_library(builder.assembler.clone());
+
+        builder.with_dynamically_linked_library(&mock_account_library)
+    }
 }
 
 impl Default for ScriptBuilder {

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -55,7 +55,7 @@ use crate::{errors::ScriptBuilderError, transaction::TransactionKernel};
 /// # // Create sample libraries for the example
 /// # let my_lib = StdLibrary::default().into(); // Convert StdLibrary to Library
 /// # let fpi_lib = StdLibrary::default().into();
-/// let script = ScriptBuilder::new(true)
+/// let script = ScriptBuilder::new(false)
 ///     .with_linked_module("my::module", module_code).context("failed to link module")?
 ///     .with_statically_linked_library(&my_lib).context("failed to link static library")?
 ///     .with_dynamically_linked_library(&fpi_lib).context("failed to link dynamic library")?  // For FPI calls
@@ -292,13 +292,13 @@ mod tests {
 
     #[test]
     fn test_script_builder_new() {
-        let _builder = ScriptBuilder::new(true);
+        let _builder = ScriptBuilder::new(false);
         // Test that the builder can be created successfully
     }
 
     #[test]
     fn test_script_builder_basic_script_compilation() -> anyhow::Result<()> {
-        let builder = ScriptBuilder::new(true);
+        let builder = ScriptBuilder::new(false);
         builder
             .compile_tx_script("begin nop end")
             .context("failed to compile basic tx script")?;
@@ -329,7 +329,7 @@ mod tests {
 
         let library_path = "external_contract::counter_contract";
 
-        let mut builder_with_lib = ScriptBuilder::new(true);
+        let mut builder_with_lib = ScriptBuilder::new(false);
         builder_with_lib
             .link_module(library_path, account_code)
             .context("failed to link module")?;
@@ -365,7 +365,7 @@ mod tests {
         let library_path = "external_contract::counter_contract";
 
         // Test single library
-        let mut builder_with_lib = ScriptBuilder::new(true);
+        let mut builder_with_lib = ScriptBuilder::new(false);
         builder_with_lib
             .link_module(library_path, account_code)
             .context("failed to link module")?;
@@ -374,7 +374,7 @@ mod tests {
             .context("failed to compile tx script")?;
 
         // Test multiple libraries
-        let mut builder_with_libs = ScriptBuilder::new(true);
+        let mut builder_with_libs = ScriptBuilder::new(false);
         builder_with_libs
             .link_module(library_path, account_code)
             .context("failed to link first module")?;
@@ -411,7 +411,7 @@ mod tests {
         ";
 
         // Test builder-style chaining with modules
-        let builder = ScriptBuilder::new(true)
+        let builder = ScriptBuilder::new(false)
             .with_linked_module("external_contract::counter_contract", account_code)
             .context("failed to link module")?;
 
@@ -426,7 +426,7 @@ mod tests {
             "use.test::lib1 use.test::lib2 begin exec.lib1::test1 exec.lib2::test2 end";
 
         // Test chaining multiple modules
-        let builder = ScriptBuilder::new(true)
+        let builder = ScriptBuilder::new(false)
             .with_linked_module("test::lib1", "export.test1 push.1 add end")
             .context("failed to link first module")?
             .with_linked_module("test::lib2", "export.test2 push.2 add end")

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -55,7 +55,7 @@ use crate::{errors::ScriptBuilderError, transaction::TransactionKernel};
 /// # // Create sample libraries for the example
 /// # let my_lib = StdLibrary::default().into(); // Convert StdLibrary to Library
 /// # let fpi_lib = StdLibrary::default().into();
-/// let script = ScriptBuilder::new(false)
+/// let script = ScriptBuilder::default()
 ///     .with_linked_module("my::module", module_code).context("failed to link module")?
 ///     .with_statically_linked_library(&my_lib).context("failed to link static library")?
 ///     .with_dynamically_linked_library(&fpi_lib).context("failed to link dynamic library")?  // For FPI calls
@@ -292,13 +292,13 @@ mod tests {
 
     #[test]
     fn test_script_builder_new() {
-        let _builder = ScriptBuilder::new(false);
+        let _builder = ScriptBuilder::default();
         // Test that the builder can be created successfully
     }
 
     #[test]
     fn test_script_builder_basic_script_compilation() -> anyhow::Result<()> {
-        let builder = ScriptBuilder::new(false);
+        let builder = ScriptBuilder::default();
         builder
             .compile_tx_script("begin nop end")
             .context("failed to compile basic tx script")?;
@@ -329,7 +329,7 @@ mod tests {
 
         let library_path = "external_contract::counter_contract";
 
-        let mut builder_with_lib = ScriptBuilder::new(false);
+        let mut builder_with_lib = ScriptBuilder::default();
         builder_with_lib
             .link_module(library_path, account_code)
             .context("failed to link module")?;
@@ -365,7 +365,7 @@ mod tests {
         let library_path = "external_contract::counter_contract";
 
         // Test single library
-        let mut builder_with_lib = ScriptBuilder::new(false);
+        let mut builder_with_lib = ScriptBuilder::default();
         builder_with_lib
             .link_module(library_path, account_code)
             .context("failed to link module")?;
@@ -374,7 +374,7 @@ mod tests {
             .context("failed to compile tx script")?;
 
         // Test multiple libraries
-        let mut builder_with_libs = ScriptBuilder::new(false);
+        let mut builder_with_libs = ScriptBuilder::default();
         builder_with_libs
             .link_module(library_path, account_code)
             .context("failed to link first module")?;
@@ -411,7 +411,7 @@ mod tests {
         ";
 
         // Test builder-style chaining with modules
-        let builder = ScriptBuilder::new(false)
+        let builder = ScriptBuilder::default()
             .with_linked_module("external_contract::counter_contract", account_code)
             .context("failed to link module")?;
 
@@ -426,7 +426,7 @@ mod tests {
             "use.test::lib1 use.test::lib2 begin exec.lib1::test1 exec.lib2::test2 end";
 
         // Test chaining multiple modules
-        let builder = ScriptBuilder::new(false)
+        let builder = ScriptBuilder::default()
             .with_linked_module("test::lib1", "export.test1 push.1 add end")
             .context("failed to link first module")?
             .with_linked_module("test::lib2", "export.test2 push.2 add end")

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -246,9 +246,10 @@ impl ScriptBuilder {
     ) -> Result<TransactionScript, ScriptBuilderError> {
         let assembler = self.assembler;
 
-        TransactionScript::compile(tx_script.as_ref(), assembler).map_err(|err| {
-            ScriptBuilderError::build_error_with_source("failed to compile transaction script", err)
-        })
+        let program = assembler.assemble_program(tx_script.as_ref()).map_err(|err| {
+            ScriptBuilderError::build_error_with_report("failed to compile transaction script", err)
+        })?;
+        Ok(TransactionScript::new(program))
     }
 
     /// Compiles a note script with the provided program code.
@@ -267,9 +268,10 @@ impl ScriptBuilder {
     ) -> Result<NoteScript, ScriptBuilderError> {
         let assembler = self.assembler;
 
-        NoteScript::compile(program.as_ref(), assembler).map_err(|err| {
-            ScriptBuilderError::build_error_with_source("failed to compile note script", err)
-        })
+        let program = assembler.assemble_program(program.as_ref()).map_err(|err| {
+            ScriptBuilderError::build_error_with_report("failed to compile note script", err)
+        })?;
+        Ok(NoteScript::new(program))
     }
 }
 

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -4,12 +4,11 @@ use alloc::{
     vec::Vec,
 };
 
-use assembly::{Assembler, Parse};
 use miden_crypto::merkle::InnerNodeInfo;
 
 use super::{AccountInputs, Felt, Word};
 use crate::{
-    EMPTY_WORD, MastForest, MastNodeId, TransactionScriptError,
+    EMPTY_WORD, MastForest, MastNodeId,
     note::{NoteId, NoteRecipient},
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     vm::{AdviceInputs, AdviceMap, Program},
@@ -272,21 +271,6 @@ impl TransactionScript {
     /// Returns a new [TransactionScript] instantiated with the provided code.
     pub fn new(code: Program) -> Self {
         Self::from_parts(code.mast_forest().clone(), code.entrypoint())
-    }
-
-    /// Returns a new [TransactionScript] compiled from the provided source code using the specified
-    /// assembler.
-    ///
-    /// # Errors
-    /// Returns an error if the compilation of the provided source code fails.
-    pub fn compile(
-        source_code: impl Parse,
-        assembler: Assembler,
-    ) -> Result<Self, TransactionScriptError> {
-        let program = assembler
-            .assemble_program(source_code)
-            .map_err(TransactionScriptError::AssemblyError)?;
-        Ok(Self::new(program))
     }
 
     /// Returns a new [TransactionScript] instantiated from the provided MAST forest and entrypoint.

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -178,7 +178,7 @@ fn update_expiration_tx_script(expiration_delta: u16) -> TransactionScript {
         "
     );
 
-    ScriptBuilder::new(false).compile_tx_script(code).unwrap()
+    ScriptBuilder::default().compile_tx_script(code).unwrap()
 }
 
 pub fn generate_batch(chain: &mut MockChain, txs: Vec<ProvenTransaction>) -> ProvenBatch {

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, vec, vec::Vec};
 
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
+use miden_lib::{note::create_p2id_note, transaction::TransactionKernel, utils::ScriptBuilder};
 use miden_objects::{
     Felt, ONE, Word, ZERO,
     account::{Account, AccountId},
@@ -178,8 +178,7 @@ fn update_expiration_tx_script(expiration_delta: u16) -> TransactionScript {
         "
     );
 
-    TransactionScript::compile(code, TransactionKernel::testing_assembler_with_mock_account())
-        .unwrap()
+    ScriptBuilder::new(false).compile_tx_script(code).unwrap()
 }
 
 pub fn generate_batch(chain: &mut MockChain, txs: Vec<ProvenTransaction>) -> ProvenBatch {

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use std::{collections::BTreeMap, string::String};
 
 use anyhow::Context;
-use miden_lib::transaction::TransactionKernel;
+use miden_lib::{transaction::TransactionKernel, utils::ScriptBuilder};
 use miden_objects::{
     EMPTY_WORD, Felt, LexicographicWord, Word, ZERO,
     account::{AccountBuilder, AccountId, AccountStorage, AccountType, StorageMap, StorageSlot},
@@ -700,10 +700,7 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
         UPDATED_MAP_KEY = word_to_masm_push_string(&updated_map_key),
     );
 
-    let tx_script = TransactionScript::compile(
-        tx_script_src,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_src)?;
 
     // Create the input note that carries the assets that we will assert later
     let input_note = {
@@ -822,11 +819,9 @@ fn compile_tx_script(code: impl AsRef<str>) -> anyhow::Result<TransactionScript>
         code = code.as_ref()
     );
 
-    TransactionScript::compile(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account().with_debug_mode(true),
-    )
-    .context("failed to compile tx script")
+    ScriptBuilder::with_mock_account_library()?
+        .compile_tx_script(&code)
+        .context("failed to compile tx script")
 }
 
 const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -103,7 +103,7 @@ fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
         end
     ";
 
-    let tx_script = ScriptBuilder::new(false)
+    let tx_script = ScriptBuilder::default()
         .with_dynamically_linked_library(auth_component.library())
         .unwrap()
         .compile_tx_script(tx_script_source)?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -3,6 +3,7 @@ use miden_lib::{
     account::wallets::BasicWallet,
     errors::{MasmError, note_script_errors::ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT},
     transaction::TransactionKernel,
+    utils::ScriptBuilder,
 };
 use miden_objects::{
     account::{Account, AccountBuilder},
@@ -102,12 +103,10 @@ fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
         end
     ";
 
-    let tx_script = miden_objects::transaction::TransactionScript::compile(
-        tx_script_source,
-        TransactionKernel::testing_assembler()
-            .with_dynamic_library(auth_component.library())
-            .unwrap(),
-    )?;
+    let tx_script = ScriptBuilder::new(false)
+        .with_dynamically_linked_library(auth_component.library())
+        .unwrap()
+        .compile_tx_script(tx_script_source)?;
 
     let tx_context = TransactionContextBuilder::new(account).tx_script(tx_script).build()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -104,8 +104,7 @@ fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
     ";
 
     let tx_script = ScriptBuilder::default()
-        .with_dynamically_linked_library(auth_component.library())
-        .unwrap()
+        .with_dynamically_linked_library(auth_component.library())?
         .compile_tx_script(tx_script_source)?;
 
     let tx_context = TransactionContextBuilder::new(account).tx_script(tx_script).build()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -618,7 +618,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         map_key = STORAGE_LEAVES_2[0].0,
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
         .get_foreign_account_inputs(foreign_account.id())
@@ -837,7 +837,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         first_account_foreign_proc_hash = first_foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(native_account.id(), &[], &[])
@@ -1007,7 +1007,7 @@ fn test_nested_fpi_stack_overflow() {
 
 
 
-                let tx_script = ScriptBuilder::new(false).compile_tx_script(code).unwrap();
+                let tx_script = ScriptBuilder::default().compile_tx_script(code).unwrap();
 
             let tx_context = mock_chain
                 .build_tx_context(native_account.id(), &[], &[])
@@ -1124,7 +1124,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         first_account_foreign_proc_hash = foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(native_account.id(), &[], &[])

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -14,6 +14,7 @@ use miden_lib::{
             NUM_ACCT_PROCEDURES_OFFSET, NUM_ACCT_STORAGE_SLOTS_OFFSET,
         },
     },
+    utils::ScriptBuilder,
 };
 use miden_objects::{
     FieldElement,
@@ -22,7 +23,7 @@ use miden_objects::{
         AccountStorageMode, PartialAccount, StorageSlot,
     },
     testing::{account_component::AccountMockComponent, storage::STORAGE_LEAVES_2},
-    transaction::{AccountInputs, TransactionScript},
+    transaction::AccountInputs,
 };
 use miden_tx::TransactionExecutorError;
 use rand::{Rng, SeedableRng};
@@ -617,7 +618,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         map_key = STORAGE_LEAVES_2[0].0,
     );
 
-    let tx_script = TransactionScript::compile(code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
         .get_foreign_account_inputs(foreign_account.id())
@@ -836,10 +837,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         first_account_foreign_proc_hash = first_foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let tx_script = TransactionScript::compile(
-        code,
-        TransactionKernel::testing_assembler().with_debug_mode(true),
-    )?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(native_account.id(), &[], &[])
@@ -1007,11 +1005,9 @@ fn test_nested_fpi_stack_overflow() {
                 foreign_suffix = foreign_accounts.last().unwrap().id().suffix(),
             );
 
-            let tx_script = TransactionScript::compile(
-                code,
-                TransactionKernel::testing_assembler().with_debug_mode(true),
-            )
-            .unwrap();
+
+
+                let tx_script = ScriptBuilder::new(false).compile_tx_script(code).unwrap();
 
             let tx_context = mock_chain
                 .build_tx_context(native_account.id(), &[], &[])
@@ -1128,10 +1124,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         first_account_foreign_proc_hash = foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let tx_script = TransactionScript::compile(
-        code,
-        TransactionKernel::testing_assembler().with_debug_mode(true),
-    )?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(native_account.id(), &[], &[])

--- a/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
-use miden_lib::transaction::TransactionKernel;
-use miden_objects::{Word, note::Note, transaction::TransactionScript};
+use miden_lib::utils::ScriptBuilder;
+use miden_objects::{Word, note::Note};
 
 use super::{TestSetup, setup_test, word_to_masm_push_string};
 use crate::TxContextInput;
@@ -76,7 +76,7 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         ),
     );
 
-    let tx_script = TransactionScript::compile(code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(
@@ -134,7 +134,7 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         METADATA = word_to_masm_push_string(&p2id_note_1_asset.metadata().into()),
     );
 
-    let tx_script = TransactionScript::compile(code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[p2id_note_1_asset])?
@@ -225,7 +225,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         check_note_2 = check_assets_code(2, 8, &p2id_note_2_assets),
     );
 
-    let tx_script = TransactionScript::compile(code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -8,6 +8,7 @@ use miden_lib::{
     },
     note::create_p2id_note,
     transaction::{TransactionKernel, memory::CURRENT_INPUT_NOTE_PTR},
+    utils::ScriptBuilder,
 };
 use miden_objects::{
     EMPTY_WORD, FieldElement, ONE, WORD_SIZE, Word,
@@ -20,7 +21,7 @@ use miden_objects::{
     },
     note::{
         Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteInputs, NoteMetadata,
-        NoteRecipient, NoteScript, NoteTag, NoteType,
+        NoteRecipient, NoteTag, NoteType,
     },
     testing::{
         account_id::{
@@ -31,7 +32,7 @@ use miden_objects::{
         },
         note::NoteBuilder,
     },
-    transaction::{AccountInputs, OutputNote, TransactionArgs, TransactionScript},
+    transaction::{AccountInputs, OutputNote, TransactionArgs},
 };
 use miden_tx::TransactionExecutorError;
 use rand::SeedableRng;
@@ -385,7 +386,7 @@ fn test_input_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_1 = p2id_note_2.assets().num_assets(),
     );
 
-    let tx_script = TransactionScript::compile(code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::new(true).compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(
@@ -540,8 +541,7 @@ fn test_output_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_2 = output_note_2.assets().num_assets(),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -665,7 +665,8 @@ fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
     )
     .context("failed to create metadata")?;
     let vault = NoteAssets::new(vec![]).context("failed to create input note assets")?;
-    let note_script = NoteScript::compile("begin nop end", TransactionKernel::assembler())
+    let note_script = ScriptBuilder::new(false)
+        .compile_note_script("begin nop end")
         .context("failed to compile note script")?;
 
     // create a recipient with note inputs, which number divides by 8. For simplicity create 8 input
@@ -1203,7 +1204,7 @@ fn test_public_key_as_note_input() -> anyhow::Result<()> {
         Default::default(),
     )?;
     let vault = NoteAssets::new(vec![])?;
-    let note_script = NoteScript::compile("begin nop end", TransactionKernel::testing_assembler())?;
+    let note_script = ScriptBuilder::new(true).compile_note_script("begin nop end")?;
     let recipient =
         NoteRecipient::new(serial_num, note_script, NoteInputs::new(public_key_value.to_vec())?);
     let note_with_pub_key = Note::new(vault.clone(), metadata, recipient);

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -386,7 +386,7 @@ fn test_input_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_1 = p2id_note_2.assets().num_assets(),
     );
 
-    let tx_script = ScriptBuilder::new(true).compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(
@@ -541,7 +541,7 @@ fn test_output_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_2 = output_note_2.assets().num_assets(),
     );
 
-    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -1204,7 +1204,7 @@ fn test_public_key_as_note_input() -> anyhow::Result<()> {
         Default::default(),
     )?;
     let vault = NoteAssets::new(vec![])?;
-    let note_script = ScriptBuilder::new(true).compile_note_script("begin nop end")?;
+    let note_script = ScriptBuilder::new(false).compile_note_script("begin nop end")?;
     let recipient =
         NoteRecipient::new(serial_num, note_script, NoteInputs::new(public_key_value.to_vec())?);
     let note_with_pub_key = Note::new(vault.clone(), metadata, recipient);

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -386,7 +386,7 @@ fn test_input_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_1 = p2id_note_2.assets().num_assets(),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(
@@ -541,7 +541,7 @@ fn test_output_notes_get_asset_info() -> anyhow::Result<()> {
         assets_number_2 = output_note_2.assets().num_assets(),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -665,7 +665,7 @@ fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
     )
     .context("failed to create metadata")?;
     let vault = NoteAssets::new(vec![]).context("failed to create input note assets")?;
-    let note_script = ScriptBuilder::new(false)
+    let note_script = ScriptBuilder::default()
         .compile_note_script("begin nop end")
         .context("failed to compile note script")?;
 
@@ -1204,7 +1204,7 @@ fn test_public_key_as_note_input() -> anyhow::Result<()> {
         Default::default(),
     )?;
     let vault = NoteAssets::new(vec![])?;
-    let note_script = ScriptBuilder::new(false).compile_note_script("begin nop end")?;
+    let note_script = ScriptBuilder::default().compile_note_script("begin nop end")?;
     let recipient =
         NoteRecipient::new(serial_num, note_script, NoteInputs::new(public_key_value.to_vec())?);
     let note_with_pub_key = Note::new(vault.clone(), metadata, recipient);

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -1,6 +1,6 @@
 use alloc::string::String;
 
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
+use miden_lib::{note::create_p2id_note, utils::ScriptBuilder};
 use miden_objects::{
     Word,
     account::AccountId,
@@ -11,7 +11,7 @@ use miden_objects::{
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
     },
-    transaction::{OutputNote, TransactionScript},
+    transaction::OutputNote,
 };
 
 use super::{Felt, TestSetup, setup_test, word_to_masm_push_string};
@@ -156,8 +156,7 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         assets_number_1 = output_note_1.assets().num_assets(),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -230,8 +229,7 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         METADATA = word_to_masm_push_string(&output_note.metadata().into()),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -334,8 +332,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         check_note_2 = check_assets_code(2, 8, &p2id_note_2_assets),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1417,7 +1417,7 @@ fn test_tx_script_inputs() -> anyhow::Result<()> {
         value = word_to_masm_push_string(&tx_script_input_value)
     );
 
-    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src).unwrap();
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -16,7 +16,7 @@ use miden_lib::{
             OUTPUT_NOTE_METADATA_OFFSET, OUTPUT_NOTE_RECIPIENT_OFFSET, OUTPUT_NOTE_SECTION_OFFSET,
         },
     },
-    utils::word_to_masm_push_string,
+    utils::{ScriptBuilder, word_to_masm_push_string},
 };
 use miden_objects::{
     FieldElement, Hasher, Word,
@@ -29,7 +29,7 @@ use miden_objects::{
     block::BlockNumber,
     note::{
         Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteHeader, NoteId, NoteInputs,
-        NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType,
+        NoteMetadata, NoteRecipient, NoteTag, NoteType,
     },
     testing::{
         account_component::IncrNonceAuthComponent,
@@ -42,9 +42,7 @@ use miden_objects::{
         constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA, NON_FUNGIBLE_ASSET_DATA_2},
         note::DEFAULT_NOTE_CODE,
     },
-    transaction::{
-        InputNotes, OutputNote, OutputNotes, TransactionArgs, TransactionScript, TransactionSummary,
-    },
+    transaction::{InputNotes, OutputNote, OutputNotes, TransactionArgs, TransactionSummary},
 };
 use miden_tx::{
     AccountProcedureIndexMap, ExecutionOptions, ScriptMastForestStore, TransactionExecutor,
@@ -1024,8 +1022,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 2 which is public
     let serial_num_2 = Word::from([1, 2, 3, 4u32]);
-    let note_script_2 =
-        NoteScript::compile(DEFAULT_NOTE_CODE, TransactionKernel::testing_assembler())?;
+    let note_script_2 = ScriptBuilder::new(true).compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_2 = NoteInputs::new(vec![ONE])?;
     let metadata_2 =
         NoteMetadata::new(account_id, note_type2, tag2, NoteExecutionHint::none(), aux2)?;
@@ -1035,8 +1032,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 3 which is public
     let serial_num_3 = Word::from([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
-    let note_script_3 =
-        NoteScript::compile(DEFAULT_NOTE_CODE, TransactionKernel::testing_assembler())?;
+    let note_script_3 = ScriptBuilder::new(true).compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_3 = NoteInputs::new(vec![ONE, Felt::new(2)])?;
     let metadata_3 = NoteMetadata::new(
         account_id,
@@ -1151,10 +1147,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
         EXECUTION_HINT_3 = Felt::from(NoteExecutionHint::on_block_slot(11, 22, 33)),
     );
 
-    let tx_script = TransactionScript::compile(
-        tx_script_src,
-        TransactionKernel::testing_assembler_with_mock_account().with_debug_mode(true),
-    )?;
+    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_src)?;
 
     // expected delta
     // --------------------------------------------------------------------------------------------
@@ -1373,8 +1366,7 @@ fn execute_tx_view_script() -> anyhow::Result<()> {
     end
     ";
 
-    let tx_script = TransactionScript::compile(source, assembler)?;
-
+    let tx_script = miden_objects::transaction::TransactionScript::compile(source, assembler)?;
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script.clone())
         .build()?;
@@ -1425,8 +1417,7 @@ fn test_tx_script_inputs() -> anyhow::Result<()> {
         value = word_to_masm_push_string(&tx_script_input_value)
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler()).unwrap();
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src).unwrap();
 
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
@@ -1464,9 +1455,9 @@ fn test_tx_script_args() -> anyhow::Result<()> {
             push.5.6.7.8 assert_eqw.err="obtained advice map value doesn't match the expected one"
         end"#;
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())
-            .context("failed to compile transaction script")?;
+    let tx_script = ScriptBuilder::new(false)
+        .compile_tx_script(tx_script_src)
+        .context("failed to compile transaction script")?;
 
     // extend the advice map with the entry that is accessed using the provided transaction script
     // argument
@@ -1532,7 +1523,8 @@ fn inputs_created_correctly() -> anyhow::Result<()> {
         assert_adv_map_proc_root =
             component.library().get_procedure_root_by_name("$anon::assert_adv_map").unwrap()
     );
-    let tx_script = TransactionScript::compile(script, TransactionKernel::assembler())?;
+
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(script)?;
 
     assert!(tx_script.mast().advice_map().get(&Word::try_from([1u64, 2, 3, 4])?).is_some());
     assert!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1022,7 +1022,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 2 which is public
     let serial_num_2 = Word::from([1, 2, 3, 4u32]);
-    let note_script_2 = ScriptBuilder::new(true).compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_2 = ScriptBuilder::new(false).compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_2 = NoteInputs::new(vec![ONE])?;
     let metadata_2 =
         NoteMetadata::new(account_id, note_type2, tag2, NoteExecutionHint::none(), aux2)?;
@@ -1032,7 +1032,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 3 which is public
     let serial_num_3 = Word::from([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
-    let note_script_3 = ScriptBuilder::new(true).compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_3 = ScriptBuilder::new(false).compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_3 = NoteInputs::new(vec![ONE, Felt::new(2)])?;
     let metadata_3 = NoteMetadata::new(
         account_id,
@@ -1147,7 +1147,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
         EXECUTION_HINT_3 = Felt::from(NoteExecutionHint::on_block_slot(11, 22, 33)),
     );
 
-    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
 
     // expected delta
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1022,7 +1022,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 2 which is public
     let serial_num_2 = Word::from([1, 2, 3, 4u32]);
-    let note_script_2 = ScriptBuilder::new(false).compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_2 = ScriptBuilder::default().compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_2 = NoteInputs::new(vec![ONE])?;
     let metadata_2 =
         NoteMetadata::new(account_id, note_type2, tag2, NoteExecutionHint::none(), aux2)?;
@@ -1032,7 +1032,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 3 which is public
     let serial_num_3 = Word::from([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
-    let note_script_3 = ScriptBuilder::new(false).compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_3 = ScriptBuilder::default().compile_note_script(DEFAULT_NOTE_CODE)?;
     let inputs_3 = NoteInputs::new(vec![ONE, Felt::new(2)])?;
     let metadata_3 = NoteMetadata::new(
         account_id,
@@ -1147,7 +1147,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
         EXECUTION_HINT_3 = Felt::from(NoteExecutionHint::on_block_slot(11, 22, 33)),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     // expected delta
     // --------------------------------------------------------------------------------------------
@@ -1417,7 +1417,7 @@ fn test_tx_script_inputs() -> anyhow::Result<()> {
         value = word_to_masm_push_string(&tx_script_input_value)
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src).unwrap();
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src).unwrap();
 
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
@@ -1455,7 +1455,7 @@ fn test_tx_script_args() -> anyhow::Result<()> {
             push.5.6.7.8 assert_eqw.err="obtained advice map value doesn't match the expected one"
         end"#;
 
-    let tx_script = ScriptBuilder::new(false)
+    let tx_script = ScriptBuilder::default()
         .compile_tx_script(tx_script_src)
         .context("failed to compile transaction script")?;
 
@@ -1524,7 +1524,7 @@ fn inputs_created_correctly() -> anyhow::Result<()> {
             component.library().get_procedure_root_by_name("$anon::assert_adv_map").unwrap()
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(script)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(script)?;
 
     assert!(tx_script.mast().advice_map().get(&Word::try_from([1u64, 2, 3, 4])?).is_some());
     assert!(

--- a/crates/miden-testing/tests/auth/rpo_falcon_procedure_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_procedure_acl.rs
@@ -1,5 +1,8 @@
 use assert_matches::assert_matches;
-use miden_lib::transaction::{TransactionKernel, TransactionKernelError};
+use miden_lib::{
+    transaction::{TransactionKernel, TransactionKernelError},
+    utils::ScriptBuilder,
+};
 use miden_objects::{
     Felt, FieldElement, Word,
     account::{
@@ -9,7 +12,7 @@ use miden_objects::{
     testing::{
         account_component::AccountMockComponent, account_id::ACCOUNT_ID_SENDER, note::NoteBuilder,
     },
-    transaction::{OutputNote, TransactionScript},
+    transaction::OutputNote,
 };
 use miden_testing::{Auth, MockChain};
 use miden_tx::TransactionExecutorError;
@@ -130,20 +133,14 @@ fn test_rpo_falcon_procedure_acl() -> anyhow::Result<()> {
         end
         "#;
 
-    let tx_script_trigger_1 = TransactionScript::compile(
-        tx_script_with_trigger_1,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script_trigger_1 =
+        ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_with_trigger_1)?;
 
-    let tx_script_trigger_2 = TransactionScript::compile(
-        tx_script_with_trigger_2,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script_trigger_2 =
+        ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_with_trigger_2)?;
 
-    let tx_script_no_trigger = TransactionScript::compile(
-        TX_SCRIPT_NO_TRIGGER,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script_no_trigger =
+        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test 1: Transaction WITH authenticator calling trigger procedure 1 (should succeed)
     let tx_context_with_auth_1 = mock_chain
@@ -210,10 +207,8 @@ fn test_rpo_falcon_procedure_acl_with_allow_unauthorized_output_notes() -> anyho
     // [2, 1, 1, 0]
     assert_eq!(slot_1, Word::from([2u32, 1, 1, 0]));
 
-    let tx_script_no_trigger = TransactionScript::compile(
-        TX_SCRIPT_NO_TRIGGER,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script_no_trigger =
+        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test: Transaction WITHOUT authenticator calling non-trigger procedure (should succeed)
     // This tests that when allow_unauthorized_output_notes=true, transactions without
@@ -246,10 +241,8 @@ fn test_rpo_falcon_procedure_acl_with_disallow_unauthorized_input_notes() -> any
     // be [2, 1, 0, 0]
     assert_eq!(slot_1, Word::from([2u32, 1, 0, 0]));
 
-    let tx_script_no_trigger = TransactionScript::compile(
-        TX_SCRIPT_NO_TRIGGER,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let tx_script_no_trigger =
+        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test: Transaction WITHOUT authenticator calling non-trigger procedure but consuming input
     // notes This should FAIL because allow_unauthorized_input_notes=false and we're consuming

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -81,7 +81,7 @@ pub fn get_note_with_fungible_asset_and_script(
 ) -> Note {
     use miden_objects::note::NoteExecutionHint;
 
-    let note_script = ScriptBuilder::new(true).compile_note_script(note_script).unwrap();
+    let note_script = ScriptBuilder::new(false).compile_note_script(note_script).unwrap();
     let serial_num = Word::from([1, 2, 3, 4u32]);
     let sender_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -81,7 +81,7 @@ pub fn get_note_with_fungible_asset_and_script(
 ) -> Note {
     use miden_objects::note::NoteExecutionHint;
 
-    let note_script = ScriptBuilder::new(false).compile_note_script(note_script).unwrap();
+    let note_script = ScriptBuilder::default().compile_note_script(note_script).unwrap();
     let serial_num = Word::from([1, 2, 3, 4u32]);
     let sender_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -4,13 +4,13 @@ mod auth;
 mod scripts;
 mod wallet;
 
-use miden_lib::transaction::TransactionKernel;
+use miden_lib::utils::ScriptBuilder;
 use miden_objects::{
     Word, ZERO,
     account::AccountId,
     asset::FungibleAsset,
     crypto::utils::Serializable,
-    note::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteType},
+    note::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipient, NoteType},
     testing::account_id::ACCOUNT_ID_SENDER,
     transaction::{ExecutedTransaction, ProvenTransaction},
 };
@@ -81,8 +81,7 @@ pub fn get_note_with_fungible_asset_and_script(
 ) -> Note {
     use miden_objects::note::NoteExecutionHint;
 
-    let assembler = TransactionKernel::assembler().with_debug_mode(true);
-    let note_script = NoteScript::compile(note_script, assembler).unwrap();
+    let note_script = ScriptBuilder::new(true).compile_note_script(note_script).unwrap();
     let serial_num = Word::from([1, 2, 3, 4u32]);
     let sender_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -2,13 +2,13 @@ extern crate alloc;
 
 use miden_lib::{
     errors::tx_kernel_errors::ERR_FUNGIBLE_ASSET_DISTRIBUTE_WOULD_CAUSE_MAX_SUPPLY_TO_BE_EXCEEDED,
-    transaction::{TransactionKernel, memory::FAUCET_STORAGE_DATA_SLOT},
+    transaction::memory::FAUCET_STORAGE_DATA_SLOT, utils::ScriptBuilder,
 };
 use miden_objects::{
     Felt, Word,
     asset::{Asset, FungibleAsset},
     note::{NoteAssets, NoteExecutionHint, NoteId, NoteMetadata, NoteTag, NoteType},
-    transaction::{OutputNote, TransactionScript},
+    transaction::OutputNote,
 };
 use miden_testing::{Auth, MockChain};
 use miden_tx::utils::word_to_masm_push_string;
@@ -66,8 +66,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(note_execution_hint)
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_code, TransactionKernel::testing_assembler()).unwrap();
+    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_code).unwrap();
     let tx_context = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)
@@ -131,8 +130,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() -> anyhow::Res
         recipient = word_to_masm_push_string(&recipient),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_code, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_code)?;
     let tx = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -66,7 +66,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(note_execution_hint)
     );
 
-    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_code).unwrap();
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_code)?;
     let tx_context = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -66,7 +66,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(note_execution_hint)
     );
 
-    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_code).unwrap();
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_code).unwrap();
     let tx_context = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)
@@ -130,7 +130,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() -> anyhow::Res
         recipient = word_to_masm_push_string(&recipient),
     );
 
-    let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script_code)?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_code)?;
     let tx = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -66,7 +66,7 @@ fn prove_faucet_contract_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(note_execution_hint)
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_code).unwrap();
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_code).unwrap();
     let tx_context = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)
@@ -130,7 +130,7 @@ fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() -> anyhow::Res
         recipient = word_to_masm_push_string(&recipient),
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_code)?;
     let tx = mock_chain
         .build_tx_context(faucet.id(), &[], &[])?
         .tx_script(tx_script)

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -258,7 +258,7 @@ fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
         note_execution_hint_2 = Felt::from(output_note_2.metadata().execution_hint())
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[input_note_1.id(), input_note_2.id()], &[])?

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -1,6 +1,6 @@
 use miden_lib::{
     errors::note_script_errors::ERR_P2ID_TARGET_ACCT_MISMATCH, note::create_p2id_note,
-    transaction::TransactionKernel,
+    utils::ScriptBuilder,
 };
 use miden_objects::{
     Felt, Word,
@@ -13,7 +13,7 @@ use miden_objects::{
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE_2, ACCOUNT_ID_SENDER,
     },
-    transaction::{OutputNote, TransactionScript},
+    transaction::OutputNote,
 };
 use miden_testing::{Auth, MockChain};
 use miden_tx::utils::word_to_masm_push_string;
@@ -258,8 +258,7 @@ fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
         note_execution_hint_2 = Felt::from(output_note_2.metadata().execution_hint())
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script_src, TransactionKernel::testing_assembler())?;
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[input_note_1.id(), input_note_2.id()], &[])?

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 
-use miden_lib::{account::interface::AccountInterface, transaction::TransactionKernel};
+use miden_lib::{account::interface::AccountInterface, utils::ScriptBuilder};
 use miden_objects::{
     Word,
     asset::{Asset, FungibleAsset},
     crypto::rand::{FeltRng, RpoRandomCoin},
     note::{
-        Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteScript,
-        NoteTag, NoteType, PartialNote,
+        Note, NoteAssets, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient, NoteTag,
+        NoteType, PartialNote,
     },
     transaction::OutputNote,
 };
@@ -37,8 +37,10 @@ fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         Default::default(),
     )?;
     let assets = NoteAssets::new(vec![sent_asset]).unwrap();
-    let note_script =
-        NoteScript::compile("begin nop end", TransactionKernel::testing_assembler()).unwrap();
+    let note_script = ScriptBuilder::with_kernel_library()
+        .unwrap()
+        .compile_note_script("begin nop end")
+        .unwrap();
     let serial_num = RpoRandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
 
@@ -101,8 +103,10 @@ fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
     let assets = NoteAssets::new(vec![Asset::Fungible(
         FungibleAsset::new(sender_basic_fungible_faucet_account.id(), 10).unwrap(),
     )])?;
-    let note_script =
-        NoteScript::compile("begin nop end", TransactionKernel::testing_assembler()).unwrap();
+    let note_script = ScriptBuilder::with_kernel_library()
+        .unwrap()
+        .compile_note_script("begin nop end")
+        .unwrap();
     let serial_num = RpoRandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
 

--- a/crates/miden-testing/tests/scripts/swap.rs
+++ b/crates/miden-testing/tests/scripts/swap.rs
@@ -53,7 +53,7 @@ pub fn prove_send_swap_note() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(swap_note.metadata().execution_hint())
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src).unwrap();
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
 
     let create_swap_note_tx = mock_chain
         .build_tx_context(sender_account.id(), &[], &[])

--- a/crates/miden-testing/tests/scripts/swap.rs
+++ b/crates/miden-testing/tests/scripts/swap.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use miden_lib::{note::utils, transaction::TransactionKernel};
+use miden_lib::{note::utils, utils::ScriptBuilder};
 use miden_objects::{
     Felt, NoteError, Word,
     account::{Account, AccountId, AccountStorageMode, AccountType},
@@ -8,7 +8,7 @@ use miden_objects::{
     testing::account_id::{
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1, AccountIdBuilder,
     },
-    transaction::{OutputNote, TransactionScript},
+    transaction::OutputNote,
 };
 use miden_testing::{Auth, MockChain};
 use miden_tx::utils::word_to_masm_push_string;
@@ -53,11 +53,7 @@ pub fn prove_send_swap_note() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(swap_note.metadata().execution_hint())
     );
 
-    let tx_script = TransactionScript::compile(
-        tx_script_src,
-        TransactionKernel::testing_assembler().with_debug_mode(true),
-    )
-    .unwrap();
+    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src).unwrap();
 
     let create_swap_note_tx = mock_chain
         .build_tx_context(sender_account.id(), &[], &[])

--- a/crates/miden-testing/tests/scripts/swap.rs
+++ b/crates/miden-testing/tests/scripts/swap.rs
@@ -53,7 +53,7 @@ pub fn prove_send_swap_note() -> anyhow::Result<()> {
         note_execution_hint = Felt::from(swap_note.metadata().execution_hint())
     );
 
-    let tx_script = ScriptBuilder::new(false).compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let create_swap_note_tx = mock_chain
         .build_tx_context(sender_account.id(), &[], &[])


### PR DESCRIPTION
This PR addresses #1568 to use the `ScriptBuilder` `compile_note_script` and `compile_tx_script` methods instead of `{TransactionScript, NoteScript}::compile` which requires us to pass in an assembler. 

There were some tests that use a custom assembler which could not use the `ScriptBuilder` because the `ScriptBuilder` uses the standard `TransactionKernel::assembler()` assembler. 