### PR TITLE
chore: make bech32 decode error transparent

### DIFF
--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -214,8 +214,8 @@ pub enum AccountTreeError {
 
 #[derive(Debug, Error)]
 pub enum Bech32Error {
-    #[error("failed to decode bech32 string")]
-    DecodeError(#[source] Box<dyn Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    DecodeError(Box<dyn Error + Send + Sync + 'static>),
     #[error("found unknown address type {0} which is not the expected {account_addr} account ID address type",
       account_addr = AddressType::AccountId as u8
     )]


### PR DESCRIPTION
To simplify the error message, makes the bech32 decode error transparent. It turns this

```
Failed to receive tokens: account ID failed to parse 
caused by: failed to decode bech32 string into account ID 
caused by: failed to decode bech32 string 
caused by: invalid checksum: the checksummed string is not a valid length
```

into this:

```
Failed to receive tokens: account ID failed to parse 
caused by: failed to decode bech32 string into account ID 
caused by: invalid checksum: the checksummed string is not a valid length
```
