### PR TITLE
feat: split mock library into account and faucet libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - [BREAKING] Move `IncrNonceAuthComponent`, `ConditionalAuthComponent` and `AccountMockComponent` to `miden-lib` ([#1722](https://github.com/0xMiden/miden-base/pull/1722)).
 - Refactor `contracts::auth::basic` into a reusable library procedure `auth::rpo_falcon512` ([#1712](https://github.com/0xMiden/miden-base/pull/1712)).
 - [BREAKING] Refactored `FungibleAsset::sub` to be more similar to `FungibleAsset::add` ([#1720](https://github.com/0xMiden/miden-base/pull/1720)).
+- [BREAKING] Split `AccountCode::mock_library` into an account and faucet library ([#1732](https://github.com/0xMiden/miden-base/pull/1732)).
 
 ## 0.10.1 (2025-08-02)
 

--- a/crates/miden-lib/src/testing/account_component/mock_account_component.rs
+++ b/crates/miden-lib/src/testing/account_component/mock_account_component.rs
@@ -7,13 +7,16 @@ use crate::testing::mock_account_code::MockAccountCodeExt;
 // MOCK ACCOUNT COMPONENT
 // ================================================================================================
 
-/// Creates a mock [`Library`](miden_objects::assembly::Library) which can be used to assemble
-/// programs and as a library to create a mock [`AccountCode`](miden_objects::account::AccountCode)
-/// interface. Transaction and note scripts that make use of this interface should be assembled with
-/// this.
+/// A mock account component for use in tests.
+///
+/// It uses the [`MockAccountCodeExt::mock_account_library`][account_lib] and allows for an
+/// arbitrary number of storage slots (within the overall limit) so anything can be set for testing
+/// purposes.
 ///
 /// This component supports all [`AccountType`](miden_objects::account::AccountType)s for testing
 /// purposes.
+///
+/// [account_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_account_library
 pub struct MockAccountComponent {
     storage_slots: Vec<StorageSlot>,
 }

--- a/crates/miden-lib/src/testing/account_component/mock_account_component.rs
+++ b/crates/miden-lib/src/testing/account_component/mock_account_component.rs
@@ -4,7 +4,7 @@ use miden_objects::account::{AccountCode, AccountComponent, AccountStorage, Stor
 
 use crate::testing::mock_account_code::MockAccountCodeExt;
 
-// ACCOUNT MOCK COMPONENT
+// MOCK ACCOUNT COMPONENT
 // ================================================================================================
 
 /// Creates a mock [`Library`](miden_objects::assembly::Library) which can be used to assemble
@@ -51,8 +51,8 @@ impl MockAccountComponent {
 
 impl From<MockAccountComponent> for AccountComponent {
     fn from(mock_component: MockAccountComponent) -> Self {
-        AccountComponent::new(AccountCode::mock_library(), mock_component.storage_slots)
-          .expect("account mock component should satisfy the requirements of a valid account component")
+        AccountComponent::new(AccountCode::mock_account_library(), mock_component.storage_slots)
+          .expect("mock account component should satisfy the requirements of a valid account component")
           .with_supports_all_types()
     }
 }

--- a/crates/miden-lib/src/testing/account_component/mock_faucet_component.rs
+++ b/crates/miden-lib/src/testing/account_component/mock_faucet_component.rs
@@ -5,13 +5,15 @@ use crate::testing::mock_account_code::MockAccountCodeExt;
 // MOCK FAUCET COMPONENT
 // ================================================================================================
 
-/// Creates a mock [`Library`](miden_objects::assembly::Library) which can be used to assemble
-/// programs and as a library to create a mock [`AccountCode`](miden_objects::account::AccountCode)
-/// interface. Transaction and note scripts that make use of this interface should be assembled with
-/// this.
+/// A mock faucet account component for use in tests.
+///
+/// It uses the [`MockAccountCodeExt::mock_faucet_library`][faucet_lib] and contains no storage
+/// slots.
 ///
 /// This component supports the faucet [`AccountType`](miden_objects::account::AccountType)s for
 /// testing purposes.
+///
+/// [faucet_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_faucet_library
 pub struct MockFaucetComponent;
 
 impl From<MockFaucetComponent> for AccountComponent {

--- a/crates/miden-lib/src/testing/account_component/mock_faucet_component.rs
+++ b/crates/miden-lib/src/testing/account_component/mock_faucet_component.rs
@@ -1,0 +1,24 @@
+use miden_objects::account::{AccountCode, AccountComponent, AccountType};
+
+use crate::testing::mock_account_code::MockAccountCodeExt;
+
+// MOCK FAUCET COMPONENT
+// ================================================================================================
+
+/// Creates a mock [`Library`](miden_objects::assembly::Library) which can be used to assemble
+/// programs and as a library to create a mock [`AccountCode`](miden_objects::account::AccountCode)
+/// interface. Transaction and note scripts that make use of this interface should be assembled with
+/// this.
+///
+/// This component supports the faucet [`AccountType`](miden_objects::account::AccountType)s for
+/// testing purposes.
+pub struct MockFaucetComponent;
+
+impl From<MockFaucetComponent> for AccountComponent {
+    fn from(_: MockFaucetComponent) -> Self {
+        AccountComponent::new(AccountCode::mock_faucet_library(), vec![])
+          .expect("mock faucet component should satisfy the requirements of a valid account component")
+          .with_supported_type(AccountType::FungibleFaucet)
+          .with_supported_type(AccountType::NonFungibleFaucet)
+    }
+}

--- a/crates/miden-lib/src/testing/account_component/mod.rs
+++ b/crates/miden-lib/src/testing/account_component/mod.rs
@@ -6,3 +6,5 @@ pub use conditional_auth::{ConditionalAuthComponent, ERR_WRONG_ARGS_MSG};
 
 mod mock_account_component;
 pub use mock_account_component::MockAccountComponent;
+
+mod mock_faucet_component;

--- a/crates/miden-lib/src/testing/account_component/mod.rs
+++ b/crates/miden-lib/src/testing/account_component/mod.rs
@@ -8,3 +8,4 @@ mod mock_account_component;
 pub use mock_account_component::MockAccountComponent;
 
 mod mock_faucet_component;
+pub use mock_faucet_component::MockFaucetComponent;

--- a/crates/miden-lib/src/testing/mock_account.rs
+++ b/crates/miden-lib/src/testing/mock_account.rs
@@ -4,6 +4,7 @@ use miden_objects::account::{
     AccountComponent,
     AccountId,
     AccountStorage,
+    AccountType,
     StorageMap,
     StorageSlot,
 };
@@ -45,6 +46,8 @@ impl MockAccountExt for Account {
 
     fn mock_fungible_faucet(account_id: u128, initial_balance: Felt) -> Self {
         let account_id = AccountId::try_from(account_id).unwrap();
+        assert_eq!(account_id.account_type(), AccountType::FungibleFaucet);
+
         let account = AccountBuilder::new([1; 32])
             .account_type(account_id.account_type())
             .with_auth_component(NoopAuthComponent)
@@ -61,6 +64,8 @@ impl MockAccountExt for Account {
 
     fn mock_non_fungible_faucet(account_id: u128) -> Self {
         let account_id = AccountId::try_from(account_id).unwrap();
+        assert_eq!(account_id.account_type(), AccountType::NonFungibleFaucet);
+
         let account = AccountBuilder::new([1; 32])
             .account_type(account_id.account_type())
             .with_auth_component(NoopAuthComponent)

--- a/crates/miden-lib/src/testing/mock_account.rs
+++ b/crates/miden-lib/src/testing/mock_account.rs
@@ -13,7 +13,7 @@ use miden_objects::testing::noop_auth_component::NoopAuthComponent;
 use miden_objects::testing::storage::FAUCET_STORAGE_DATA_SLOT;
 use miden_objects::{Felt, Word, ZERO};
 
-use crate::testing::account_component::MockAccountComponent;
+use crate::testing::account_component::{MockAccountComponent, MockFaucetComponent};
 
 // MOCK ACCOUNT EXT
 // ================================================================================================
@@ -44,8 +44,15 @@ impl MockAccountExt for Account {
     }
 
     fn mock_non_fungible_faucet(account_id: u128) -> Self {
-        let account = build_mock_account(account_id, NoopAuthComponent, AssetVault::default());
-        let (id, vault, _storage, code, nonce) = account.into_parts();
+        let account_id = AccountId::try_from(account_id).unwrap();
+        let account = AccountBuilder::new([1; 32])
+            .account_type(account_id.account_type())
+            .with_auth_component(NoopAuthComponent)
+            .with_component(MockAccountComponent::with_slots(AccountStorage::mock_storage_slots()))
+            .with_component(MockFaucetComponent)
+            .build_existing()
+            .expect("account should be valid");
+        let (_id, vault, _storage, code, nonce) = account.into_parts();
 
         let asset = NonFungibleAsset::mock(&constants::NON_FUNGIBLE_ASSET_DATA_2);
         let non_fungible_storage_map =
@@ -53,7 +60,7 @@ impl MockAccountExt for Account {
         let storage =
             AccountStorage::new(vec![StorageSlot::Map(non_fungible_storage_map)]).unwrap();
 
-        Account::from_parts(id, vault, storage, code, nonce)
+        Account::from_parts(account_id, vault, storage, code, nonce)
     }
 }
 
@@ -64,11 +71,11 @@ fn build_mock_account(
     vault: AssetVault,
 ) -> Account {
     let account_id = AccountId::try_from(account_id).unwrap();
-    let mock_component = MockAccountComponent::with_slots(AccountStorage::mock_storage_slots());
     let account = AccountBuilder::new([1; 32])
         .account_type(account_id.account_type())
         .with_auth_component(auth)
-        .with_component(mock_component)
+        .with_component(MockAccountComponent::with_slots(AccountStorage::mock_storage_slots()))
+        .with_component(MockFaucetComponent)
         .with_assets(vault.assets())
         .build_existing()
         .expect("account should be valid");

--- a/crates/miden-lib/src/testing/mock_account_code.rs
+++ b/crates/miden-lib/src/testing/mock_account_code.rs
@@ -6,7 +6,7 @@ use miden_objects::utils::sync::LazyLock;
 use crate::transaction::TransactionKernel;
 
 const MOCK_FAUCET_CODE: &str = "
-    export.::miden::contracts::faucets::basic_fungible::distribute
+    use.miden::faucet
 
     # Stack:  [ASSET, pad(12)]
     # Output: [ASSET, pad(12)]
@@ -25,7 +25,6 @@ const MOCK_FAUCET_CODE: &str = "
 
 const MOCK_ACCOUNT_CODE: &str = "
     use.miden::account
-    use.miden::faucet
     use.miden::tx
 
     export.::miden::contracts::wallets::basic::receive_asset

--- a/crates/miden-lib/src/testing/mock_account_code.rs
+++ b/crates/miden-lib/src/testing/mock_account_code.rs
@@ -5,6 +5,24 @@ use miden_objects::utils::sync::LazyLock;
 
 use crate::transaction::TransactionKernel;
 
+const MOCK_FAUCET_CODE: &str = "
+    export.::miden::contracts::faucets::basic_fungible::distribute
+
+    # Stack:  [ASSET, pad(12)]
+    # Output: [ASSET, pad(12)]
+    export.mint
+        exec.faucet::mint
+        # => [ASSET, pad(12)]
+    end
+
+    # Stack:  [ASSET, pad(12)]
+    # Output: [ASSET, pad(12)]
+    export.burn
+        exec.faucet::burn
+        # => [ASSET, pad(12)]
+    end
+";
+
 const MOCK_ACCOUNT_CODE: &str = "
     use.miden::account
     use.miden::faucet
@@ -12,7 +30,6 @@ const MOCK_ACCOUNT_CODE: &str = "
 
     export.::miden::contracts::wallets::basic::receive_asset
     export.::miden::contracts::wallets::basic::move_asset_to_note
-    export.::miden::contracts::faucets::basic_fungible::distribute
 
     # Note: all account's export procedures below should be only called or dyncall'ed, so it
     # is assumed that the operand stack at the beginning of their execution is pad'ed and
@@ -97,21 +114,14 @@ const MOCK_ACCOUNT_CODE: &str = "
         # truncate the stack
         swap drop
     end
-
-    # Stack:  [ASSET, pad(12)]
-    # Output: [ASSET, pad(12)]
-    export.mint
-        exec.faucet::mint
-        # => [ASSET, pad(12)]
-    end
-
-    # Stack:  [ASSET, pad(12)]
-    # Output: [ASSET, pad(12)]
-    export.burn
-        exec.faucet::burn
-        # => [ASSET, pad(12)]
-    end
 ";
+
+static MOCK_FAUCET_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
+    let source = NamedSource::new("mock::faucet", MOCK_FAUCET_CODE);
+    TransactionKernel::assembler()
+        .assemble_library([source])
+        .expect("mock faucet code should be valid")
+});
 
 static MOCK_ACCOUNT_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
     let source = NamedSource::new("mock::account", MOCK_ACCOUNT_CODE);
@@ -123,16 +133,25 @@ static MOCK_ACCOUNT_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
 // MOCK ACCOUNT CODE EXT
 // ================================================================================================
 
-/// Extension trait for [`AccountCode`] to access the mock library.
+/// Extension trait for [`AccountCode`] to access the mock libraries.
 pub trait MockAccountCodeExt {
     /// Returns the [`Library`] of the mock account under the `mock::account` namespace.
     ///
     /// This account interface wraps most account kernel APIs for testing purposes.
-    fn mock_library() -> Library;
+    fn mock_account_library() -> Library;
+
+    /// Returns the [`Library`] of the mock faucet under the `mock::faucet` namespace.
+    ///
+    /// This account interface wraps most faucet kernel APIs for testing purposes.
+    fn mock_faucet_library() -> Library;
 }
 
 impl MockAccountCodeExt for AccountCode {
-    fn mock_library() -> Library {
+    fn mock_account_library() -> Library {
         MOCK_ACCOUNT_LIBRARY.clone()
+    }
+
+    fn mock_faucet_library() -> Library {
+        MOCK_FAUCET_LIBRARY.clone()
     }
 }

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -476,7 +476,7 @@ impl TransactionKernel {
         let assembler = Self::testing_assembler().with_debug_mode(true);
 
         assembler
-            .with_dynamic_library(AccountCode::mock_library())
+            .with_dynamic_library(AccountCode::mock_account_library())
             .expect("failed to add mock account code")
     }
 }

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -463,7 +463,6 @@ impl TransactionKernel {
             .with_debug_mode(true)
     }
 
-    // TODO: Rename to `...with_mock_libraries` and update docs.
     /// Returns the testing assembler, and additionally contains the library for
     /// [`MockAccountCodeExt::mock_library`][mock_lib], which is a
     /// mock wallet used in tests.

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -463,6 +463,7 @@ impl TransactionKernel {
             .with_debug_mode(true)
     }
 
+    // TODO: Rename to `...with_mock_libraries` and update docs.
     /// Returns the testing assembler, and additionally contains the library for
     /// [`MockAccountCodeExt::mock_library`][mock_lib], which is a
     /// mock wallet used in tests.
@@ -477,7 +478,9 @@ impl TransactionKernel {
 
         assembler
             .with_dynamic_library(AccountCode::mock_account_library())
-            .expect("failed to add mock account code")
+            .expect("failed to add mock account library")
+            .with_dynamic_library(AccountCode::mock_faucet_library())
+            .expect("failed to add mock faucet library")
     }
 }
 

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -288,7 +288,7 @@ impl ScriptBuilder {
 
         let builder = Self::with_kernel_library()?;
 
-        builder.with_dynamically_linked_library(&AccountCode::mock_library())
+        builder.with_dynamically_linked_library(&AccountCode::mock_account_library())
     }
 }
 

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -288,7 +288,9 @@ impl ScriptBuilder {
 
         let builder = Self::with_kernel_library()?;
 
-        builder.with_dynamically_linked_library(&AccountCode::mock_account_library())
+        builder
+            .with_dynamically_linked_library(&AccountCode::mock_account_library())?
+            .with_dynamically_linked_library(&AccountCode::mock_faucet_library())
     }
 }
 

--- a/crates/miden-objects/src/testing/asset.rs
+++ b/crates/miden-objects/src/testing/asset.rs
@@ -102,9 +102,7 @@ impl NonFungibleAsset {
     /// Returns the account ID of the issuer of [`NonFungibleAsset::mock()`]
     /// ([ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET]).
     pub fn mock_issuer() -> AccountId {
-        let id = AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap();
-        std::println!("typ0 {}", id.account_type());
-        id
+        AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap()
     }
 }
 

--- a/crates/miden-objects/src/testing/asset.rs
+++ b/crates/miden-objects/src/testing/asset.rs
@@ -102,7 +102,9 @@ impl NonFungibleAsset {
     /// Returns the account ID of the issuer of [`NonFungibleAsset::mock()`]
     /// ([ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET]).
     pub fn mock_issuer() -> AccountId {
-        AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap()
+        let id = AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap();
+        std::println!("typ0 {}", id.account_type());
+        id
     }
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -45,10 +45,10 @@ use crate::{TransactionContextBuilder, assert_execution_error, assert_transactio
 #[test]
 fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
-    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_fungible_faucet(
         faucet_id.into(),
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    ))
+    )
     .build()?;
 
     let code = format!(
@@ -131,10 +131,10 @@ fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         10u32.into(),
-    ))
+    )
     .build()?;
 
     let code = format!(
@@ -175,10 +175,10 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
     );
     let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let result = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let result = TransactionContextBuilder::with_fungible_faucet(
         FungibleAsset::mock_issuer().into(),
         Felt::new(1),
-    ))
+    )
     .tx_script(tx_script)
     .build()?
     .execute_blocking();
@@ -195,10 +195,9 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
-        NonFungibleAsset::mock_issuer().into(),
-    ))
-    .build()?;
+    let tx_context =
+        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
+            .build()?;
 
     let non_fungible_asset = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA);
     let asset_vault_key = non_fungible_asset.vault_key();
@@ -254,9 +253,9 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_non_fungible_faucet(
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
-    ))
+    )
     .build()?;
     let non_fungible_asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
 
@@ -312,10 +311,9 @@ fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
-        NonFungibleAsset::mock_issuer().into(),
-    ))
-    .build()?;
+    let tx_context =
+        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
+            .build()?;
 
     let non_fungible_asset = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
 
