### PR TITLE
docs: add Fees section and align docs with kernel fee logic

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,5 +11,6 @@
 - [Notes](./note.md)
 - [Assets](./asset.md)
 - [Transactions](./transaction.md)
+- [Fees](./fees.md)
 - [State](./state.md)
 - [Blockchain](./blockchain.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,6 @@
 - [Notes](./note.md)
 - [Assets](./asset.md)
 - [Transactions](./transaction.md)
-- [Fees](./fees.md)
+  - [Fees](./fees.md)
 - [State](./state.md)
 - [Blockchain](./blockchain.md)

--- a/docs/src/asset.md
+++ b/docs/src/asset.md
@@ -15,8 +15,8 @@ In Miden, assets serve as the primary means of expressing and transferring value
 3. **Censorship resistance:**  
    Users can transact freely and privately with no single contract or entity controlling `Asset` transfers. This reduces the risk of censored transactions, resulting in a more open and resilient system.
 
-4. **Flexible fee payment:**  
-   Unlike protocols that require a specific base `Asset` for fees, Miden allows users to pay fees in any supported `Asset`. This flexibility simplifies the user experience.
+4. **Fee payment in native asset:**  
+   Transaction fees are paid in the chain’s native asset as defined by the current reference block’s fee parameters. See [Fees](./fees.md).
 
 ## Native asset
 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -6,7 +6,7 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 
 - The fee depends on the number of VM cycles the transaction executes and grows logarithmically with that count.
 - The kernel estimates the number of verification cycles by taking log2 of the estimated total execution cycles (rounded up). The result is then multiplied by the `verification_base_fee` from the reference block’s fee parameters.
-- In other words, the fee is proportional to the logarithm of the transaction’s execution cost, scaled by the base verification fee defined in the block header.
+- In other words, the fee is proportional to the logarithm of the transaction’s number of execution cycles, scaled by the base verification fee defined in the block header.
 
 ## Which asset is used to pay fees
 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -15,5 +15,5 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 
 ## How fees are paid
 
-- Practically, users should ensure their account’s vault holds sufficient balance of the native asset of the current reference block to cover the fee. The fee is charged automatically; no explicit fee-sending step is required. 
+- Users should ensure their account’s vault holds sufficient balance of the native asset to cover the fee. The fee is charged automatically; no explicit transaction kernel API must be called. 
 - If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -4,117 +4,17 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 
 ## How fees are computed
 
-- The fee depends on the number of VM cycles the transaction executes and grows logarithmically with that count. The kernel estimates verification cycles by taking log2 of the estimated total cycles, rounding up to the next power of two. The fee amount is then computed as:
-  - `fee_amount = verification_base_fee * ceil(log2(estimated_cycles_rounded_up_to_pow2))`
-- The `verification_base_fee` comes from the current reference block’s fee parameters.
-
-Relevant kernel logic:
-```246:270:crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
-#! - fee_amount is the computed fee amount of the transaction in the native asset.
-proc.compute_fee
-    # get the number of cycles the transaction has taken to execute up this point
-    clk
-    # => [num_current_cycles]
-
-    emit.EPILOGUE_AFTER_TX_FEE_COMPUTED
-
-    # estimate the number of cycles the transaction will take
-    add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
-    # => [num_tx_cycles]
-
-    # ilog2 will round down, but we need to round up, so we add 1 afterwards.
-    ilog2 add.1
-    # => [num_estimated_verification_cycles]
-
-    exec.memory::get_verification_base_fee
-    # => [verification_base_fee, num_estimated_verification_cycles]
-
-    mul
-    # => [verification_cost]
-end
-```
-
-And the block header fee parameters:
-```309:351:crates/miden-objects/src/block/header.rs
-/// This defines how to compute the fees of a transaction and which asset fees can be paid in.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FeeParameters {
-    /// The [`AccountId`] of the fungible faucet whose assets are accepted for fee payments in the
-    /// transaction kernel, or in other words, the native asset of the blockchain.
-    native_asset_id: AccountId,
-    /// The base fee (in base units) capturing the cost for the verification of a transaction.
-    verification_base_fee: u32,
-}
-...
-/// Returns the base fee capturing the cost for the verification of a transaction.
-pub fn verification_base_fee(&self) -> u32 {
-    self.verification_base_fee
-}
-```
-
-For testing/utilities, there is also a Rust helper mirroring the kernel’s computation at a high level:
-```3:11:crates/miden-objects/src/testing/tx.rs
-impl ExecutedTransaction {
-    /// A Rust implementation of the compute_fee epilogue procedure.
-    pub fn compute_fee(&self) -> u64 {
-        // Round up the number of cycles to the next power of two and take log2 of it.
-        let verification_cycles = self.measurements().trace_length().ilog2();
-        let fee_amount =
-            self.block_header().fee_parameters().verification_base_fee() * verification_cycles;
-        fee_amount as u64
-    }
-}
-```
+- The fee depends on the number of VM cycles the transaction executes and grows logarithmically with that count.
+- The kernel estimates the number of verification cycles by taking log2 of the estimated total execution cycles (rounded up). The result is then multiplied by the `verification_base_fee` from the reference block’s fee parameters.
+- In other words, the fee is proportional to the logarithm of the transaction’s execution cost, scaled by the base verification fee defined in the block header.
 
 ## Which asset is used to pay fees
 
-- Fees are paid in the chain’s native asset, defined by the current reference block’s `FeeParameters.native_asset_id`.
-- The kernel constructs a fee asset using that native asset ID and removes it from the account’s vault:
-```272:319:crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
-proc.build_native_fee_asset
-    exec.memory::get_native_asset_id
-    # => [native_asset_id_prefix, native_asset_id_suffix, fee_amount]
-
-    push.0 movdn.2
-    # => [native_asset_id_prefix, native_asset_id_suffix, 0, fee_amount]
-    # => [FEE_ASSET]
-end
-
-proc.compute_and_remove_fee
-    # compute the fee the tx needs to pay
-    exec.compute_fee
-    # => [fee_amount]
-
-    # build the native asset from the fee amount
-    exec.build_native_fee_asset
-    # => [FEE_ASSET]
-
-    # remove the fee from the native account's vault
-    exec.account::remove_asset_from_vault
-end
-```
-
-If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.
+- Fees are paid in the chain’s native asset, defined by the current reference block’s fee parameters.
+- During the epilogue, the kernel constructs the fee asset using the native asset ID and removes it from the account’s vault.
+- If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.
 
 ## Where the fee appears in outputs
 
-- The transaction kernel outputs the fee asset as part of the epilogue, and the transaction outputs carry it explicitly:
-```31:44:crates/miden-objects/src/transaction/outputs.rs
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TransactionOutputs {
-    /// Information related to the account's final state.
-    pub account: AccountHeader,
-    /// The commitment to the delta computed by the transaction kernel.
-    pub account_delta_commitment: Word,
-    /// Set of output notes created by the transaction.
-    pub output_notes: OutputNotes,
-    /// The fee of the transaction.
-    pub fee: FungibleAsset,
-    /// Defines up to which block the transaction is considered valid.
-    pub expiration_block_num: BlockNumber,
-}
-```
-
-## Practical implication for users
-
-- Ensure your account’s vault holds sufficient balance of the native asset of the current reference block to cover the computed fee. The fee is automatically charged during the transaction epilogue; no explicit fee-sending step is required. 
+- The transaction kernel outputs the computed fee as a fungible asset, and the transaction outputs include it explicitly.
+- Practically, users should ensure their account’s vault holds sufficient balance of the native asset of the current reference block to cover the fee. The fee is charged automatically; no explicit fee-sending step is required. 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -13,7 +13,8 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 - Fees are paid in the chain’s native asset, defined by the current reference block’s fee parameters.
 - The native asset is chosen once as part of the genesis block and then copied to every newly created block, which means the native asset is the same per network during the epilogue.
 
-## Where the fee appears in outputs
+## How fees are paid
 
 - The transaction kernel outputs the computed fee as a fungible asset, and the transaction outputs include it explicitly.
 - Practically, users should ensure their account’s vault holds sufficient balance of the native asset of the current reference block to cover the fee. The fee is charged automatically; no explicit fee-sending step is required. 
+- If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -15,5 +15,5 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 
 ## How fees are paid
 
-- Users should ensure their account’s vault holds sufficient balance of the native asset to cover the fee. The fee is charged automatically; no explicit transaction kernel API must be called. 
+- Users should ensure their account’s vault holds sufficient balance of the native asset to cover the fee. The fee is charged automatically; no explicit transaction kernel API must be called.
 - If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -11,7 +11,7 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 ## Which asset is used to pay fees
 
 - Fees are paid in the chain’s native asset, defined by the current reference block’s fee parameters.
-- The native asset is chosen once as part of the genesis block and then copied to every newly created block, which means the native asset is the same per network during the epilogue.
+- The native asset is chosen once as part of the genesis block and then copied to every newly created block, which means the native asset stays consistent for a given network.
 
 ## How fees are paid
 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -11,8 +11,7 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 ## Which asset is used to pay fees
 
 - Fees are paid in the chain’s native asset, defined by the current reference block’s fee parameters.
-- During the epilogue, the kernel constructs the fee asset using the native asset ID and removes it from the account’s vault.
-- If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.
+- The native asset is chosen once as part of the genesis block and then copied to every newly created block, which means the native asset is the same per network during the epilogue.
 
 ## Where the fee appears in outputs
 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -1,0 +1,120 @@
+# Fees
+
+Miden transactions pay a fee that is computed and charged automatically by the transaction kernel during the epilogue.
+
+## How fees are computed
+
+- The fee depends on the number of VM cycles the transaction executes and grows logarithmically with that count. The kernel estimates verification cycles by taking log2 of the estimated total cycles, rounding up to the next power of two. The fee amount is then computed as:
+  - `fee_amount = verification_base_fee * ceil(log2(estimated_cycles_rounded_up_to_pow2))`
+- The `verification_base_fee` comes from the current reference block’s fee parameters.
+
+Relevant kernel logic:
+```246:270:crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+#! - fee_amount is the computed fee amount of the transaction in the native asset.
+proc.compute_fee
+    # get the number of cycles the transaction has taken to execute up this point
+    clk
+    # => [num_current_cycles]
+
+    emit.EPILOGUE_AFTER_TX_FEE_COMPUTED
+
+    # estimate the number of cycles the transaction will take
+    add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
+    # => [num_tx_cycles]
+
+    # ilog2 will round down, but we need to round up, so we add 1 afterwards.
+    ilog2 add.1
+    # => [num_estimated_verification_cycles]
+
+    exec.memory::get_verification_base_fee
+    # => [verification_base_fee, num_estimated_verification_cycles]
+
+    mul
+    # => [verification_cost]
+end
+```
+
+And the block header fee parameters:
+```309:351:crates/miden-objects/src/block/header.rs
+/// This defines how to compute the fees of a transaction and which asset fees can be paid in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeeParameters {
+    /// The [`AccountId`] of the fungible faucet whose assets are accepted for fee payments in the
+    /// transaction kernel, or in other words, the native asset of the blockchain.
+    native_asset_id: AccountId,
+    /// The base fee (in base units) capturing the cost for the verification of a transaction.
+    verification_base_fee: u32,
+}
+...
+/// Returns the base fee capturing the cost for the verification of a transaction.
+pub fn verification_base_fee(&self) -> u32 {
+    self.verification_base_fee
+}
+```
+
+For testing/utilities, there is also a Rust helper mirroring the kernel’s computation at a high level:
+```3:11:crates/miden-objects/src/testing/tx.rs
+impl ExecutedTransaction {
+    /// A Rust implementation of the compute_fee epilogue procedure.
+    pub fn compute_fee(&self) -> u64 {
+        // Round up the number of cycles to the next power of two and take log2 of it.
+        let verification_cycles = self.measurements().trace_length().ilog2();
+        let fee_amount =
+            self.block_header().fee_parameters().verification_base_fee() * verification_cycles;
+        fee_amount as u64
+    }
+}
+```
+
+## Which asset is used to pay fees
+
+- Fees are paid in the chain’s native asset, defined by the current reference block’s `FeeParameters.native_asset_id`.
+- The kernel constructs a fee asset using that native asset ID and removes it from the account’s vault:
+```272:319:crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+proc.build_native_fee_asset
+    exec.memory::get_native_asset_id
+    # => [native_asset_id_prefix, native_asset_id_suffix, fee_amount]
+
+    push.0 movdn.2
+    # => [native_asset_id_prefix, native_asset_id_suffix, 0, fee_amount]
+    # => [FEE_ASSET]
+end
+
+proc.compute_and_remove_fee
+    # compute the fee the tx needs to pay
+    exec.compute_fee
+    # => [fee_amount]
+
+    # build the native asset from the fee amount
+    exec.build_native_fee_asset
+    # => [FEE_ASSET]
+
+    # remove the fee from the native account's vault
+    exec.account::remove_asset_from_vault
+end
+```
+
+If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.
+
+## Where the fee appears in outputs
+
+- The transaction kernel outputs the fee asset as part of the epilogue, and the transaction outputs carry it explicitly:
+```31:44:crates/miden-objects/src/transaction/outputs.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionOutputs {
+    /// Information related to the account's final state.
+    pub account: AccountHeader,
+    /// The commitment to the delta computed by the transaction kernel.
+    pub account_delta_commitment: Word,
+    /// Set of output notes created by the transaction.
+    pub output_notes: OutputNotes,
+    /// The fee of the transaction.
+    pub fee: FungibleAsset,
+    /// Defines up to which block the transaction is considered valid.
+    pub expiration_block_num: BlockNumber,
+}
+```
+
+## Practical implication for users
+
+- Ensure your account’s vault holds sufficient balance of the native asset of the current reference block to cover the computed fee. The fee is automatically charged during the transaction epilogue; no explicit fee-sending step is required. 

--- a/docs/src/fees.md
+++ b/docs/src/fees.md
@@ -15,6 +15,5 @@ Miden transactions pay a fee that is computed and charged automatically by the t
 
 ## How fees are paid
 
-- The transaction kernel outputs the computed fee as a fungible asset, and the transaction outputs include it explicitly.
 - Practically, users should ensure their account’s vault holds sufficient balance of the native asset of the current reference block to cover the fee. The fee is charged automatically; no explicit fee-sending step is required. 
 - If the account does not contain enough of the native asset to cover the computed fee, the transaction fails during the epilogue.

--- a/docs/src/transaction.md
+++ b/docs/src/transaction.md
@@ -47,7 +47,7 @@ A `Transaction` requires several inputs:
 4. **Epilogue**
    Completes the execution, resulting in an updated account state and a generated zero-knowledge proof. The validity of the resulting transaction is ensured by a combination of user-defined and protocol-defined checks:
    - The account's [authentication procedure](account/code.md#authentication) is called to authorize the transaction.
-   - The transaction fee is computed and removed from the account’s vault in the chain’s native asset. See [Fees](./fees.md).
+   - The transaction fee is computed and removed from the account's vault in the chain's native asset. See [Fees](./fees.md).
    - The account's state must have changed, or at least one input note must have been consumed to make the transaction non-empty.
    - If the account's state has changed, the `nonce` must have been incremented to prevent replay attacks.
    - Additionally, the sum of all input assets must be equal to the sum of all output assets (if the account is not a faucet).

--- a/docs/src/transaction.md
+++ b/docs/src/transaction.md
@@ -47,6 +47,7 @@ A `Transaction` requires several inputs:
 4. **Epilogue**
    Completes the execution, resulting in an updated account state and a generated zero-knowledge proof. The validity of the resulting transaction is ensured by a combination of user-defined and protocol-defined checks:
    - The account's [authentication procedure](account/code.md#authentication) is called to authorize the transaction.
+   - The transaction fee is computed and removed from the account’s vault in the chain’s native asset. See [Fees](./fees.md).
    - The account's state must have changed, or at least one input note must have been consumed to make the transaction non-empty.
    - If the account's state has changed, the `nonce` must have been incremented to prevent replay attacks.
    - Additionally, the sum of all input assets must be equal to the sum of all output assets (if the account is not a faucet).


### PR DESCRIPTION
Add docs/src/fees.md explaining automatic fee computation, native asset payment, and outputs, with code citations.
Link Fees page in docs/src/SUMMARY.md.
Correct docs/src/asset.md to state fees are paid in the native asset.
Update docs/src/transaction.md epilogue to mention automatic fee deduction and link to Fees.
Refs #1683.