### PR TITLE
Introduce `Address` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add `FeeParameters` to `BlockHeader` and automatically compute and remove fees from account in the transaction kernel epilogue ([#1652](https://github.com/0xMiden/miden-base/pull/1652), [#1654](https://github.com/0xMiden/miden-base/pull/1654), [#1659](https://github.com/0xMiden/miden-base/pull/1659), [#1664](https://github.com/0xMiden/miden-base/pull/1664)).
 - [BREAKING] Make transaction execution and transaction authentication asynchronous ([#1699](https://github.com/0xMiden/miden-base/pull/1699)).
 - [BREAKING] Consolidate to a single async interface and drop `#[maybe_async]` usage ([#1666](https://github.com/0xMiden/miden-base/pull/#1666)).
+- Add `Address` type to represent account-id based addresses ([#1713](https://github.com/0xMiden/miden-base/pull/1713)).
 
 ### Changes
 

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -3,9 +3,6 @@ use crate::account::{AccountId, AccountStorageMode};
 use crate::note::{DEFAULT_LOCAL_TAG_LENGTH, MAX_LOCAL_TAG_LENGTH};
 
 /// A user-facing address in Miden.
-///
-/// For now this supports only account-id based addressing. Future schemes (e.g. public keys)
-/// can be added as new enum variants.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Address {
     AccountId(AccountIdAddress),

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -75,6 +75,7 @@ impl Address {
                 AccountStorageMode::Network => NoteTag::from_network_account_id(addr.id),
                 AccountStorageMode::Private | AccountStorageMode::Public => {
                     NoteTag::from_local_account_id(addr.id, addr.tag_len)
+                        .expect("AccountIdAddress validated that tag len does not exceed MAX_LOCAL_TAG_LENGTH bits")
                 },
             },
         }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -34,7 +34,7 @@ impl AccountIdAddress {
     }
 
     /// Returns the preferred tag length.
-    pub fn tag_len(&self) -> u8 {
+    pub fn note_tag_len(&self) -> u8 {
         self.tag_len
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -69,7 +69,7 @@ impl AccountIdAddress {
 
 impl Address {
     /// Returns a note tag derived from this address.
-    pub fn get_note_tag(&self) -> NoteTag {
+    pub fn to_note_tag(&self) -> NoteTag {
         match self {
             Address::AccountId(addr) => match addr.id.storage_mode() {
                 AccountStorageMode::Network => NoteTag::from_network_account_id(addr.id),

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -68,19 +68,24 @@ impl AccountIdAddress {
     pub fn note_tag_len(&self) -> u8 {
         self.tag_len
     }
+
+    /// Returns a note tag derived from this address.
+    pub fn to_note_tag(&self) -> NoteTag {
+        match self.id.storage_mode() {
+            AccountStorageMode::Network => NoteTag::from_network_account_id(self.id),
+            AccountStorageMode::Private | AccountStorageMode::Public => {
+                NoteTag::from_local_account_id(self.id, self.tag_len)
+                    .expect("AccountIdAddress validated that tag len does not exceed MAX_LOCAL_TAG_LENGTH bits")
+            },
+        }
+    }
 }
 
 impl Address {
     /// Returns a note tag derived from this address.
     pub fn to_note_tag(&self) -> NoteTag {
         match self {
-            Address::AccountId(addr) => match addr.id.storage_mode() {
-                AccountStorageMode::Network => NoteTag::from_network_account_id(addr.id),
-                AccountStorageMode::Private | AccountStorageMode::Public => {
-                    NoteTag::from_local_account_id(addr.id, addr.tag_len)
-                        .expect("AccountIdAddress validated that tag len does not exceed MAX_LOCAL_TAG_LENGTH bits")
-                },
-            },
+            Address::AccountId(addr) => addr.to_note_tag(),
         }
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -9,6 +9,10 @@ pub enum Address {
 }
 
 /// Address that targets a specific `AccountId` with an explicit tag length preference.
+///
+/// The tag length preference lets the owner of the account choose their level of privacy. A higher
+/// tag length makes the account more uniquely identifiable and reduces privacy, while a shorter
+/// length increases privacy at the cost of matching more notes published onchain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountIdAddress {
     id: AccountId,

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -1,6 +1,6 @@
 use crate::AddressError;
-use crate::account::{AccountId, AccountStorageMode};
-use crate::note::{DEFAULT_LOCAL_TAG_LENGTH, MAX_LOCAL_TAG_LENGTH};
+use crate::account::AccountId;
+use crate::note::NoteTag;
 
 /// A user-facing address in Miden.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,11 +21,8 @@ impl AccountIdAddress {
     /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
     /// If no `tag_len` is provided, it defaults to [`DEFAULT_LOCAL_TAG_LENGTH`].
     pub fn new(id: AccountId, tag_len: Option<u8>) -> Result<Self, AddressError> {
-        if id.storage_mode() == AccountStorageMode::Network {
-            return Err(AddressError::NetworkAddressesNotSupported);
-        }
-        let tag_len = tag_len.unwrap_or(DEFAULT_LOCAL_TAG_LENGTH);
-        if tag_len > MAX_LOCAL_TAG_LENGTH {
+        let tag_len = tag_len.unwrap_or(NoteTag::DEFAULT_LOCAL_TAG_LENGTH);
+        if tag_len > NoteTag::MAX_LOCAL_TAG_LENGTH {
             return Err(AddressError::TagLengthTooLarge(tag_len));
         }
         Ok(Self { id, tag_len })
@@ -39,5 +36,14 @@ impl AccountIdAddress {
     /// Returns the preferred tag length.
     pub fn tag_len(&self) -> u8 {
         self.tag_len
+    }
+}
+
+impl Address {
+    /// Returns a note tag derived from this address.
+    pub fn get_note_tag(&self) -> NoteTag {
+        match self {
+            Address::AccountId(addr) => NoteTag::from_account_id(addr.id()),
+        }
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -16,16 +16,27 @@ pub struct AccountIdAddress {
 }
 
 impl AccountIdAddress {
-    /// Creates a new account-id based address with an optional tag length.
+    /// Creates a new account-id based address with the default tag length.
     ///
     /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
-    /// If no `tag_len` is provided, it defaults to [`DEFAULT_LOCAL_TAG_LENGTH`].
-    pub fn new(id: AccountId, tag_len: Option<u8>) -> Result<Self, AddressError> {
-        let tag_len = tag_len.unwrap_or(NoteTag::DEFAULT_LOCAL_TAG_LENGTH);
+    /// The tag length defaults to [`DEFAULT_LOCAL_TAG_LENGTH`].
+    pub fn new(id: AccountId) -> Self {
+        Self {
+            id,
+            tag_len: NoteTag::DEFAULT_LOCAL_TAG_LENGTH,
+        }
+    }
+
+    /// Sets a custom tag length for the address.
+    ///
+    /// # Errors
+    /// Returns an error if the tag length exceeds [`MAX_LOCAL_TAG_LENGTH`].
+    pub fn with_tag_len(mut self, tag_len: u8) -> Result<Self, AddressError> {
         if tag_len > NoteTag::MAX_LOCAL_TAG_LENGTH {
             return Err(AddressError::TagLengthTooLarge(tag_len));
         }
-        Ok(Self { id, tag_len })
+        self.tag_len = tag_len;
+        Ok(self)
     }
 
     /// Returns the underlying account id.

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -1,7 +1,6 @@
-use core::cmp::min;
-
-use crate::account::AccountId;
-use crate::note::NoteTag;
+use crate::AddressError;
+use crate::account::{AccountId, AccountStorageMode};
+use crate::note::{DEFAULT_LOCAL_TAG_LENGTH, MAX_LOCAL_TAG_LENGTH};
 
 /// A user-facing address in Miden.
 ///
@@ -12,21 +11,6 @@ pub enum Address {
     AccountId(AccountIdAddress),
 }
 
-impl Address {
-    /// Derives a `NoteTag` from this address according to its scheme.
-    ///
-    /// The `tag_len` semantics depend on the underlying address scheme. For account-id based
-    /// addressing:
-    /// - For network accounts, up to 30 MSBs of the account ID may be included.
-    /// - For public/private accounts, up to 14 MSBs of the account ID may be included in the
-    ///   tag field; the remaining bits are zeroed.
-    pub fn to_note_tag(&self) -> NoteTag {
-        match self {
-            Address::AccountId(addr) => addr.to_note_tag(),
-        }
-    }
-}
-
 /// Address that targets a specific `AccountId` with an explicit tag length preference.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountIdAddress {
@@ -35,12 +19,19 @@ pub struct AccountIdAddress {
 }
 
 impl AccountIdAddress {
-    /// Creates a new account-id based address with a desired tag length.
+    /// Creates a new account-id based address with an optional tag length.
     ///
-    /// For network accounts, up to 30 bits can be encoded into the tag.
-    /// For local (public/private) accounts, up to 14 bits can be encoded into the tag.
-    pub fn new(id: AccountId, tag_len: u8) -> Self {
-        Self { id, tag_len }
+    /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
+    /// If no `tag_len` is provided, it defaults to [`DEFAULT_LOCAL_TAG_LENGTH`].
+    pub fn new(id: AccountId, tag_len: Option<u8>) -> Result<Self, AddressError> {
+        if id.storage_mode() == AccountStorageMode::Network {
+            return Err(AddressError::NetworkAddressesNotSupported);
+        }
+        let tag_len = tag_len.unwrap_or(DEFAULT_LOCAL_TAG_LENGTH);
+        if tag_len > MAX_LOCAL_TAG_LENGTH {
+            return Err(AddressError::TagLengthTooLarge(tag_len));
+        }
+        Ok(Self { id, tag_len })
     }
 
     /// Returns the underlying account id.
@@ -51,42 +42,5 @@ impl AccountIdAddress {
     /// Returns the preferred tag length.
     pub fn tag_len(&self) -> u8 {
         self.tag_len
-    }
-
-    /// Builds a NoteTag from this account-id address using the `tag_len` policy.
-    pub fn to_note_tag(&self) -> NoteTag {
-        // Extract the top 30 bits of the account id prefix once; all schemes derive from these.
-        let prefix_id: u64 = self.id.prefix().into();
-        let high_bits_30 = (prefix_id >> 34) & 0x3fff_ffff; // 30 MSBs of the account id
-
-        match self.id.storage_mode() {
-            // Network accounts: use up to 30 bits located in the lower 30 bits of the tag payload.
-            crate::account::AccountStorageMode::Network => {
-                let k = min(self.tag_len as u32, 30) as u32;
-                let payload = if k == 0 {
-                    0u32
-                } else {
-                    // Keep the top-k bits in their top positions within the 30-bit field.
-                    let mask_k = (((1u64 << k) - 1) << (30 - k)) as u32;
-                    (high_bits_30 as u32) & mask_k
-                };
-                NoteTag::NetworkAccount(payload)
-            }
-            // Local (public/private) accounts: only 14 bits available in the upper part of the 30-bit field.
-            crate::account::AccountStorageMode::Private | crate::account::AccountStorageMode::Public => {
-                let k = min(self.tag_len as u32, 14) as u32;
-                if k == 0 {
-                    // No bits embedded, payload is zero.
-                    NoteTag::LocalAny(0)
-                } else {
-                    // Take the top 14 bits from the 30-bit sequence.
-                    let top14 = ((high_bits_30 >> 16) & 0x3fff) as u32; // 14 bits
-                    // Keep only the top-k bits of those 14 bits and place them in the 14-bit segment (bits 16..29).
-                    let mask_k_in_14 = ((1u32 << k) - 1) << (14 - k);
-                    let payload = (top14 & mask_k_in_14) << 16;
-                    NoteTag::LocalAny(payload)
-                }
-            }
-        }
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -3,7 +3,7 @@ use crate::account::AccountId;
 use crate::note::NoteTag;
 
 /// A user-facing address in Miden.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Address {
     AccountId(AccountIdAddress),
 }
@@ -13,7 +13,7 @@ pub enum Address {
 /// The tag length preference lets the owner of the account choose their level of privacy. A higher
 /// tag length makes the account more uniquely identifiable and reduces privacy, while a shorter
 /// length increases privacy at the cost of matching more notes published onchain.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AccountIdAddress {
     id: AccountId,
     tag_len: u8,

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -10,9 +10,11 @@ pub enum Address {
 
 /// Address that targets a specific `AccountId` with an explicit tag length preference.
 ///
-/// The tag length preference lets the owner of the account choose their level of privacy. A higher
-/// tag length makes the account more uniquely identifiable and reduces privacy, while a shorter
-/// length increases privacy at the cost of matching more notes published onchain.
+/// The tag length preference determines how many bits of the account ID are encoded into
+/// [`NoteTag`]s of notes targeted to this address. This lets the owner of the account choose
+/// their level of privacy. A higher tag length makes the account more uniquely identifiable and
+/// reduces privacy, while a shorter length increases privacy at the cost of matching more notes
+/// published onchain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AccountIdAddress {
     id: AccountId,
@@ -34,7 +36,8 @@ impl AccountIdAddress {
         Self { id, tag_len }
     }
 
-    /// Sets a custom tag length for the address.
+    /// Sets a custom tag length for the address, determining how many bits of the account ID
+    /// are encoded into [`NoteTag`]s.
     ///
     /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
     /// For network accounts, the tag length should always be set to 30 bits.

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -1,5 +1,5 @@
 use crate::AddressError;
-use crate::account::AccountId;
+use crate::account::{AccountId, AccountStorageMode};
 use crate::note::NoteTag;
 
 /// A user-facing address in Miden.
@@ -22,23 +22,36 @@ pub struct AccountIdAddress {
 impl AccountIdAddress {
     /// Creates a new account-id based address with the default tag length.
     ///
-    /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
-    /// The tag length defaults to [`DEFAULT_LOCAL_TAG_LENGTH`].
+    /// The tag length defaults to [`DEFAULT_LOCAL_TAG_LENGTH`] for local, and
+    /// [`DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
     pub fn new(id: AccountId) -> Self {
-        Self {
-            id,
-            tag_len: NoteTag::DEFAULT_LOCAL_TAG_LENGTH,
-        }
+        let tag_len = if id.storage_mode() == AccountStorageMode::Network {
+            NoteTag::DEFAULT_NETWORK_TAG_LENGTH
+        } else {
+            NoteTag::DEFAULT_LOCAL_TAG_LENGTH
+        };
+
+        Self { id, tag_len }
     }
 
     /// Sets a custom tag length for the address.
     ///
+    /// For local (both public and private) accounts, up to 30 bits can be encoded into the tag.
+    /// For network accounts, the tag length should always be set to 30 bits.
+    ///
     /// # Errors
-    /// Returns an error if the tag length exceeds [`MAX_LOCAL_TAG_LENGTH`].
+    /// Returns an error if:
+    /// - The tag length exceeds [`MAX_LOCAL_TAG_LENGTH`] for local accounts.
+    /// - The tag length is not [`DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
     pub fn with_tag_len(mut self, tag_len: u8) -> Result<Self, AddressError> {
-        if tag_len > NoteTag::MAX_LOCAL_TAG_LENGTH {
+        if self.id.storage_mode() == AccountStorageMode::Network {
+            if tag_len != NoteTag::DEFAULT_NETWORK_TAG_LENGTH {
+                return Err(AddressError::CustomTagLengthNotAllowedForNetworkAccounts(tag_len));
+            }
+        } else if tag_len > NoteTag::MAX_LOCAL_TAG_LENGTH {
             return Err(AddressError::TagLengthTooLarge(tag_len));
         }
+
         self.tag_len = tag_len;
         Ok(self)
     }
@@ -58,7 +71,12 @@ impl Address {
     /// Returns a note tag derived from this address.
     pub fn get_note_tag(&self) -> NoteTag {
         match self {
-            Address::AccountId(addr) => NoteTag::from_account_id(addr.id()),
+            Address::AccountId(addr) => match addr.id.storage_mode() {
+                AccountStorageMode::Network => NoteTag::from_network_account_id(addr.id),
+                AccountStorageMode::Private | AccountStorageMode::Public => {
+                    NoteTag::from_local_account_id(addr.id, addr.tag_len)
+                },
+            },
         }
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -20,7 +20,7 @@ pub struct AccountIdAddress {
 }
 
 impl AccountIdAddress {
-    /// Creates a new account-id based address with the default tag length.
+    /// Creates a new account ID based address with the default tag length.
     ///
     /// The tag length defaults to [`NoteTag::DEFAULT_LOCAL_TAG_LENGTH`] for local, and
     /// [`NoteTag::DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -18,6 +18,12 @@ impl Address {
     }
 }
 
+impl From<AccountIdAddress> for Address {
+    fn from(addr: AccountIdAddress) -> Self {
+        Address::AccountId(addr)
+    }
+}
+
 /// Address that targets a specific `AccountId` with an explicit tag length preference.
 ///
 /// The tag length preference determines how many bits of the account ID are encoded into

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -9,6 +9,15 @@ pub enum Address {
     AccountId(AccountIdAddress),
 }
 
+impl Address {
+    /// Returns a note tag derived from this address.
+    pub fn to_note_tag(&self) -> NoteTag {
+        match self {
+            Address::AccountId(addr) => addr.to_note_tag(),
+        }
+    }
+}
+
 /// Address that targets a specific `AccountId` with an explicit tag length preference.
 ///
 /// The tag length preference determines how many bits of the account ID are encoded into
@@ -78,15 +87,6 @@ impl AccountIdAddress {
                 NoteTag::from_local_account_id(self.id, self.tag_len)
                     .expect("AccountIdAddress validated that tag len does not exceed MAX_LOCAL_TAG_LENGTH bits")
             },
-        }
-    }
-}
-
-impl Address {
-    /// Returns a note tag derived from this address.
-    pub fn to_note_tag(&self) -> NoteTag {
-        match self {
-            Address::AccountId(addr) => addr.to_note_tag(),
         }
     }
 }

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -22,8 +22,8 @@ pub struct AccountIdAddress {
 impl AccountIdAddress {
     /// Creates a new account-id based address with the default tag length.
     ///
-    /// The tag length defaults to [`DEFAULT_LOCAL_TAG_LENGTH`] for local, and
-    /// [`DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
+    /// The tag length defaults to [`NoteTag::DEFAULT_LOCAL_TAG_LENGTH`] for local, and
+    /// [`NoteTag::DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
     pub fn new(id: AccountId) -> Self {
         let tag_len = if id.storage_mode() == AccountStorageMode::Network {
             NoteTag::DEFAULT_NETWORK_TAG_LENGTH
@@ -41,8 +41,8 @@ impl AccountIdAddress {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The tag length exceeds [`MAX_LOCAL_TAG_LENGTH`] for local accounts.
-    /// - The tag length is not [`DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
+    /// - The tag length exceeds [`NoteTag::MAX_LOCAL_TAG_LENGTH`] for local accounts.
+    /// - The tag length is not [`NoteTag::DEFAULT_NETWORK_TAG_LENGTH`] for network accounts.
     pub fn with_tag_len(mut self, tag_len: u8) -> Result<Self, AddressError> {
         if self.id.storage_mode() == AccountStorageMode::Network {
             if tag_len != NoteTag::DEFAULT_NETWORK_TAG_LENGTH {

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -3,6 +3,7 @@ use crate::account::{AccountId, AccountStorageMode};
 use crate::note::NoteTag;
 
 /// A user-facing address in Miden.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Address {
     AccountId(AccountIdAddress),

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -1,0 +1,92 @@
+use core::cmp::min;
+
+use crate::account::AccountId;
+use crate::note::NoteTag;
+
+/// A user-facing address in Miden.
+///
+/// For now this supports only account-id based addressing. Future schemes (e.g. public keys)
+/// can be added as new enum variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Address {
+    AccountId(AccountIdAddress),
+}
+
+impl Address {
+    /// Derives a `NoteTag` from this address according to its scheme.
+    ///
+    /// The `tag_len` semantics depend on the underlying address scheme. For account-id based
+    /// addressing:
+    /// - For network accounts, up to 30 MSBs of the account ID may be included.
+    /// - For public/private accounts, up to 14 MSBs of the account ID may be included in the
+    ///   tag field; the remaining bits are zeroed.
+    pub fn to_note_tag(&self) -> NoteTag {
+        match self {
+            Address::AccountId(addr) => addr.to_note_tag(),
+        }
+    }
+}
+
+/// Address that targets a specific `AccountId` with an explicit tag length preference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountIdAddress {
+    id: AccountId,
+    tag_len: u8,
+}
+
+impl AccountIdAddress {
+    /// Creates a new account-id based address with a desired tag length.
+    ///
+    /// For network accounts, up to 30 bits can be encoded into the tag.
+    /// For local (public/private) accounts, up to 14 bits can be encoded into the tag.
+    pub fn new(id: AccountId, tag_len: u8) -> Self {
+        Self { id, tag_len }
+    }
+
+    /// Returns the underlying account id.
+    pub fn id(&self) -> AccountId {
+        self.id
+    }
+
+    /// Returns the preferred tag length.
+    pub fn tag_len(&self) -> u8 {
+        self.tag_len
+    }
+
+    /// Builds a NoteTag from this account-id address using the `tag_len` policy.
+    pub fn to_note_tag(&self) -> NoteTag {
+        // Extract the top 30 bits of the account id prefix once; all schemes derive from these.
+        let prefix_id: u64 = self.id.prefix().into();
+        let high_bits_30 = (prefix_id >> 34) & 0x3fff_ffff; // 30 MSBs of the account id
+
+        match self.id.storage_mode() {
+            // Network accounts: use up to 30 bits located in the lower 30 bits of the tag payload.
+            crate::account::AccountStorageMode::Network => {
+                let k = min(self.tag_len as u32, 30) as u32;
+                let payload = if k == 0 {
+                    0u32
+                } else {
+                    // Keep the top-k bits in their top positions within the 30-bit field.
+                    let mask_k = (((1u64 << k) - 1) << (30 - k)) as u32;
+                    (high_bits_30 as u32) & mask_k
+                };
+                NoteTag::NetworkAccount(payload)
+            }
+            // Local (public/private) accounts: only 14 bits available in the upper part of the 30-bit field.
+            crate::account::AccountStorageMode::Private | crate::account::AccountStorageMode::Public => {
+                let k = min(self.tag_len as u32, 14) as u32;
+                if k == 0 {
+                    // No bits embedded, payload is zero.
+                    NoteTag::LocalAny(0)
+                } else {
+                    // Take the top 14 bits from the 30-bit sequence.
+                    let top14 = ((high_bits_30 >> 16) & 0x3fff) as u32; // 14 bits
+                    // Keep only the top-k bits of those 14 bits and place them in the 14-bit segment (bits 16..29).
+                    let mask_k_in_14 = ((1u32 << k) - 1) << (14 - k);
+                    let payload = (top14 & mask_k_in_14) << 16;
+                    NoteTag::LocalAny(payload)
+                }
+            }
+        }
+    }
+}

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -214,9 +214,7 @@ pub enum AccountTreeError {
 
 #[derive(Debug, Error)]
 pub enum AddressError {
-    #[error("network addresses are not supported")]
-    NetworkAddressesNotSupported,
-    #[error("tag length {0} is too large, must be less than or equal to {max}", max = crate::note::MAX_LOCAL_TAG_LENGTH)]
+    #[error("tag length {0} is too large, must be less than or equal to {max}", max = crate::note::NoteTag::MAX_LOCAL_TAG_LENGTH)]
     TagLengthTooLarge(u8),
 }
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -214,6 +214,8 @@ pub enum AccountTreeError {
 
 #[derive(Debug, Error)]
 pub enum AddressError {
+    #[error("tag length {0} should be {expected} bits for network accounts", expected = crate::note::NoteTag::DEFAULT_NETWORK_TAG_LENGTH)]
+    CustomTagLengthNotAllowedForNetworkAccounts(u8),
     #[error("tag length {0} is too large, must be less than or equal to {max}", max = crate::note::NoteTag::MAX_LOCAL_TAG_LENGTH)]
     TagLengthTooLarge(u8),
 }

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -209,6 +209,17 @@ pub enum AccountTreeError {
     WitnessMerklePathDepthDoesNotMatchAccountTreeDepth(usize),
 }
 
+// ADDRESS ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum AddressError {
+    #[error("network addresses are not supported")]
+    NetworkAddressesNotSupported,
+    #[error("tag length {0} is too large, must be less than or equal to {max}", max = crate::note::MAX_LOCAL_TAG_LENGTH)]
+    TagLengthTooLarge(u8),
+}
+
 // BECH32 ERROR
 // ================================================================================================
 

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -399,8 +399,8 @@ pub enum AssetVaultError {
 
 #[derive(Debug, Error)]
 pub enum NoteError {
-    #[error("note tag tag length {0} exceeds the maximum of {max}", max = NoteTag::MAX_LOCAL_TAG_LENGTH)]
-    NoteTagTagLengthTooLarge(u8),
+    #[error("note tag length {0} exceeds the maximum of {max}", max = NoteTag::MAX_LOCAL_TAG_LENGTH)]
+    NoteTagLengthTooLarge(u8),
     #[error("duplicate fungible asset from issuer {0} in note")]
     DuplicateFungibleAsset(AccountId),
     #[error("duplicate non fungible asset {0} in note")]

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -399,6 +399,8 @@ pub enum AssetVaultError {
 
 #[derive(Debug, Error)]
 pub enum NoteError {
+    #[error("note tag tag length {0} exceeds the maximum of {max}", max = NoteTag::MAX_LOCAL_TAG_LENGTH)]
+    NoteTagTagLengthTooLarge(u8),
     #[error("duplicate fungible asset from issuer {0} in note")]
     DuplicateFungibleAsset(AccountId),
     #[error("duplicate non fungible asset {0} in note")]

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -30,6 +30,7 @@ pub use errors::{
     AccountError,
     AccountIdError,
     AccountTreeError,
+    AddressError,
     AssetError,
     AssetVaultError,
     BatchAccountUpdateError,

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -7,13 +7,12 @@ extern crate alloc;
 extern crate std;
 
 pub mod account;
+pub mod address;
 pub mod asset;
 pub mod batch;
 pub mod block;
 pub mod note;
 pub mod transaction;
-
-pub mod address;
 
 #[cfg(any(feature = "testing", test))]
 pub mod testing;

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -13,6 +13,8 @@ pub mod block;
 pub mod note;
 pub mod transaction;
 
+pub mod address;
+
 #[cfg(any(feature = "testing", test))]
 pub mod testing;
 

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -27,7 +27,7 @@ mod note_id;
 pub use note_id::NoteId;
 
 mod note_tag;
-pub use note_tag::{DEFAULT_LOCAL_TAG_LENGTH, MAX_LOCAL_TAG_LENGTH, NoteExecutionMode, NoteTag};
+pub use note_tag::{NoteExecutionMode, NoteTag};
 
 mod note_type;
 pub use note_type::NoteType;

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -27,7 +27,7 @@ mod note_id;
 pub use note_id::NoteId;
 
 mod note_tag;
-pub use note_tag::{NoteExecutionMode, NoteTag};
+pub use note_tag::{DEFAULT_LOCAL_TAG_LENGTH, MAX_LOCAL_TAG_LENGTH, NoteExecutionMode, NoteTag};
 
 mod note_type;
 pub use note_type::NoteType;

--- a/crates/miden-objects/src/note/note_tag.rs
+++ b/crates/miden-objects/src/note/note_tag.rs
@@ -118,9 +118,9 @@ impl NoteTag {
     /// The exponent of the maximum allowed use case id. In other words, 2^exponent is the maximum
     /// allowed use case id.
     pub(crate) const MAX_USE_CASE_ID_EXPONENT: u8 = 14;
-    // Creating a tag for local execution directly from AccountId defaults to using 14 bits.
+    /// The default note tag length for an account ID with local execution.
     pub const DEFAULT_LOCAL_TAG_LENGTH: u8 = 14;
-    // Creating a tag for network accounts should always use 30 bits.
+    /// The default note tag length for an account ID with network execution.
     pub const DEFAULT_NETWORK_TAG_LENGTH: u8 = 30;
     /// The maximum number of bits that can be encoded into the tag for local accounts.
     pub const MAX_LOCAL_TAG_LENGTH: u8 = 30;
@@ -179,7 +179,7 @@ impl NoteTag {
         let high_bits = high_bits as u32;
 
         // Select the top `tag_len` bits of the account ID, i.e.:
-        // [2 zero bits | remaining high bits (tag_len bits) | 16 zero bits].
+        // [2 zero bits | remaining high bits (tag_len bits) | (30 - tag_len) zero bits].
         let high_bits = high_bits & (u32::MAX << (32 - 2 - tag_len));
 
         // Set the local execution tag in the two most significant bits.

--- a/crates/miden-objects/src/note/note_tag.rs
+++ b/crates/miden-objects/src/note/note_tag.rs
@@ -13,7 +13,6 @@ use super::{
     Serializable,
 };
 use crate::account::AccountStorageMode;
-use crate::address::Address;
 
 // CONSTANTS
 // ================================================================================================
@@ -28,11 +27,6 @@ const NETWORK_PUBLIC_USECASE: u32 = 0x4000_0000;
 const LOCAL_PUBLIC_ANY: u32 = 0x8000_0000;
 // The 2 most significant bits are set to `0b11`.
 const LOCAL_ANY: u32 = 0xc000_0000;
-
-// Creating a tag for local use case directly from AccountId defaults to using 14 bits.
-pub const DEFAULT_LOCAL_TAG_LENGTH: u8 = 14;
-/// The maximum number of bits that can be encoded into the tag for local accounts.
-pub const MAX_LOCAL_TAG_LENGTH: u8 = 30;
 
 /// [super::Note]'s execution mode hints.
 ///
@@ -124,24 +118,12 @@ impl NoteTag {
     /// The exponent of the maximum allowed use case id. In other words, 2^exponent is the maximum
     /// allowed use case id.
     pub(crate) const MAX_USE_CASE_ID_EXPONENT: u8 = 14;
-
+    // Creating a tag for local execution directly from AccountId defaults to using 14 bits.
+    pub const DEFAULT_LOCAL_TAG_LENGTH: u8 = 14;
+    /// The maximum number of bits that can be encoded into the tag for local accounts.
+    pub const MAX_LOCAL_TAG_LENGTH: u8 = 30;
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
-
-    pub fn from_address(address: Address) -> Self {
-        match address {
-            Address::AccountId(addr) => {
-                let account_id = addr.id();
-                assert_ne!(
-                    account_id.storage_mode(),
-                    AccountStorageMode::Network,
-                    "Network addresses are not supported"
-                );
-
-                NoteTag::from_local_account_id(account_id, addr.tag_len())
-            },
-        }
-    }
 
     /// Returns a new [NoteTag::NetworkAccount] or [NoteTag::LocalAny] instantiated from the
     /// specified account ID.
@@ -171,7 +153,7 @@ impl NoteTag {
                 Self::NetworkAccount(high_bits as u32)
             },
             AccountStorageMode::Private | AccountStorageMode::Public => {
-                Self::from_local_account_id(account_id, DEFAULT_LOCAL_TAG_LENGTH)
+                Self::from_local_account_id(account_id, Self::DEFAULT_LOCAL_TAG_LENGTH)
             },
         }
     }

--- a/crates/miden-objects/src/note/note_tag.rs
+++ b/crates/miden-objects/src/note/note_tag.rs
@@ -158,6 +158,13 @@ impl NoteTag {
         }
     }
 
+    /// Constructs a [`NoteTag::LocalAny`] from the given `account_id` and `tag_len`.
+    ///
+    /// The tag is constructed as follows:
+    ///
+    /// - The two most significant bits are set to `0b11` to indicate a [LOCAL_ANY] tag.
+    /// - The next `tag_len` bits are set to the most significant bits of the account ID prefix.
+    /// - The remaining bits are set to zero.
     fn from_local_account_id(account_id: AccountId, tag_len: u8) -> Self {
         let prefix_id: u64 = account_id.prefix().into();
 

--- a/crates/miden-objects/src/note/note_tag.rs
+++ b/crates/miden-objects/src/note/note_tag.rs
@@ -165,7 +165,7 @@ impl NoteTag {
         tag_len: u8,
     ) -> Result<Self, NoteError> {
         if tag_len > Self::MAX_LOCAL_TAG_LENGTH {
-            return Err(NoteError::NoteTagTagLengthTooLarge(tag_len));
+            return Err(NoteError::NoteTagLengthTooLarge(tag_len));
         }
 
         let prefix_id: u64 = account_id.prefix().into();


### PR DESCRIPTION
Add `Address` and `AccountIdAddress` types.

Enable `NoteTag` derivation from `Address` with configurable tag length.

For now, we're skipping the fields `encryption_key` and `interface` from the issue https://github.com/0xMiden/miden-base/issues/1454.

For now I decided not to include `Network` accounts - these will not have public keys, so I'm not sure whether `Address` makes sense. If anything, then for consistency we could just make `Address` simply wrap the `AccountId` with pub_key as `None` and `tag_len` always set to 30.

This is just the first step, with no breaking change here in miden-base, and I don't think (?) there will be any. For example, protocol level methods such as `create_p2ide_note` etc. which currently take `AccountId`, should continue to operate the same.

Most changes will happen in miden-client, where we might need to change how the recipient is specified (`Address` instead of `AccountId`). If we do that, then perhaps it's worth implementing `Deref` for `Address` with `type Target = AccountId`.

closes https://github.com/0xMiden/miden-base/issues/1739