@@ -444,10 +442,10 @@ fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         Felt::try_from(FUNGIBLE_FAUCET_INITIAL_BALANCE).unwrap(),
-    ))
+    )
     .build()?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
@@ -478,10 +476,10 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    ))
+    )
     .build()?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
@@ -516,10 +514,9 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
-        NonFungibleAsset::mock_issuer().into(),
-    ))
-    .build()?;
+    let tx_context =
+        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
+            .build()?;
 
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
     let burnt_asset_vault_key = non_fungible_asset_burnt.vault_key();
@@ -591,10 +588,9 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
-        NonFungibleAsset::mock_issuer().into(),
-    ))
-    .build()?;
+    let tx_context =
+        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
+            .build()?;
 
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
 
@@ -654,9 +650,9 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
 
     // Run code from a different non-fungible asset issuer
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_non_fungible_faucet(
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
-    ))
+    )
     .build()?;
 
     let code = format!(
@@ -690,10 +686,9 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
     // NON_FUNGIBLE_ASSET_DATA_2 is "issued" during the mock faucet creation, so it is already in
     // the map of issued assets.
-    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
-        NonFungibleAsset::mock_issuer().into(),
-    ))
-    .build()?;
+    let tx_context =
+        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
+            .build()?;
 
     let non_fungible_asset_1 = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA);
     let non_fungible_asset_2 = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
