### PR TITLE
delete trait `TransactionProver`, avoid `#[maybe_async]`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,67 +4,52 @@ name: build
 
 # Limits workflow concurrency to only the latest commit in the PR.
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
-  cancel-in-progress: true
+    group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+    cancel-in-progress: true
 
 on:
-  push:
-    branches: [main, next]
-  pull_request:
-    types: [opened, reopened, synchronize]
+    push:
+        branches: [main, next]
+    pull_request:
+        types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  async:
-    name: build using async feature
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Only update the cache on push onto the next branch. This strikes a nice balance between
-          # cache hits and cache evictions (github has a 10GB cache limit).
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      - name: build
-        run: |
-          rustup update --no-self-update
-          make build-async
+    no-std:
+        name: build for no-std
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@main
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  # Only update the cache on push onto the next branch. This strikes a nice balance between
+                  # cache hits and cache evictions (github has a 10GB cache limit).
+                  save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+            - name: build
+              run: |
+                  rustup update --no-self-update
+                  rustup target add wasm32-unknown-unknown
+                  make build-no-std
+                  make build-no-std-testing
 
-  no-std:
-    name: build for no-std
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Only update the cache on push onto the next branch. This strikes a nice balance between
-          # cache hits and cache evictions (github has a 10GB cache limit).
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      - name: build
-        run: |
-          rustup update --no-self-update
-          rustup target add wasm32-unknown-unknown
-          make build-no-std
-          make build-no-std-testing
-
-  feature-check:
-    name: Check feature combinations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Only update the cache on push onto the next branch. This strikes a nice balance between
-          # cache hits and cache evictions (github has a 10GB cache limit).
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      # Install cargo-hack or restore from cache if already built.
-      - uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cargo-hack
-      - name: Update Rust toolchain
-        run: rustup update --no-self-update
-      # Run cargo hack check with each feature to ensure crates compile with individual features
-      - name: Check each feature
-        run: cargo hack check --each-feature --workspace --exclude bench-prover
+    feature-check:
+        name: Check feature combinations
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@main
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  # Only update the cache on push onto the next branch. This strikes a nice balance between
+                  # cache hits and cache evictions (github has a 10GB cache limit).
+                  save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+            # Install cargo-hack or restore from cache if already built.
+            - uses: taiki-e/cache-cargo-install-action@v2
+              with:
+                  tool: cargo-hack
+            - name: Update Rust toolchain
+              run: rustup update --no-self-update
+            # Run cargo hack check with each feature to ensure crates compile with individual features
+            - name: Check each feature
+              run: cargo hack check --each-feature --workspace --exclude bench-prover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Pass the full `TransactionSummary` to `TransactionAuthenticator` ([#1618](https://github.com/0xMiden/miden-base/pull/1618)).
 - Add `PartialBlockchain::num_tracked_blocks()` ([#1643](https://github.com/0xMiden/miden-base/pull/1643)).
 - [BREAKING] Make transaction execution and transaction authenticatiro asynchronous ([#1636](https://github.com/0xMiden/miden-base/pull/1636)).
+- [BREAKING] Consolidate to a single async interface and drop `#[maybe_async]` usage ([#1666](https://github.com/0xMiden/miden-base/pull/#1666)).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "miden-air"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly-syntax"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "miden-debug-types"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1165,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "miden-mast-package"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-debug-types",
@@ -1275,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "miden-stdlib"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "env_logger",
  "miden-assembly",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-diagnostics"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-sync"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "lock_api",
  "loom",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "miden-verifier"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "miden-air"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly-syntax"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "miden-debug-types"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1165,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "miden-mast-package"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-debug-types",
@@ -1275,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "miden-stdlib"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "env_logger",
  "miden-assembly",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-diagnostics"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-sync"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "lock_api",
  "loom",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "miden-verifier"
 version = "0.17.0"
-source = "git+https://github.com/0xMiden/miden-vm.git?branch=async-experimental#a35aa4dccef9ecc960e73e6a8b40ee824170791c"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=bernhard-async-experimental#91e1d9d70dc1c2cbcc241878ef171671067dc586"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ dependencies = [
  "miden-debug-types",
  "miden-processor",
  "tracing",
- "winter-maybe-async 0.13.1",
+ "winter-maybe-async",
  "winter-prover",
 ]
 
@@ -1302,7 +1302,6 @@ dependencies = [
  "rand_chacha",
  "thiserror 2.0.12",
  "tokio",
- "winter-maybe-async 0.13.1",
  "winter-rand-utils",
  "winterfell",
 ]
@@ -1324,7 +1323,6 @@ dependencies = [
  "rand",
  "thiserror 2.0.12",
  "tokio",
- "winter-maybe-async 0.12.0",
 ]
 
 [[package]]
@@ -3075,16 +3073,6 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "winter-maybe-async"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
@@ -3104,7 +3092,7 @@ dependencies = [
  "winter-crypto",
  "winter-fri",
  "winter-math",
- "winter-maybe-async 0.13.1",
+ "winter-maybe-async",
  "winter-utils",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ miden-tx              = { default-features = false, path = "crates/miden-tx", ve
 miden-tx-batch-prover = { default-features = false, path = "crates/miden-tx-batch-prover", version = "0.11" }
 
 # Miden dependencies
-assembly         = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-assembly" }
+assembly         = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-assembly" }
 miden-crypto     = { default-features = false, version = "0.15.6" }
-miden-prover     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-stdlib     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-utils-sync = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-verifier   = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-vm-core          = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-core" }
-vm-processor     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-processor" }
+miden-prover     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-stdlib     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-utils-sync = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-verifier   = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+vm-core          = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-core" }
+vm-processor     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-processor" }
 
 # External dependencies
 assert_matches = { default-features = false, version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ miden-tx              = { default-features = false, path = "crates/miden-tx", ve
 miden-tx-batch-prover = { default-features = false, path = "crates/miden-tx-batch-prover", version = "0.11" }
 
 # Miden dependencies
-assembly         = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-assembly" }
+assembly         = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-assembly" }
 miden-crypto     = { default-features = false, version = "0.15.6" }
-miden-prover     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-stdlib     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-utils-sync = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-miden-verifier   = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
-vm-core          = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-core" }
-vm-processor     = { branch = "async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-processor" }
+miden-prover     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-stdlib     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-utils-sync = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+miden-verifier   = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git" }
+vm-core          = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-core" }
+vm-processor     = { branch = "bernhard-async-experimental", default-features = false, git = "https://github.com/0xMiden/miden-vm.git", package = "miden-processor" }
 
 # External dependencies
 assert_matches = { default-features = false, version = "1.5" }

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 # -- variables --------------------------------------------------------------------------------------
 
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-ALL_FEATURES_BUT_ASYNC=--features concurrent,testing
+ALL_FEATURES=--features concurrent,testing
 # Enable file generation in the `src` directory.
 # This is used in the build scripts of miden-lib.
 BUILD_GENERATED_FILES_IN_SRC=BUILD_GENERATED_FILES_IN_SRC=1
@@ -19,7 +19,7 @@ BACKTRACE=RUST_BACKTRACE=1
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo clippy --workspace --all-targets $(ALL_FEATURES_BUT_ASYNC) -- -D warnings
+	cargo clippy --workspace --all-targets $(ALL_FEATURES) -- -D warnings
 
 
 .PHONY: clippy-no-std
@@ -29,7 +29,7 @@ clippy-no-std: ## Runs Clippy with configs
 
 .PHONY: fix
 fix: ## Runs Fix with configs
-	cargo fix --workspace --allow-staged --allow-dirty --all-targets $(ALL_FEATURES_BUT_ASYNC)
+	cargo fix --workspace --allow-staged --allow-dirty --all-targets $(ALL_FEATURES)
 
 
 .PHONY: format
@@ -94,14 +94,14 @@ test-dev: ## Run default tests excluding slow prove tests in debug mode intended
 
 .PHONY: test-docs
 test-docs: ## Run documentation tests
-	$(WARNINGS) cargo test --doc $(ALL_FEATURES_BUT_ASYNC)
+	$(WARNINGS) cargo test --doc $(ALL_FEATURES)
 
 
 # --- checking ------------------------------------------------------------------------------------
 
 .PHONY: check
 check: ## Check all targets and features for errors without code generation
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo check --all-targets $(ALL_FEATURES_BUT_ASYNC)
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo check --all-targets $(ALL_FEATURES)
 
 
 .PHONY: check-no-std
@@ -123,11 +123,6 @@ build-no-std: ## Build without the standard library
 .PHONY: build-no-std-testing
 build-no-std-testing: ## Build without the standard library. Includes the `testing` feature
 	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude miden-bench-tx --features testing --exclude bench-prover
-
-
-.PHONY: build-async
-build-async: ## Build with the `async` feature enabled (only libraries)
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --lib --release --features async --workspace --exclude bench-prover
 
 # --- benchmarking --------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lint: ## Runs all linting tasks at once (Clippy, fixing, formatting, typos)
 
 .PHONY: doc
 doc: ## Generates & checks documentation
-	$(WARNINGS) cargo doc $(ALL_FEATURES_BUT_ASYNC) --keep-going --release
+	$(WARNINGS) cargo doc $(ALL_FEATURES) --keep-going --release
 
 
 .PHONY: book

--- a/bin/bench-prover/src/bench_functions.rs
+++ b/bin/bench-prover/src/bench_functions.rs
@@ -96,13 +96,13 @@ pub fn setup_consume_multiple_notes() -> Result<ExecutedTransaction> {
     Ok(executed_transaction)
 }
 
-pub async fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
+pub fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
     let executed_transaction_id = executed_transaction.id();
 
     let proof_options = ProvingOptions::default();
     let prover = LocalTransactionProver::new(proof_options);
     let proven_transaction: miden_objects::transaction::ProvenTransaction =
-        prover.prove(executed_transaction.into()).await.unwrap();
+        prover.prove(executed_transaction.into()).unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
     Ok(())

--- a/bin/bench-prover/src/bench_functions.rs
+++ b/bin/bench-prover/src/bench_functions.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     transaction::ExecutedTransaction,
 };
 use miden_testing::{Auth, MockChain};
-use miden_tx::{LocalTransactionProver, ProvingOptions, TransactionProver};
+use miden_tx::{LocalTransactionProver, ProvingOptions};
 
 pub fn setup_consume_note_with_new_account() -> Result<ExecutedTransaction> {
     // Create assets
@@ -96,13 +96,13 @@ pub fn setup_consume_multiple_notes() -> Result<ExecutedTransaction> {
     Ok(executed_transaction)
 }
 
-pub fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
+pub async fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
     let executed_transaction_id = executed_transaction.id();
 
     let proof_options = ProvingOptions::default();
     let prover = LocalTransactionProver::new(proof_options);
     let proven_transaction: miden_objects::transaction::ProvenTransaction =
-        prover.prove(executed_transaction.into()).unwrap();
+        prover.prove(executed_transaction.into()).await.unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
     Ok(())

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-async = ["miden-tx/async", "winter-maybe-async/async"]
+async = ["winter-maybe-async/async"]
 std   = ["miden-lib/std"]
 
 [dependencies]

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-std   = ["miden-lib/std"]
+std = ["miden-lib/std"]
 
 [dependencies]
 # Workspace dependencies
@@ -26,14 +26,14 @@ miden-tx           = { features = ["testing"], workspace = true }
 vm-processor = { workspace = true }
 
 # External dependencies
-anyhow             = { default-features = false, version = "1.0" }
-async-trait        = "0.1"
-itertools          = { default-features = false, features = ["use_alloc"], version = "0.14" }
-rand               = { features = ["os_rng", "small_rng"], workspace = true }
-rand_chacha        = { default-features = false, version = "0.9" }
-thiserror          = { workspace = true }
-tokio              = { features = ["macros", "rt"], workspace = true }
-winterfell         = { version = "0.13" }
+anyhow      = { default-features = false, version = "1.0" }
+async-trait = "0.1"
+itertools   = { default-features = false, features = ["use_alloc"], version = "0.14" }
+rand        = { features = ["os_rng", "small_rng"], workspace = true }
+rand_chacha = { default-features = false, version = "0.9" }
+thiserror   = { workspace = true }
+tokio       = { features = ["macros", "rt"], workspace = true }
+winterfell  = { version = "0.13" }
 
 [dev-dependencies]
 anyhow            = { features = ["backtrace", "std"], version = "1.0" }

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-async = ["winter-maybe-async/async"]
 std   = ["miden-lib/std"]
 
 [dependencies]
@@ -34,7 +33,6 @@ rand               = { features = ["os_rng", "small_rng"], workspace = true }
 rand_chacha        = { default-features = false, version = "0.9" }
 thiserror          = { workspace = true }
 tokio              = { features = ["macros", "rt"], workspace = true }
-winter-maybe-async = { version = "0.13" }
 winterfell         = { version = "0.13" }
 
 [dev-dependencies]
@@ -42,7 +40,3 @@ anyhow            = { features = ["backtrace", "std"], version = "1.0" }
 assert_matches    = { workspace = true }
 miden-objects     = { features = ["std"], workspace = true }
 winter-rand-utils = { version = "0.13" }
-
-[package.metadata.cargo-machete]
-# cargo machete flags async-trait as unused but it is used by winter-maybe-async with the async feature
-ignored = ["async-trait"]

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -19,7 +19,9 @@ use miden_tx::{
     auth::BasicAuthenticator,
 };
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{AdviceInputs, ExecutionError, MastForest, MastForestStore, Process, Word};
+use vm_processor::{
+    AdviceInputs, AsyncHostFuture, ExecutionError, MastForest, MastForestStore, Process, Word,
+};
 
 use crate::{MockHost, executor::CodeExecutor, tx_context::builder::MockAuthenticator};
 
@@ -188,9 +190,9 @@ impl DataStore for TransactionContext {
         &self,
         account_id: AccountId,
         _ref_blocks: BTreeSet<BlockNumber>,
-    ) -> impl Future<
-        Output = Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
-    > + Send {
+    ) -> impl AsyncHostFuture<
+        Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
+    > {
         assert_eq!(account_id, self.account().id());
         let (account, seed, header, mmr, _) = self.tx_inputs.clone().into_parts();
         async move { Ok((account, seed, header, mmr)) }

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "async")]
-use alloc::boxed::Box;
 use alloc::{borrow::ToOwned, collections::BTreeSet, rc::Rc, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -15,8 +15,7 @@ use miden_objects::{
     transaction::{ExecutedTransaction, ProvenTransaction},
 };
 use miden_tx::{
-    LocalTransactionProver, ProvingOptions, TransactionProver, TransactionVerifier,
-    TransactionVerifierError,
+    LocalTransactionProver, ProvingOptions, TransactionVerifier, TransactionVerifierError,
 };
 use vm_processor::utils::Deserializable;
 
@@ -60,7 +59,8 @@ pub fn prove_and_verify_transaction(
 
     let proof_options = ProvingOptions::default();
     let prover = LocalTransactionProver::new(proof_options);
-    let proven_transaction = prover.prove(executed_transaction.into()).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+    let proven_transaction = rt.block_on(prover.prove(executed_transaction.into())).unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
 

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -59,8 +59,7 @@ pub fn prove_and_verify_transaction(
 
     let proof_options = ProvingOptions::default();
     let prover = LocalTransactionProver::new(proof_options);
-    let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
-    let proven_transaction = rt.block_on(prover.prove(executed_transaction.into())).unwrap();
+    let proven_transaction = prover.prove(executed_transaction.into()).unwrap();
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
 

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -32,7 +32,7 @@ vm-processor   = { workspace = true }
 async-trait        = "0.1"
 rand               = { workspace = true }
 thiserror          = { workspace = true }
-tokio              = { workspace = true }
+tokio              = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 anyhow         = { default-features = false, features = ["backtrace", "std"], version = "1.0" }

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -13,8 +13,6 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-# async      = ["miden-prover/async", "winter-maybe-async/async"]
-async = [] # FIXME TODO
 concurrent = ["miden-prover/concurrent", "std"]
 default    = ["std"]
 std        = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -33,14 +33,9 @@ async-trait        = "0.1"
 rand               = { workspace = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
-winter-maybe-async = { version = "0.12" }
 
 [dev-dependencies]
 anyhow         = { default-features = false, features = ["backtrace", "std"], version = "1.0" }
 assembly       = { workspace = true }
 assert_matches = { workspace = true }
 miden-tx       = { features = ["testing"], path = "." }
-
-[package.metadata.cargo-machete]
-# cargo machete flags async-trait as unused but it is used by winter-maybe-async with the async feature
-ignored = ["async-trait"]

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -29,10 +29,10 @@ miden-verifier = { workspace = true }
 vm-processor   = { workspace = true }
 
 # External dependencies
-async-trait        = "0.1"
-rand               = { workspace = true }
-thiserror          = { workspace = true }
-tokio              = { workspace = true, features = ["rt"] }
+async-trait = "0.1"
+rand        = { workspace = true }
+thiserror   = { workspace = true }
+tokio       = { features = ["rt"], workspace = true }
 
 [dev-dependencies]
 anyhow         = { default-features = false, features = ["backtrace", "std"], version = "1.0" }

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -13,7 +13,8 @@ rust-version.workspace = true
 version                = "0.11.0"
 
 [features]
-async      = ["miden-prover/async", "winter-maybe-async/async"]
+# async      = ["miden-prover/async", "winter-maybe-async/async"]
+async = [] # FIXME TODO
 concurrent = ["miden-prover/concurrent", "std"]
 default    = ["std"]
 std        = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -8,7 +8,6 @@ use miden_objects::{
     transaction::PartialBlockchain,
 };
 use vm_processor::{MastForestStore, Word};
-use winter_maybe_async::*;
 
 use crate::DataStoreError;
 
@@ -17,7 +16,6 @@ use crate::DataStoreError;
 
 /// The [DataStore] trait defines the interface that transaction objects use to fetch data
 /// required for transaction execution.
-#[maybe_async_trait]
 pub trait DataStore: MastForestStore {
     /// Returns all the data required to execute a transaction against the account with the
     /// specified ID and consuming input notes created in blocks in the input `ref_blocks` set.
@@ -32,10 +30,11 @@ pub trait DataStore: MastForestStore {
     /// - The block with the specified number could not be found in the data store.
     /// - The combination of specified inputs resulted in a transaction input error.
     /// - The data store encountered some internal error
-    #[maybe_async]
     fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         ref_blocks: BTreeSet<BlockNumber>,
-    ) -> Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>;
+    ) -> impl Future<
+        Output = Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
+    > + Send;
 }

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -5,7 +5,7 @@ use miden_objects::{
     block::{BlockHeader, BlockNumber},
     transaction::PartialBlockchain,
 };
-use vm_processor::{MastForestStore, Word};
+use vm_processor::{AsyncHostFuture, MastForestStore, Word};
 
 use crate::DataStoreError;
 
@@ -32,7 +32,7 @@ pub trait DataStore: MastForestStore {
         &self,
         account_id: AccountId,
         ref_blocks: BTreeSet<BlockNumber>,
-    ) -> impl Future<
-        Output = Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
-    > + Send;
+    ) -> impl AsyncHostFuture<
+        Result<(Account, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
+    >;
 }

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "async")]
-use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 
 use miden_objects::{

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -308,7 +308,7 @@ where
         notes: InputNotes<InputNote>,
         tx_args: TransactionArgs,
         // TODO: Pass source manager to host once refactored.
-        _source_manager: Arc<dyn SourceManager>,
+        _source_manager: Arc<dyn SourceManager + Sync + Send>,
     ) -> Result<NoteAccountExecution, TransactionExecutorError> {
         let mut ref_blocks = validate_input_notes(&notes, block_ref)?;
         ref_blocks.insert(block_ref);

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -15,7 +15,6 @@ use miden_objects::{
 };
 use vm_processor::{AdviceInputs, ExecutionError, StackInputs, fast::FastProcessor};
 pub use vm_processor::{ExecutionOptions, MastForestStore};
-use winter_maybe_async::maybe_await;
 
 use super::TransactionExecutorError;
 use crate::{
@@ -151,9 +150,11 @@ where
         let mut ref_blocks = validate_input_notes(&notes, block_ref)?;
         ref_blocks.insert(block_ref);
 
-        let (account, seed, ref_block, mmr) =
-            maybe_await!(self.data_store.get_transaction_inputs(account_id, ref_blocks))
-                .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
+        let (account, seed, ref_block, mmr) = self
+            .data_store
+            .get_transaction_inputs(account_id, ref_blocks)
+            .await
+            .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
 
         validate_account_inputs(&tx_args, &ref_block)?;
 
@@ -233,9 +234,11 @@ where
         _source_manager: Arc<dyn SourceManager + Send + Sync>,
     ) -> Result<[Felt; 16], TransactionExecutorError> {
         let ref_blocks = [block_ref].into_iter().collect();
-        let (account, seed, ref_block, mmr) =
-            maybe_await!(self.data_store.get_transaction_inputs(account_id, ref_blocks))
-                .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
+        let (account, seed, ref_block, mmr) = self
+            .data_store
+            .get_transaction_inputs(account_id, ref_blocks)
+            .await
+            .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
         let tx_args = TransactionArgs::new(Default::default(), foreign_account_inputs)
             .with_tx_script(tx_script);
 
@@ -310,9 +313,11 @@ where
         let mut ref_blocks = validate_input_notes(&notes, block_ref)?;
         ref_blocks.insert(block_ref);
 
-        let (account, seed, ref_block, mmr) =
-            maybe_await!(self.data_store.get_transaction_inputs(account_id, ref_blocks))
-                .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
+        let (account, seed, ref_block, mmr) = self
+            .data_store
+            .get_transaction_inputs(account_id, ref_blocks)
+            .await
+            .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
 
         validate_account_inputs(&tx_args, &ref_block)?;
 

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -48,7 +48,7 @@ where
         block_ref: BlockNumber,
         input_notes: InputNotes<InputNote>,
         tx_args: TransactionArgs,
-        source_manager: Arc<dyn SourceManager>,
+        source_manager: Arc<dyn SourceManager + Sync + Send>,
     ) -> Result<NoteAccountExecution, TransactionExecutorError> {
         // Check input notes
         // ----------------------------------------------------------------------------------------

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -19,8 +19,7 @@ pub use host::{AccountProcedureIndexMap, LinkMap, ScriptMastForestStore};
 
 mod prover;
 pub use prover::{
-    LocalTransactionProver, ProvingOptions, TransactionMastStore, TransactionProver,
-    TransactionProverHost,
+    LocalTransactionProver, ProvingOptions, TransactionMastStore, TransactionProverHost,
 };
 
 mod verifier;

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -20,26 +20,6 @@ pub use prover_host::TransactionProverHost;
 mod mast_store;
 pub use mast_store::TransactionMastStore;
 
-// TRANSACTION PROVER TRAIT
-// ================================================================================================
-
-/// The [TransactionProver] trait defines the interface that transaction witness objects use to
-/// prove transactions and generate a [ProvenTransaction].
-#[maybe_async_trait]
-pub trait TransactionProver {
-    /// Proves the provided transaction and returns a [ProvenTransaction].
-    ///
-    /// # Errors
-    /// - If the input note data in the transaction witness is corrupt.
-    /// - If the transaction program cannot be proven.
-    /// - If the transaction result is corrupt.
-    #[maybe_async]
-    fn prove(
-        &self,
-        tx_witness: TransactionWitness,
-    ) -> Result<ProvenTransaction, TransactionProverError>;
-}
-
 // LOCAL TRANSACTION PROVER
 // ------------------------------------------------------------------------------------------------
 
@@ -70,13 +50,11 @@ impl Default for LocalTransactionProver {
     }
 }
 
-#[maybe_async_trait]
-impl TransactionProver for LocalTransactionProver {
-    #[maybe_async]
+impl LocalTransactionProver {
     fn prove(
         &self,
         tx_witness: TransactionWitness,
-    ) -> Result<ProvenTransaction, TransactionProverError> {
+    ) -> impl Future<Output = Result<ProvenTransaction, TransactionProverError>> + Send {
         let TransactionWitness { tx_inputs, tx_args, advice_witness } = tx_witness;
 
         let account = tx_inputs.account();
@@ -116,57 +94,66 @@ impl TransactionProver for LocalTransactionProver {
 
         let advice_inputs = advice_inputs.into_advice_inputs();
 
-        let (stack_outputs, proof) = maybe_await!(prove(
-            &TransactionKernel::main(),
-            stack_inputs,
-            advice_inputs.clone(),
-            &mut host,
-            self.proof_options.clone(),
-        ))
-        .map_err(TransactionProverError::TransactionProgramExecutionFailed)?;
+        let proof_options = self.proof_options.clone();
+        async move {
+            // FIXME TODO this `fn prove()` is also `#[maybe_async]`
+            let (stack_outputs, proof) = prove(
+                &TransactionKernel::main(),
+                stack_inputs,
+                advice_inputs.clone(),
+                &mut host,
+                proof_options,
+            )
+            .await
+            .map_err(TransactionProverError::TransactionProgramExecutionFailed)?;
 
-        // extract transaction outputs and process transaction data
-        let (account_delta, output_notes, _tx_progress) = host.into_parts();
-        let tx_outputs =
-            TransactionKernel::from_transaction_parts(&stack_outputs, &advice_inputs, output_notes)
-                .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;
+            // extract transaction outputs and process transaction data
+            let (account_delta, output_notes, _tx_progress) = host.into_parts();
+            let tx_outputs = TransactionKernel::from_transaction_parts(
+                &stack_outputs,
+                &advice_inputs,
+                output_notes,
+            )
+            .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;
 
-        // erase private note information (convert private full notes to just headers)
-        let output_notes: Vec<_> = tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
-        let account_delta_commitment = account_delta.to_commitment();
+            // erase private note information (convert private full notes to just headers)
+            let output_notes: Vec<_> =
+                tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
+            let account_delta_commitment = account_delta.to_commitment();
 
-        let builder = ProvenTransactionBuilder::new(
-            account.id(),
-            account.init_commitment(),
-            tx_outputs.account.commitment(),
-            account_delta_commitment,
-            ref_block_num,
-            ref_block_commitment,
-            tx_outputs.expiration_block_num,
-            proof,
-        )
-        .add_input_notes(input_notes)
-        .add_output_notes(output_notes);
+            let builder = ProvenTransactionBuilder::new(
+                account.id(),
+                account.init_commitment(),
+                tx_outputs.account.commitment(),
+                account_delta_commitment,
+                ref_block_num,
+                ref_block_commitment,
+                tx_outputs.expiration_block_num,
+                proof,
+            )
+            .add_input_notes(input_notes)
+            .add_output_notes(output_notes);
 
-        // If the account is on-chain, add the update details.
-        let builder = match account.is_onchain() {
-            true => {
-                let account_update_details = if account.is_new() {
-                    let mut account = account.clone();
-                    account
-                        .apply_delta(&account_delta)
-                        .map_err(TransactionProverError::AccountDeltaApplyFailed)?;
+            // If the account is on-chain, add the update details.
+            let builder = match account.is_onchain() {
+                true => {
+                    let account_update_details = if account.is_new() {
+                        let mut account = account.clone();
+                        account
+                            .apply_delta(&account_delta)
+                            .map_err(TransactionProverError::AccountDeltaApplyFailed)?;
 
-                    AccountUpdateDetails::New(account)
-                } else {
-                    AccountUpdateDetails::Delta(account_delta)
-                };
+                        AccountUpdateDetails::New(account)
+                    } else {
+                        AccountUpdateDetails::Delta(account_delta)
+                    };
 
-                builder.account_update_details(account_update_details)
-            },
-            false => builder,
-        };
+                    builder.account_update_details(account_update_details)
+                },
+                false => builder,
+            };
 
-        builder.build().map_err(TransactionProverError::ProvenTransactionBuildFailed)
+            builder.build().map_err(TransactionProverError::ProvenTransactionBuildFailed)
+        }
     }
 }

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -56,7 +56,7 @@ impl LocalTransactionProver {
         let TransactionWitness { tx_inputs, tx_args, advice_witness } = tx_witness;
 
         let account = tx_inputs.account();
-        let input_notes = tx_inputs.input_notes().clone();
+        let input_notes = tx_inputs.input_notes();
         let ref_block_num = tx_inputs.block_header().block_num();
         let ref_block_commitment = tx_inputs.block_header().commitment();
 

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "async")]
-use alloc::boxed::Box;
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
@@ -156,7 +154,8 @@ impl LocalTransactionProver {
 
             builder.build().map_err(TransactionProverError::ProvenTransactionBuildFailed)
         });
-        let y = jh.await.unwrap(); // FIXME
-        y
+        jh.await.map_err(|e| {
+            TransactionProverError::other_with_source("tokio task join failed", Box::new(e))
+        })?
     }
 }

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -53,9 +53,9 @@ impl LocalTransactionProver {
         let mast_store = self.mast_store.clone();
         let proof_options = self.proof_options.clone();
 
-        let TransactionWitness { tx_inputs, tx_args, advice_witness } = tx_witness.clone(); // FIXME
+        let TransactionWitness { tx_inputs, tx_args, advice_witness } = tx_witness;
 
-        let account = tx_inputs.account().clone();
+        let account = tx_inputs.account();
         let input_notes = tx_inputs.input_notes().clone();
         let ref_block_num = tx_inputs.block_header().block_num();
         let ref_block_commitment = tx_inputs.block_header().commitment();
@@ -67,8 +67,6 @@ impl LocalTransactionProver {
 
         // load the store with account/note/tx_script MASTs
         self.mast_store.load_account_code(account.code());
-
-        let account = &account;
 
         let script_mast_store = ScriptMastForestStore::new(
             tx_args.tx_script(),

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -21,8 +21,6 @@ pub use mast_store::TransactionMastStore;
 // ------------------------------------------------------------------------------------------------
 
 /// Local Transaction prover is a stateless component which is responsible for proving transactions.
-///
-/// Local Transaction Prover implements the [TransactionProver] trait.
 pub struct LocalTransactionProver {
     mast_store: Arc<TransactionMastStore>,
     proof_options: ProvingOptions,

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -105,16 +105,12 @@ impl LocalTransactionProver {
 
         // extract transaction outputs and process transaction data
         let (account_delta, output_notes, _tx_progress) = host.into_parts();
-        let tx_outputs = TransactionKernel::from_transaction_parts(
-            &stack_outputs,
-            &advice_inputs,
-            output_notes,
-        )
-        .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;
+        let tx_outputs =
+            TransactionKernel::from_transaction_parts(&stack_outputs, &advice_inputs, output_notes)
+                .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;
 
         // erase private note information (convert private full notes to just headers)
-        let output_notes: Vec<_> =
-            tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
+        let output_notes: Vec<_> = tx_outputs.output_notes.iter().map(OutputNote::shrink).collect();
         let account_delta_commitment = account_delta.to_commitment();
 
         let builder = ProvenTransactionBuilder::new(


### PR DESCRIPTION
~Does not compile yet, since it calls
`fn prove` from `miden-vm`, which in turn uses the provers in `winterfell-prover` which also use `#[maybe_async]` which resolves to `#[async_trait(?Send)]`~

~Possibly requires: https://github.com/0xMiden/miden-vm/pull/2044~

Changes:
*  Add extra bounds to two instances of `Arc<dyn SourceManager>` -> `Arc<dyn SourceManager +Send + Sync>` -> this might go away with a refactor which is out of scope for this PR
* `fn prove` becomes async
* Delete `trait TransactionProver`
* Avoid any usage of `#[maybe_async]`, which does not enforce `+ Send` requirements for a multithreaded executor
* Remove "async" feature
* Delete dead CI target
* Delete makefile target