### PR TITLE
chore: optimize storage delta commitment computation

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -128,8 +128,9 @@ proc.update_storage_delta
         dup movdn.13
         # => [next_slot_idx, RATE, RATE, PERM, next_slot_idx, num_storage_slots]
 
-        # compute next_slot_idx < num_storage_slots
-        dup.14 lt
+        # continue if next_slot_idx != num_storage_slots
+        # we use neq instead of lt for efficiency
+        dup.14 neq
         # => [should_loop, RATE, RATE, PERM, next_slot_idx, num_storage_slots]
     end
     # => [RATE, RATE, PERM, next_slot_idx, num_storage_slots]

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -40,7 +40,7 @@ pub const KERNEL0_PROCEDURES: [Word; 46] = [
     // account_has_non_fungible_asset
     word!("0x4fea67ed25474d5494a23c5e1e06a93f8aa140d0a673c6e140e0d4f1dd8bd835"),
     // account_compute_delta_commitment
-    word!("0x828f6c3389e95319374adaeb0abcc3a1fbd111faa3c931efa66667d2c337ffd9"),
+    word!("0x5f99cbccb3b72eeafbc4db478b80370627e07f52bdb917175968f76e84811dc1"),
     // account_was_procedure_called
     word!("0xe85f7a761f0d90e4d880239c4c1f349125d5a53db1e058a51c462b9442117ab6"),
     // faucet_mint_asset


### PR DESCRIPTION
Optimizes the storage delta computation by using `neq` instead of `lt`.

The original idea in https://github.com/0xMiden/miden-base/issues/1509 was to use `mem_stream` in `update_storage_delta`, but I don't think that works as intended. `mem_stream` overwrites the `RATE` words directly, but we cannot overwrite them until we have computed whether the value slot has actually changed. If it hasn't changed, we need to keep the original RATE words.
So we could only use `mem_stream` in `update_value_slot_delta`, but even here we first load the current and initial item, compare them and _then_ overwrite the RATE words. We could use `mem_stream` for loading them, so instead of `account::get_item` and `get_item_initial`, but we would only save a few cycles for not having to compute the `slot_ptr` from the `slot_idx`. At the same time, if we pass around the `slot_ptr`, we also need helper procedures to go back to `slot_idx`. So overall, I think this would make the procedures less readable and not sure we would save a meaningful amount of cycles.

closes #1509