@@ -739,10 +734,10 @@ fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+    let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    ))
+    )
     .build()?;
 
     let code = format!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -1,5 +1,4 @@
 use miden_lib::errors::tx_kernel_errors::{
-    ERR_FAUCET_BURN_NON_FUNGIBLE_ASSET_CAN_ONLY_BE_CALLED_ON_NON_FUNGIBLE_FAUCET,
     ERR_FAUCET_NEW_TOTAL_SUPPLY_WOULD_EXCEED_MAX_ASSET_AMOUNT,
     ERR_FAUCET_NON_FUNGIBLE_ASSET_ALREADY_ISSUED,
     ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND,
@@ -10,9 +9,15 @@ use miden_lib::errors::tx_kernel_errors::{
 use miden_lib::testing::mock_account::MockAccountExt;
 use miden_lib::transaction::TransactionKernel;
 use miden_lib::transaction::memory::NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR;
-use miden_lib::utils::word_to_masm_push_string;
-use miden_objects::Felt;
-use miden_objects::account::{Account, AccountId, StorageMap};
+use miden_lib::utils::{ScriptBuilder, word_to_masm_push_string};
+use miden_objects::account::{
+    Account,
+    AccountBuilder,
+    AccountComponent,
+    AccountId,
+    AccountType,
+    StorageMap,
+};
 use miden_objects::asset::{FungibleAsset, NonFungibleAsset};
 use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
@@ -27,27 +32,28 @@ use miden_objects::testing::constants::{
     NON_FUNGIBLE_ASSET_DATA,
     NON_FUNGIBLE_ASSET_DATA_2,
 };
+use miden_objects::testing::noop_auth_component::NoopAuthComponent;
 use miden_objects::testing::storage::FAUCET_STORAGE_DATA_SLOT;
+use miden_objects::{Felt, Word};
 
 use crate::utils::create_p2any_note;
-use crate::{TransactionContextBuilder, assert_execution_error};
+use crate::{TransactionContextBuilder, assert_execution_error, assert_transaction_executor_error};
 
 // FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
 
 #[test]
 fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_fungible_faucet(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
-        Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    )
-    .build()?;
-
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
+    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+        faucet_id.into(),
+        Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
+    ))
+    .build()?;
 
     let code = format!(
         r#"
-        use.mock::account
+        use.mock::faucet
         use.$kernel::asset_vault
         use.$kernel::memory
         use.$kernel::prologue
@@ -56,7 +62,7 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
             # mint asset
             exec.prologue::prepare_transaction
             push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::mint
+            call.faucet::mint
 
             # assert the correct asset is returned
             push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
@@ -96,54 +102,53 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that minting a fungible asset on a non-faucet account fails.
 #[test]
-fn test_mint_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?;
+fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+    let account = setup_non_faucet_account()?;
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
+      use.mock::faucet
 
-        begin
-            exec.prologue::prepare_transaction
-            push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::mint
-        end
-        ",
-        prefix = faucet_id.prefix().as_felt(),
-        suffix = faucet_id.suffix(),
+      begin
+          push.{asset}
+          call.faucet::mint
+      end
+      ",
+        asset = Word::from(FungibleAsset::mock(50))
     );
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let result = TransactionContextBuilder::new(account)
+        .tx_script(tx_script)
+        .build()?
+        .execute_blocking();
+    assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
-    assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
 #[test]
 fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
