### PR TITLE
chore: Fix release-plz workflow (#1558)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
+      # Ensure the release tag refers to the latest commit on main.
+      # Compare the commit SHA that triggered the workflow with the HEAD of the branch we just
+      # checked out (main).
+      - name: Verify release was triggered from main HEAD
+        run: |
+          tag_sha="${{ github.sha }}"
+          main_sha="$(git rev-parse HEAD)"
+
+          echo "Tag points to:        $tag_sha"
+          echo "Current main HEAD is: $main_sha"
+
+          if [ "$tag_sha" != "$main_sha" ]; then
+            echo "::error::The release tag was not created from the latest commit on main. Aborting."
+            exit 1
+          fi
+          echo "Release tag matches main HEAD — continuing."
       - name: Update Rust toolchain
         run: |
           rustup update --no-self-update


### PR DESCRIPTION
cherry-picked 83b4e5d from `next` to `main` so that the release CI job can be automated
