### PR TITLE
fix: avoid modifying asset vault when adding fungible asset with amount zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [BREAKING] Changed `PartialStorage` and `PartialVault` to use `PartialSmt` instead of separate merkle proofs ([#1590](https://github.com/0xMiden/miden-base/pull/1590)).
 - [BREAKING] Move transaction inputs insertion out of transaction hosts ([#1639](https://github.com/0xMiden/miden-node/issues/1639))
 - Implemented serialization for `MockChain` ([#1642](https://github.com/0xMiden/miden-base/pull/1642)).
+- Avoid modifying an asset vault when adding a fungible asset with amount zero and the asset does not already exist ([#1668](https://github.com/0xMiden/miden-base/pull/1668)).
 
 ## 0.10.0 (2025-07-08)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -109,8 +109,11 @@ end
 # ADD ASSET
 # =================================================================================================
 
-#! Add the specified fungible asset to the vault. If the vault already contains an asset issued by
-#! the same faucet, the amounts are added together.
+#! Add the specified fungible asset to the vault.
+#!
+#! If the vault already contains an asset issued by the same faucet, the amounts are added together.
+#! If the amount to be added is zero and the asset does not already exist in the vault, the vault
+#! remains unchanged.
 #!
 #! Inputs:  [ASSET, vault_root_ptr]
 #! Outputs: [ASSET']
@@ -188,10 +191,25 @@ export.add_fungible_asset
     swapw
     # => [ASSET', ASSET_KEY', VAULT_ROOT, CUR_VAULT_VALUE, ASSET', vault_root_ptr]
 
+    # pad empty word for insertion
+    padw
+    # => [EMPTY_WORD, ASSET', vault_root_ptr]
+
+    # check if amount of new asset is zero
+    # if it is zero, insert EMPTY_WORD to keep the merkle tree sparse
+    dup.7 eq.0
+    # => [is_amount_zero, EMPTY_WORD, ASSET', vault_root_ptr]
+
+    # If is_amount_zero EMPTY_WORD remains.
+    # If !is_amount_zero ASSET' remains.
+    cdropw
+    # => [EMPTY_WORD_OR_ASSET', vault_root_ptr]
+
     # update asset in vault and assert the old value is equivalent to the value provided via the
     # decorator
     exec.smt::set
     # => [PREV_ASSET, VAULT_ROOT', CUR_VAULT_VALUE, ASSET', vault_root_ptr]
+
     movupw.2 assert_eqw.err=ERR_VAULT_ADD_FUNGIBLE_ASSET_FAILED_INITIAL_VALUE_INVALID
     # => [VAULT_ROOT', ASSET', vault_root_ptr]
 

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -32,7 +32,7 @@ pub const KERNEL0_PROCEDURES: [Word; 42] = [
     // account_get_vault_root
     word!("0x279b4a9e5adca07f01cadf8ecc1303fa3c670003a7a4e69f09506b070c4023df"),
     // account_add_asset
-    word!("0x46a64ae46f9b2350a3924901722c1a6d65e06da3bfd9e569d1dcde507cdc78bf"),
+    word!("0xc13681846b665c1e13167af688002fbb930e46c25ebf65a59f6550665ea03398"),
     // account_remove_asset
     word!("0x99219887439af58fd5243879259bee37b1d8b6e9cdc7ab19dbcab5ea348cca6c"),
     // account_get_balance
@@ -44,7 +44,7 @@ pub const KERNEL0_PROCEDURES: [Word; 42] = [
     // account_was_procedure_called
     word!("0xe85f7a761f0d90e4d880239c4c1f349125d5a53db1e058a51c462b9442117ab6"),
     // faucet_mint_asset
-    word!("0x5fa98b2eced9242d90a88d7206f73c31b6121fc596333cab1670f131c8215952"),
+    word!("0x657d51990ab94a2df3375af165ae820084fc0270a5d6f46e649c99464c034805"),
     // faucet_burn_asset
     word!("0x48a159453fc092e4e5f5693e5ff8581c9fbacd62e5d3514039e7eabf94a2f5b2"),
     // faucet_get_total_fungible_asset_issuance

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -264,9 +264,9 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     fn add_delta(&mut self, faucet_id: AccountId, delta: i64) -> Result<(), AccountDeltaError> {
-        std::println!("delta {delta}",);
         match self.0.entry(faucet_id) {
             Entry::Vacant(entry) => {
+                // Only track non-zero amounts.
                 if delta != 0 {
                     entry.insert(delta);
                 }

--- a/crates/miden-objects/src/account/delta/vault.rs
+++ b/crates/miden-objects/src/account/delta/vault.rs
@@ -264,9 +264,12 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     fn add_delta(&mut self, faucet_id: AccountId, delta: i64) -> Result<(), AccountDeltaError> {
+        std::println!("delta {delta}",);
         match self.0.entry(faucet_id) {
             Entry::Vacant(entry) => {
-                entry.insert(delta);
+                if delta != 0 {
+                    entry.insert(delta);
+                }
             },
             Entry::Occupied(mut entry) => {
                 let old = *entry.get();

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -789,6 +789,27 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that adding a fungible asset with amount zero to the account vault works and does not
+/// result in an account delta entry.
+#[test]
+fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
+    let input_note = builder.add_p2id_note(
+        account.id(),
+        account.id(),
+        &[FungibleAsset::mock(0)],
+        NoteType::Private,
+    )?;
+    let chain = builder.build()?;
+
+    let tx = chain.build_tx_context(account, &[input_note.id()], &[])?.build()?.execute()?;
+
+    assert!(tx.account_delta().vault().is_empty());
+
+    Ok(())
+}
+
 // TEST HELPERS
 // ================================================================================================
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -729,6 +729,25 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that creating a note with a fungible asset with amount zero works.
+#[test]
+fn creating_note_with_fungible_asset_amount_zero_works() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
+    let output_note = builder.add_p2id_note(
+        account.id(),
+        account.id(),
+        &[FungibleAsset::mock(0)],
+        NoteType::Private,
+    )?;
+    let input_note = builder.add_spawn_note(account.id(), [&output_note])?;
+    let chain = builder.build()?;
+
+    chain.build_tx_context(account, &[input_note.id()], &[])?.build()?.execute()?;
+
+    Ok(())
+}
+
 #[test]
 fn test_build_recipient_hash() -> anyhow::Result<()> {
     let tx_context = {


### PR DESCRIPTION
Avoid modifying an asset vault when adding a fungible asset with amount zero and the asset does not already exist.

We already do this in `remove_fungible_asset` but not in `add_fungible_asset` for some reason.

This is useful to avoid a branch in https://github.com/0xMiden/miden-base/pull/1664 when adding a FEE_ASSET whose amount is zero to the output vault.