+        10u32.into(),
+    ))
+    .build()?;
 
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)?;
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             exec.prologue::prepare_transaction
-            push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::mint
+            push.{asset}
+            call.faucet::mint
         end
         ",
-        prefix = faucet_id.prefix().as_felt(),
-        suffix = faucet_id.suffix(),
+        asset = Word::from(FungibleAsset::mock(5))
     );
 
     let process = tx_context.execute_code_with_assembler(
@@ -157,35 +162,31 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_fungible_faucet(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
-        Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    )
-    .build()?;
-
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
-            exec.prologue::prepare_transaction
-            push.{saturating_amount}.0.{suffix}.{prefix}
-            call.account::mint
+            push.{asset}
+            call.faucet::mint
         end
-        ",
-        prefix = faucet_id.prefix().as_felt(),
-        suffix = faucet_id.suffix(),
-        saturating_amount = FungibleAsset::MAX_AMOUNT - FUNGIBLE_FAUCET_INITIAL_BALANCE + 1
+    ",
+        asset = Word::from(FungibleAsset::mock(FungibleAsset::MAX_AMOUNT))
     );
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
+    let result = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+        FungibleAsset::mock_issuer().into(),
+        Felt::new(1),
+    ))
+    .tx_script(tx_script)
+    .build()?
+    .execute_blocking();
+
+    assert_transaction_executor_error!(
+        result,
+        ERR_FAUCET_NEW_TOTAL_SUPPLY_WOULD_EXCEED_MAX_ASSET_AMOUNT
     );
-
-    assert_execution_error!(process, ERR_FAUCET_NEW_TOTAL_SUPPLY_WOULD_EXCEED_MAX_ASSET_AMOUNT);
     Ok(())
 }
 
@@ -194,9 +195,10 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
 
 #[test]
 fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        NonFungibleAsset::mock_issuer().into(),
+    ))
+    .build()?;
 
     let non_fungible_asset = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA);
     let asset_vault_key = non_fungible_asset.vault_key();
@@ -209,13 +211,13 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
         use.$kernel::asset_vault
         use.$kernel::memory
         use.$kernel::prologue
-        use.mock::account->mock_account
+        use.mock::faucet->mock_faucet
 
         begin
             # mint asset
             exec.prologue::prepare_transaction
             push.{non_fungible_asset}
-            call.mock_account::mint
+            call.mock_faucet::mint
 
             # assert the correct asset is returned
             push.{non_fungible_asset}
@@ -251,20 +253,22 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_mint_non_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-
+fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
+    ))
+    .build()?;
     let non_fungible_asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
 
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             exec.prologue::prepare_transaction
             push.{non_fungible_asset}
-            call.account::mint
+            call.faucet::mint
         end
         ",
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into())
@@ -279,52 +283,51 @@ fn test_mint_non_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()>
     Ok(())
 }
 
+/// Tests that minting a non-fungible asset on a non-faucet account fails.
 #[test]
-fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-
-    let non_fungible_asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
+fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+    let account = setup_non_faucet_account()?;
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
+      use.mock::faucet
 
-        begin
-            exec.prologue::prepare_transaction
-            push.{non_fungible_asset}
-            call.account::mint
-        end
-        ",
-        non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into())
+      begin
+          push.{asset}
+          call.faucet::mint
+      end
+      ",
+        asset = Word::from(FungibleAsset::mock(50))
     );
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let result = TransactionContextBuilder::new(account)
+        .tx_script(tx_script)
+        .build()?
+        .execute_blocking();
+    assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
-    assert_execution_error!(process, ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
 #[test]
 fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<()> {
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        NonFungibleAsset::mock_issuer().into(),
+    ))
+    .build()?;
 
     let non_fungible_asset = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
 
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             exec.prologue::prepare_transaction
             push.{non_fungible_asset}
-            call.account::mint
+            call.faucet::mint
         end
         ",
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into())
@@ -360,7 +363,7 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     let code = format!(
         r#"
-        use.mock::account
+        use.mock::faucet
         use.$kernel::asset_vault
         use.$kernel::memory
         use.$kernel::prologue
@@ -369,7 +372,7 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
             # burn asset
             exec.prologue::prepare_transaction
             push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::burn
+            call.faucet::burn
 
             # assert the correct asset is returned
             push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
@@ -412,53 +415,52 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that burning a fungible asset on a non-faucet account fails.
 #[test]
-fn test_burn_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
+fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+    let account = setup_non_faucet_account()?;
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
+      use.mock::faucet
 
-        begin
-            exec.prologue::prepare_transaction
-            push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::burn
-        end
-        ",
-        prefix = faucet_id.prefix().as_felt(),
-        suffix = faucet_id.suffix(),
+      begin
+          push.{asset}
+          call.faucet::burn
+      end
+      ",
+        asset = Word::from(FungibleAsset::mock(50))
     );
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let result = TransactionContextBuilder::new(account)
+        .tx_script(tx_script)
+        .build()?
+        .execute_blocking();
+    assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
-    assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
 #[test]
 fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
+        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+        Felt::try_from(FUNGIBLE_FAUCET_INITIAL_BALANCE).unwrap(),
+    ))
+    .build()?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
 
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             exec.prologue::prepare_transaction
             push.{FUNGIBLE_ASSET_AMOUNT}.0.{suffix}.{prefix}
-            call.account::burn
+            call.faucet::burn
         end
         ",
         prefix = faucet_id.prefix().as_felt(),
@@ -476,10 +478,10 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_fungible_faucet(
+    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    )
+    ))
     .build()?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
@@ -487,12 +489,12 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             exec.prologue::prepare_transaction
             push.{saturating_amount}.0.{suffix}.{prefix}
-            call.account::burn
+            call.faucet::burn
         end
         ",
         prefix = faucet_id.prefix().as_felt(),
@@ -514,9 +516,10 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        NonFungibleAsset::mock_issuer().into(),
+    ))
+    .build()?;
 
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
     let burnt_asset_vault_key = non_fungible_asset_burnt.vault_key();
@@ -527,7 +530,7 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
         use.$kernel::asset_vault
         use.$kernel::memory
         use.$kernel::prologue
-        use.mock::account->mock_account
+        use.mock::faucet->mock_faucet
 
         begin
             exec.prologue::prepare_transaction
@@ -552,7 +555,7 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
             # burn the non-fungible asset
             push.{non_fungible_asset}
-            call.mock_account::burn
+            call.mock_faucet::burn
 
             # assert the correct asset is returned
             push.{non_fungible_asset}
@@ -588,22 +591,23 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        NonFungibleAsset::mock_issuer().into(),
+    ))
+    .build()?;
 
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
 
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             # burn asset
             exec.prologue::prepare_transaction
             push.{non_fungible_asset}
-            call.account::burn
+            call.faucet::burn
         end
         ",
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset_burnt.into())
@@ -618,36 +622,30 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that burning a non-fungible asset on a non-faucet account fails.
 #[test]
-fn test_burn_non_fungible_asset_fails_not_faucet_account() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-
-    let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
+fn burn_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+    let account = setup_non_faucet_account()?;
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
+      use.mock::faucet
 
-        begin
-            # burn asset
-            exec.prologue::prepare_transaction
-            push.{non_fungible_asset}
-            call.account::burn
-        end
-        ",
-        non_fungible_asset = word_to_masm_push_string(&non_fungible_asset_burnt.into())
+      begin
+          push.{asset}
+          call.faucet::burn
+      end
+      ",
+        asset = Word::from(FungibleAsset::mock(50))
     );
+    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let result = TransactionContextBuilder::new(account)
+        .tx_script(tx_script)
+        .build()?
+        .execute_blocking();
+    assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
-    assert_execution_error!(
-        process,
-        ERR_FAUCET_BURN_NON_FUNGIBLE_ASSET_CAN_ONLY_BE_CALLED_ON_NON_FUNGIBLE_FAUCET
-    );
     Ok(())
 }
 
@@ -656,21 +654,21 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
 
     // Run code from a different non-fungible asset issuer
-    let tx_context = TransactionContextBuilder::with_non_fungible_faucet(
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
-    )
+    ))
     .build()?;
 
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
+        use.mock::faucet
 
         begin
             # burn asset
             exec.prologue::prepare_transaction
             push.{non_fungible_asset}
-            call.account::burn
+            call.faucet::burn
         end
         ",
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset_burnt.into())
@@ -692,9 +690,10 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
     // NON_FUNGIBLE_ASSET_DATA_2 is "issued" during the mock faucet creation, so it is already in
     // the map of issued assets.
-    let tx_context =
-        TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
+    let tx_context = TransactionContextBuilder::new(Account::mock_non_fungible_faucet(
+        NonFungibleAsset::mock_issuer().into(),
+    ))
+    .build()?;
 
     let non_fungible_asset_1 = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA);
     let non_fungible_asset_2 = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
@@ -740,10 +739,10 @@ fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
-    let tx_context = TransactionContextBuilder::with_fungible_faucet(
+    let tx_context = TransactionContextBuilder::new(Account::mock_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
-    )
+    ))
     .build()?;
 
     let code = format!(
@@ -772,4 +771,26 @@ fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
         )
         .unwrap();
     Ok(())
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Creates a regular account that exposes the faucet mint and burn procedures.
+///
+/// This is used to test that calling these procedures fails as expected.
+fn setup_non_faucet_account() -> anyhow::Result<Account> {
+    // Build a custom non-faucet account that (invalidly) exposes faucet procedures.
+    let faucet_component = AccountComponent::compile(
+        "export.::miden::faucet::mint
+         export.::miden::faucet::burn",
+        TransactionKernel::testing_assembler_with_mock_account(),
+        vec![],
+    )?
+    .with_supported_type(AccountType::RegularAccountUpdatableCode);
+    Ok(AccountBuilder::new([4; 32])
+        .account_type(AccountType::RegularAccountUpdatableCode)
+        .with_auth_component(NoopAuthComponent)
+        .with_component(faucet_component)
+        .build_existing()?)
 }

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -140,15 +140,13 @@ impl TransactionContextBuilder {
     /// Initializes a [TransactionContextBuilder] with a mocked fungible faucet.
     pub fn with_fungible_faucet(acct_id: u128, initial_balance: Felt) -> Self {
         let account = Account::mock_fungible_faucet(acct_id, initial_balance);
-
-        Self { account, ..Self::default() }
+        Self::new(account)
     }
 
     /// Initializes a [TransactionContextBuilder] with a mocked non-fungible faucet.
     pub fn with_non_fungible_faucet(acct_id: u128) -> Self {
         let account = Account::mock_non_fungible_faucet(acct_id);
-
-        Self { account, ..Self::default() }
+        Self::new(account)
     }
 
     /// Returns a clone of the assembler.


### PR DESCRIPTION
Splits `AccountCode::mock_library` into account and faucet libraries.

The basic approach is to introduce an `MockFaucetComponent` which is an account component that re-exports the `faucet::mint` and `faucet::burn` kernel APIs, and remove those from `MockAccountComponent`.

Also remove the unused `distribute` re-export from `MOCK_ACCOUNT_CODE`. Calling that would've probably never worked, given that the metadata in the slot wasn't set according to what `BasicFungibleFaucet` expects.

Refactors some tests in `test_faucet` to use this new component and to make them more concise.

Note that the `TransactionKernel` and `ScriptBuilder` testing APIs will be renamed in a follow-up PR, to keep the renames contained there.

closes #878