### PR TITLE
chore: rename mock library apis on `TransactionKernel` and `ScriptBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - [BREAKING] Move `IncrNonceAuthComponent`, `ConditionalAuthComponent` and `AccountMockComponent` to `miden-lib` ([#1722](https://github.com/0xMiden/miden-base/pull/1722)).
 - Refactor `contracts::auth::basic` into a reusable library procedure `auth::rpo_falcon512` ([#1712](https://github.com/0xMiden/miden-base/pull/1712)).
 - [BREAKING] Refactored `FungibleAsset::sub` to be more similar to `FungibleAsset::add` ([#1720](https://github.com/0xMiden/miden-base/pull/1720)).
-- [BREAKING] Split `AccountCode::mock_library` into an account and faucet library ([#1732](https://github.com/0xMiden/miden-base/pull/1732)).
+- [BREAKING] Split `AccountCode::mock_library` into an account and faucet library ([#1732](https://github.com/0xMiden/miden-base/pull/1732), [#1733](https://github.com/0xMiden/miden-base/pull/1733)).
 
 ## 0.10.1 (2025-08-02)
 

--- a/crates/miden-lib/src/account/interface/test.rs
+++ b/crates/miden-lib/src/account/interface/test.rs
@@ -144,7 +144,7 @@ fn test_custom_account_default_note() {
 
     let account_component = AccountComponent::compile(
         account_custom_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         vec![],
     )
     .unwrap()
@@ -427,7 +427,7 @@ fn test_custom_account_custom_notes() {
 
     let account_component = AccountComponent::compile_with_path(
         account_custom_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         vec![],
         "test::account::component_1",
     )
@@ -540,7 +540,7 @@ fn test_custom_account_multiple_components_custom_notes() {
 
     let custom_component = AccountComponent::compile_with_path(
         account_custom_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         vec![],
         "test::account::component_1",
     )

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -438,14 +438,14 @@ impl TransactionKernel {
             .expect("failed to deserialize transaction kernel library")
     }
 
-    /// Contains code to get an instance of the [Assembler] that should be used in tests.
+    /// Returns an [`Assembler`] with the transaction kernel as a library.
     ///
-    /// This assembler is similar to the assembler used to assemble the kernel and transactions,
-    /// with the difference that it also includes an extra library on the namespace of `kernel`.
-    /// The `kernel` library is added separately because even though the library (`api.masm`) and
-    /// the kernel binary (`main.masm`) include this code, it is not exposed explicitly. By adding
-    /// it separately, we can expose procedures from `/lib` and test them individually.
-    pub fn testing_assembler() -> Assembler {
+    /// This assembler is the same as [`TransactionKernel::assembler`] but additionally includes the
+    /// kernel library on the namespace of `$kernel`. The `$kernel` library is added separately
+    /// because even though the library (`api.masm`) and the kernel binary (`main.masm`) include
+    /// this code, it is not otherwise accessible. By adding it separately, we can invoke procedures
+    /// from the kernel library to test them individually.
+    pub fn with_kernel_library() -> Assembler {
         let source_manager: Arc<dyn SourceManager + Send + Sync> =
             Arc::new(DefaultSourceManager::default());
         let kernel_library = Self::kernel_as_library();
@@ -463,17 +463,20 @@ impl TransactionKernel {
             .with_debug_mode(true)
     }
 
-    /// Returns the testing assembler, and additionally contains the library for
-    /// [`MockAccountCodeExt::mock_library`][mock_lib], which is a
-    /// mock wallet used in tests.
+    /// Returns an [`Assembler`] with the mock account and faucet libraries.
     ///
-    /// [mock_lib]: (crate::testing::mock_account_code::MockAccountCodeExt::mock_library)
-    pub fn testing_assembler_with_mock_account() -> Assembler {
+    /// This assembler is the same as [`TransactionKernel::with_kernel_library`] but additionally
+    /// includes the [`MockAccountCodeExt::mock_account_library`][account_lib] and
+    /// [`MockAccountCodeExt::mock_faucet_library`][faucet_lib].
+    ///
+    /// [account_lib]: (crate::testing::mock_account_code::MockAccountCodeExt::mock_account_library)
+    /// [faucet_lib]: (crate::testing::mock_account_code::MockAccountCodeExt::mock_faucet_library)
+    pub fn with_mock_libraries() -> Assembler {
         use miden_objects::account::AccountCode;
 
         use crate::testing::mock_account_code::MockAccountCodeExt;
 
-        let assembler = Self::testing_assembler().with_debug_mode(true);
+        let assembler = Self::with_kernel_library().with_debug_mode(true);
 
         assembler
             .with_dynamic_library(AccountCode::mock_account_library())

--- a/crates/miden-lib/src/transaction/mod.rs
+++ b/crates/miden-lib/src/transaction/mod.rs
@@ -466,11 +466,12 @@ impl TransactionKernel {
     /// Returns an [`Assembler`] with the mock account and faucet libraries.
     ///
     /// This assembler is the same as [`TransactionKernel::with_kernel_library`] but additionally
-    /// includes the [`MockAccountCodeExt::mock_account_library`][account_lib] and
-    /// [`MockAccountCodeExt::mock_faucet_library`][faucet_lib].
+    /// includes the [`MockAccountCodeExt::mock_account_library`][account_lib]
+    /// and [`MockAccountCodeExt::mock_faucet_library`][faucet_lib], which are the standard
+    /// testing account libraries.
     ///
-    /// [account_lib]: (crate::testing::mock_account_code::MockAccountCodeExt::mock_account_library)
-    /// [faucet_lib]: (crate::testing::mock_account_code::MockAccountCodeExt::mock_faucet_library)
+    /// [account_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_account_library
+    /// [faucet_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_faucet_library
     pub fn with_mock_libraries() -> Assembler {
         use miden_objects::account::AccountCode;
 

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -266,22 +266,22 @@ impl ScriptBuilder {
     // TESTING CONVENIENCE FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a ScriptBuilder with the kernel library for testing scenarios.
+    /// Returns a [`ScriptBuilder`] with the transaction kernel as a library.
     ///
-    /// This is equivalent to using `TransactionKernel::testing_assembler()` and is intended
-    /// to replace scripts that were built with that assembler.
+    /// Assembling scripts with this library is equivalent to assembling with
+    /// [`TransactionKernel::with_kernel_library`]. See its documentaion for more details.
     #[cfg(any(feature = "testing", test))]
     pub fn with_kernel_library() -> Result<Self, ScriptBuilderError> {
         let kernel_library = TransactionKernel::kernel_as_library();
         Self::default().with_dynamically_linked_library(&kernel_library)
     }
 
-    /// Creates a ScriptBuilder with both kernel and mock account libraries for testing scenarios.
+    /// Returns a [`ScriptBuilder`] with the mock account and faucet libraries.
     ///
-    /// This is equivalent to using `TransactionKernel::testing_assembler_with_mock_account()`
-    /// and is intended to replace scripts that were built with that assembler.
+    /// Assembling scripts with these libraries is equivalent to assembling with
+    /// [`TransactionKernel::with_mock_libraries`]. See its documentaion for more details.
     #[cfg(any(feature = "testing", test))]
-    pub fn with_mock_account_library() -> Result<Self, ScriptBuilderError> {
+    pub fn with_mock_libraries() -> Result<Self, ScriptBuilderError> {
         use miden_objects::account::AccountCode;
 
         use crate::testing::mock_account_code::MockAccountCodeExt;

--- a/crates/miden-lib/src/utils/script_builder.rs
+++ b/crates/miden-lib/src/utils/script_builder.rs
@@ -266,29 +266,21 @@ impl ScriptBuilder {
     // TESTING CONVENIENCE FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a [`ScriptBuilder`] with the transaction kernel as a library.
-    ///
-    /// Assembling scripts with this library is equivalent to assembling with
-    /// [`TransactionKernel::with_kernel_library`]. See its documentaion for more details.
-    #[cfg(any(feature = "testing", test))]
-    pub fn with_kernel_library() -> Result<Self, ScriptBuilderError> {
-        let kernel_library = TransactionKernel::kernel_as_library();
-        Self::default().with_dynamically_linked_library(&kernel_library)
-    }
-
     /// Returns a [`ScriptBuilder`] with the mock account and faucet libraries.
     ///
-    /// Assembling scripts with these libraries is equivalent to assembling with
-    /// [`TransactionKernel::with_mock_libraries`]. See its documentaion for more details.
+    /// This script builder includes the [`MockAccountCodeExt::mock_account_library`][account_lib]
+    /// and [`MockAccountCodeExt::mock_faucet_library`][faucet_lib], which are the standard
+    /// testing account libraries.
+    ///
+    /// [account_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_account_library
+    /// [faucet_lib]: crate::testing::mock_account_code::MockAccountCodeExt::mock_faucet_library
     #[cfg(any(feature = "testing", test))]
     pub fn with_mock_libraries() -> Result<Self, ScriptBuilderError> {
         use miden_objects::account::AccountCode;
 
         use crate::testing::mock_account_code::MockAccountCodeExt;
 
-        let builder = Self::with_kernel_library()?;
-
-        builder
+        Self::default()
             .with_dynamically_linked_library(&AccountCode::mock_account_library())?
             .with_dynamically_linked_library(&AccountCode::mock_faucet_library())
     }

--- a/crates/miden-testing/src/executor.rs
+++ b/crates/miden-testing/src/executor.rs
@@ -49,7 +49,7 @@ impl<H: SyncHost> CodeExecutor<H> {
     /// To improve the error message quality, convert the returned [`ExecutionError`] into a
     /// [`Report`](miden_objects::assembly::diagnostics::Report).
     pub fn run(self, code: &str) -> Result<Process, ExecutionError> {
-        let assembler = TransactionKernel::testing_assembler().with_debug_mode(true);
+        let assembler = TransactionKernel::with_kernel_library().with_debug_mode(true);
         // TODO: SourceManager.
         let source_manager =
             alloc::sync::Arc::new(miden_objects::assembly::DefaultSourceManager::default())

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -126,7 +126,7 @@ pub fn compute_current_commitment() -> miette::Result<()> {
     );
 
     let tx_context_builder = TransactionContextBuilder::new(account);
-    let tx_script = ScriptBuilder::with_mock_account_library()
+    let tx_script = ScriptBuilder::with_mock_libraries()
         .into_diagnostic()?
         .compile_tx_script(tx_script)
         .into_diagnostic()?;
@@ -419,10 +419,7 @@ fn test_get_map_item() -> miette::Result<()> {
         );
 
         let process = &tx_context
-            .execute_code_with_assembler(
-                &code,
-                TransactionKernel::testing_assembler_with_mock_account(),
-            )
+            .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
             .unwrap();
 
         assert_eq!(
@@ -579,10 +576,7 @@ fn test_set_map_item() -> miette::Result<()> {
     );
 
     let process = &tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
 
     let mut new_storage_map = AccountStorage::mock_map();
@@ -605,7 +599,7 @@ fn test_set_map_item() -> miette::Result<()> {
 #[test]
 fn test_account_component_storage_offset() -> miette::Result<()> {
     // setup assembler
-    let assembler = TransactionKernel::testing_assembler();
+    let assembler = TransactionKernel::with_kernel_library();
 
     // The following code will execute the following logic that will be asserted during the test:
     //
@@ -917,10 +911,7 @@ fn test_get_storage_commitment() -> anyhow::Result<()> {
         "#,
         expected_storage_commitment = &account.storage().commitment(),
     );
-    tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     Ok(())
 }
@@ -987,10 +978,7 @@ fn test_get_vault_root() -> anyhow::Result<()> {
         fungible_asset = Word::from(&fungible_asset),
         expected_vault_root = &account.vault().root(),
     );
-    tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     Ok(())
 }
@@ -1099,7 +1087,7 @@ fn test_was_procedure_called() -> miette::Result<()> {
         "#;
 
     // Compile the transaction script using the testing assembler with mock account
-    let assembler = TransactionKernel::testing_assembler_with_mock_account();
+    let assembler = TransactionKernel::with_mock_libraries();
     let tx_script = TransactionScript::new(
         assembler
             .assemble_program(tx_script_code)
@@ -1146,7 +1134,7 @@ fn transaction_executor_account_code_using_custom_library() -> miette::Result<()
     let external_library =
         TransactionKernel::assembler().assemble_library([external_library_source])?;
 
-    let mut assembler = TransactionKernel::testing_assembler_with_mock_account();
+    let mut assembler = TransactionKernel::with_mock_libraries();
     assembler.link_static_library(&external_library)?;
 
     let account_component_source =

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -708,7 +708,7 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
         UPDATED_MAP_KEY = word_to_masm_push_string(&updated_map_key),
     );
 
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(tx_script_src)?;
 
     // Create the input note that carries the assets that we will assert later
     let input_note = {
@@ -851,7 +851,7 @@ fn compile_tx_script(code: impl AsRef<str>) -> anyhow::Result<TransactionScript>
         code = code.as_ref()
     );
 
-    ScriptBuilder::with_mock_account_library()?
+    ScriptBuilder::with_mock_libraries()?
         .compile_tx_script(&code)
         .context("failed to compile tx script")
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -132,14 +132,14 @@ async fn check_note_consumability_failure() -> anyhow::Result<()> {
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
     .code("begin push.1 drop push.0 div end")
-    .build(&TransactionKernel::testing_assembler())?;
+    .build(&TransactionKernel::with_kernel_library())?;
 
     let failing_note_2 = NoteBuilder::new(
         sender,
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
     .code("begin push.2 drop push.0 div end")
-    .build(&TransactionKernel::testing_assembler())?;
+    .build(&TransactionKernel::with_kernel_library())?;
 
     let successful_note_1 = create_p2id_note(
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -45,10 +45,8 @@ fn test_get_balance() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get(0).as_int(),
@@ -78,10 +76,8 @@ fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(
         process,
@@ -114,10 +110,8 @@ fn test_has_non_fungible_asset() -> anyhow::Result<()> {
         non_fungible_asset_key = word_to_masm_push_string(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(process.stack.get(0), ONE);
 
@@ -155,10 +149,8 @@ fn test_add_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&add_fungible_asset.into())
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),
@@ -202,10 +194,8 @@ fn test_add_non_fungible_asset_fail_overflow() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&add_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_VAULT_FUNGIBLE_MAX_AMOUNT_EXCEEDED);
     assert!(account_vault.add_asset(add_fungible_asset).is_err());
@@ -239,10 +229,8 @@ fn test_add_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&add_non_fungible_asset.into())
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),
@@ -281,10 +269,8 @@ fn test_add_non_fungible_asset_fail_duplicate() -> anyhow::Result<()> {
         NON_FUNGIBLE_ASSET = word_to_masm_push_string(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
@@ -324,10 +310,8 @@ fn test_remove_fungible_asset_success_no_balance_remaining() -> anyhow::Result<(
         FUNGIBLE_ASSET = word_to_masm_push_string(&remove_fungible_asset.into())
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),
@@ -369,10 +353,8 @@ fn test_remove_fungible_asset_fail_remove_too_much() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&remove_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW);
 
@@ -411,10 +393,8 @@ fn test_remove_fungible_asset_success_balance_remaining() -> anyhow::Result<()> 
         FUNGIBLE_ASSET = word_to_masm_push_string(&remove_fungible_asset.into())
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),
@@ -460,10 +440,8 @@ fn test_remove_inexisting_non_fungible_asset_fails() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&non_existent_non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
     assert_matches!(
@@ -502,10 +480,8 @@ fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = word_to_masm_push_string(&non_fungible_asset.into())
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -90,10 +90,8 @@ fn test_epilogue() -> anyhow::Result<()> {
         "
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     // The final account is the initial account with the nonce incremented by one.
     let mut final_account = account.clone();
@@ -190,10 +188,8 @@ fn test_compute_output_note_id() -> anyhow::Result<()> {
             "
         );
 
-        let process = &tx_context.execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )?;
+        let process = &tx_context
+            .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
         assert_eq!(
             note.assets().commitment(),
@@ -234,10 +230,10 @@ fn test_epilogue_asset_preservation_violation_too_few_input() -> anyhow::Result<
 
     let output_note_1 = NoteBuilder::new(account.id(), rng())
         .add_assets([fungible_asset_1])
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
     let output_note_2 = NoteBuilder::new(account.id(), rng())
         .add_assets([fungible_asset_2])
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
 
     let input_note = create_spawn_note(account.id(), vec![&output_note_1, &output_note_2])?;
 
@@ -271,10 +267,8 @@ fn test_epilogue_asset_preservation_violation_too_few_input() -> anyhow::Result<
         "
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
     assert_execution_error!(process, ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME);
     Ok(())
 }
@@ -304,13 +298,13 @@ fn test_epilogue_asset_preservation_violation_too_many_fungible_input() -> anyho
 
     let output_note_1 = NoteBuilder::new(account.id(), rng())
         .add_assets([fungible_asset_1])
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
     let output_note_2 = NoteBuilder::new(account.id(), rng())
         .add_assets([fungible_asset_2])
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
     let output_note_3 = NoteBuilder::new(account.id(), rng())
         .add_assets([fungible_asset_3])
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
 
     let input_note = create_spawn_note(
         ACCOUNT_ID_SENDER.try_into()?,
@@ -347,10 +341,8 @@ fn test_epilogue_asset_preservation_violation_too_many_fungible_input() -> anyho
         "
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME);
     Ok(())
@@ -389,10 +381,8 @@ fn test_block_expiration_height_monotonically_decreases() -> anyhow::Result<()> 
             .replace("{value_2}", &v2.to_string())
             .replace("{min_value}", &v2.min(v1).to_string());
 
-        let process = &tx_context.execute_code_with_assembler(
-            code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )?;
+        let process = &tx_context
+            .execute_code_with_assembler(code, TransactionKernel::with_mock_libraries())?;
 
         // Expiry block should be set to transaction's block + the stored expiration delta
         // (which can only decrease, not increase)
@@ -420,10 +410,8 @@ fn test_invalid_expiration_deltas() -> anyhow::Result<()> {
 
     for value in test_values {
         let code = &code_template.replace("{value_1}", &value.to_string());
-        let process = tx_context.execute_code_with_assembler(
-            code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        );
+        let process =
+            tx_context.execute_code_with_assembler(code, TransactionKernel::with_mock_libraries());
 
         assert_execution_error!(process, ERR_TX_INVALID_EXPIRATION_DELTA);
     }
@@ -453,10 +441,8 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
     end
     ";
 
-    let process = &tx_context.execute_code_with_assembler(
-        code_template,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process = &tx_context
+        .execute_code_with_assembler(code_template, TransactionKernel::with_mock_libraries())?;
 
     // Default value should be equal to u32::max, set in the prologue
     assert_eq!(process.stack.get(EXPIRATION_BLOCK_ELEMENT_IDX).as_int() as u32, u32::MAX);
@@ -496,10 +482,8 @@ fn test_epilogue_increment_nonce_success() -> anyhow::Result<()> {
         "
     );
 
-    tx_context.execute_code_with_assembler(
-        code.as_str(),
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    tx_context
+        .execute_code_with_assembler(code.as_str(), TransactionKernel::with_mock_libraries())?;
     Ok(())
 }
 
@@ -520,7 +504,7 @@ fn epilogue_fails_on_account_state_change_without_nonce_increment() -> anyhow::R
         end
         ";
 
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::with_noop_auth_account()
         .tx_script(tx_script)

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -80,10 +80,7 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     );
 
     let process = &tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT;
@@ -118,7 +115,7 @@ fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
       ",
         asset = Word::from(FungibleAsset::mock(50))
     );
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
@@ -151,10 +148,8 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
         asset = Word::from(FungibleAsset::mock(5))
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
@@ -173,7 +168,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
     ",
         asset = Word::from(FungibleAsset::mock(FungibleAsset::MAX_AMOUNT))
     );
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::with_fungible_faucet(
         FungibleAsset::mock_issuer().into(),
@@ -243,10 +238,7 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     );
 
     tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
     Ok(())
 }
@@ -273,10 +265,8 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
@@ -298,7 +288,7 @@ fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
       ",
         asset = Word::from(FungibleAsset::mock(50))
     );
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
@@ -331,10 +321,8 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<(
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_ALREADY_ISSUED);
     Ok(())
@@ -391,10 +379,7 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
     );
 
     let process = &tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT;
@@ -429,7 +414,7 @@ fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
       ",
         asset = Word::from(FungibleAsset::mock(50))
     );
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
@@ -465,10 +450,8 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
@@ -500,10 +483,8 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW);
     Ok(())
@@ -578,10 +559,7 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     );
 
     tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
     Ok(())
 }
@@ -609,10 +587,8 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
     Ok(())
@@ -634,7 +610,7 @@ fn burn_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
       ",
         asset = Word::from(FungibleAsset::mock(50))
     );
-    let tx_script = ScriptBuilder::with_mock_account_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::with_mock_libraries()?.compile_tx_script(code)?;
 
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
@@ -670,10 +646,8 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
         non_fungible_asset = word_to_masm_push_string(&non_fungible_asset_burnt.into())
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
     Ok(())
@@ -721,10 +695,7 @@ fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
     );
 
     tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
     Ok(())
 }
@@ -760,10 +731,7 @@ fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
     );
 
     tx_context
-        .execute_code_with_assembler(
-            &code,
-            TransactionKernel::testing_assembler_with_mock_account(),
-        )
+        .execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())
         .unwrap();
     Ok(())
 }
@@ -779,7 +747,7 @@ fn setup_non_faucet_account() -> anyhow::Result<Account> {
     let faucet_component = AccountComponent::compile(
         "export.::miden::faucet::mint
          export.::miden::faucet::burn",
-        TransactionKernel::testing_assembler_with_mock_account(),
+        TransactionKernel::with_mock_libraries(),
         vec![],
     )?
     .with_supported_type(AccountType::RegularAccountUpdatableCode);

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -76,7 +76,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
 
     let foreign_account_component = AccountComponent::compile(
         foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots.clone(),
     )?
     .with_supports_all_types();
@@ -322,14 +322,14 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
 
     let foreign_account_component_1 = AccountComponent::compile(
         foreign_account_code_source_1,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots_1.clone(),
     )?
     .with_supports_all_types();
 
     let foreign_account_component_2 = AccountComponent::compile(
         foreign_account_code_source_2,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots_2.clone(),
     )?
     .with_supports_all_types();
@@ -529,7 +529,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
 
     let foreign_account_component = AccountComponent::compile(
         foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -689,7 +689,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
 
     let second_foreign_account_component = AccountComponent::compile(
         second_foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -747,7 +747,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
 
     let first_foreign_account_component = AccountComponent::compile(
         first_foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -886,7 +886,7 @@ fn test_nested_fpi_stack_overflow() {
             let storage_slots = vec![AccountStorage::mock_item_0().slot];
             let last_foreign_account_component = AccountComponent::compile(
                 last_foreign_account_code_source,
-                TransactionKernel::testing_assembler(),
+                TransactionKernel::with_kernel_library(),
                 storage_slots,
             )
             .unwrap()
@@ -933,7 +933,7 @@ fn test_nested_fpi_stack_overflow() {
 
                 let foreign_account_component = AccountComponent::compile(
                     foreign_account_code_source,
-                    TransactionKernel::testing_assembler(),
+                    TransactionKernel::with_kernel_library(),
                     vec![],
                 )
                 .unwrap()
@@ -1050,7 +1050,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
 
     let foreign_account_component = AccountComponent::compile(
         foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         vec![],
     )?
     .with_supports_all_types();
@@ -1145,7 +1145,7 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
 
     let foreign_account_component = AccountComponent::compile(
         foreign_account_code_source,
-        TransactionKernel::testing_assembler(),
+        TransactionKernel::with_kernel_library(),
         vec![AccountStorage::mock_item_0().slot],
     )?
     .with_supports_all_types();

--- a/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
@@ -77,7 +77,7 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         ),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(
@@ -135,7 +135,7 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         METADATA = word_to_masm_push_string(&p2id_note_1_asset.metadata().into()),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[p2id_note_1_asset])?
@@ -226,7 +226,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         check_note_2 = check_assets_code(2, 8, &p2id_note_2_assets),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(code)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let tx_context = mock_chain
         .build_tx_context(

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -911,7 +911,7 @@ pub fn test_timelock() -> anyhow::Result<()> {
     let timelock_note = NoteBuilder::new(account.id(), &mut ChaCha20Rng::from_os_rng())
         .note_inputs([Felt::from(lock_timestamp)])?
         .code(code.clone())
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
 
     builder.add_note(OutputNote::Full(timelock_note.clone()));
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -156,7 +156,7 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         assets_number_1 = output_note_1.assets().num_assets(),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -229,7 +229,7 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         METADATA = word_to_masm_push_string(&output_note.metadata().into()),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
@@ -332,7 +332,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         check_note_2 = check_assets_code(2, 8, &p2id_note_2_assets),
     );
 
-    let tx_script = ScriptBuilder::with_kernel_library()?.compile_tx_script(tx_script_src)?;
+    let tx_script = ScriptBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -224,10 +224,8 @@ fn test_create_note() -> anyhow::Result<()> {
         tag = tag,
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
@@ -276,7 +274,7 @@ fn test_create_note_with_invalid_tag() -> anyhow::Result<()> {
         tx_context
             .execute_code_with_assembler(
                 &note_creation_script(invalid_tag),
-                TransactionKernel::testing_assembler()
+                TransactionKernel::with_kernel_library()
             )
             .is_err()
     );
@@ -285,7 +283,7 @@ fn test_create_note_with_invalid_tag() -> anyhow::Result<()> {
         tx_context
             .execute_code_with_assembler(
                 &note_creation_script(valid_tag),
-                TransactionKernel::testing_assembler()
+                TransactionKernel::with_kernel_library()
             )
             .is_ok()
     );
@@ -352,10 +350,8 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
         aux = Felt::ZERO,
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT);
     Ok(())
@@ -513,10 +509,8 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
         )),
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
@@ -591,10 +585,8 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
         asset = word_to_masm_push_string(&asset),
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
@@ -676,10 +668,8 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
         nft = word_to_masm_push_string(&non_fungible_asset_encoded),
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
@@ -756,10 +746,8 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
         nft = word_to_masm_push_string(&encoded),
     );
 
-    let process = tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    );
+    let process =
+        tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries());
 
     assert_execution_error!(process, ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
     Ok(())
@@ -857,10 +845,8 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
         aux = aux,
     );
 
-    let process = &tx_context.execute_code_with_assembler(
-        &code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(&code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
@@ -903,10 +889,8 @@ fn test_block_procedures() -> anyhow::Result<()> {
         end
         ";
 
-    let process = &tx_context.execute_code_with_assembler(
-        code,
-        TransactionKernel::testing_assembler_with_mock_account(),
-    )?;
+    let process =
+        &tx_context.execute_code_with_assembler(code, TransactionKernel::with_mock_libraries())?;
 
     assert_eq!(
         process.stack.get_word(0),

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -81,7 +81,7 @@ pub struct TransactionContextBuilder {
 impl TransactionContextBuilder {
     pub fn new(account: Account) -> Self {
         Self {
-            assembler: TransactionKernel::testing_assembler_with_mock_account(),
+            assembler: TransactionKernel::with_mock_libraries(),
             account,
             account_seed: None,
             input_notes: Vec::new(),
@@ -110,7 +110,7 @@ impl TransactionContextBuilder {
         let account =
             Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, IncrNonceAuthComponent);
 
-        let assembler = TransactionKernel::testing_assembler_with_mock_account();
+        let assembler = TransactionKernel::with_mock_libraries();
 
         Self {
             assembler: assembler.clone(),

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -135,7 +135,7 @@ impl TransactionContext {
     ///
     /// For more information, see the docs for [TransactionContext::execute_code_with_assembler()].
     pub fn execute_code(&self, code: &str) -> Result<Process, ExecutionError> {
-        let assembler = TransactionKernel::testing_assembler();
+        let assembler = TransactionKernel::with_kernel_library();
         self.execute_code_with_assembler(code, assembler)
     }
 

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -131,7 +131,8 @@ impl TransactionContext {
         .execute_program(program)
     }
 
-    /// Executes arbitrary code with a testing assembler ([TransactionKernel::testing_assembler()]).
+    /// Executes arbitrary code with a kernel library assembler
+    /// ([`TransactionKernel::with_kernel_library`]).
     ///
     /// For more information, see the docs for [TransactionContext::execute_code_with_assembler()].
     pub fn execute_code(&self, code: &str) -> Result<Process, ExecutionError> {

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -134,7 +134,7 @@ pub fn create_p2any_note(sender: AccountId, assets: &[Asset]) -> Note {
     NoteBuilder::new(sender, SmallRng::from_seed([0; 32]))
         .add_assets(assets.iter().copied())
         .code(code)
-        .build(&TransactionKernel::testing_assembler_with_mock_account())
+        .build(&TransactionKernel::with_mock_libraries())
         .expect("generated note script should compile")
 }
 
@@ -147,7 +147,7 @@ pub fn create_spawn_note(sender_id: AccountId, output_notes: Vec<&Note>) -> anyh
 
     let note = NoteBuilder::new(sender_id, SmallRng::from_os_rng())
         .code(note_code)
-        .build(&TransactionKernel::testing_assembler_with_mock_account())?;
+        .build(&TransactionKernel::with_mock_libraries())?;
 
     Ok(note)
 }

--- a/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
@@ -127,13 +127,13 @@ fn test_rpo_falcon_acl() -> anyhow::Result<()> {
         "#;
 
     let tx_script_trigger_1 =
-        ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_with_trigger_1)?;
+        ScriptBuilder::with_mock_libraries()?.compile_tx_script(tx_script_with_trigger_1)?;
 
     let tx_script_trigger_2 =
-        ScriptBuilder::with_mock_account_library()?.compile_tx_script(tx_script_with_trigger_2)?;
+        ScriptBuilder::with_mock_libraries()?.compile_tx_script(tx_script_with_trigger_2)?;
 
     let tx_script_no_trigger =
-        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
+        ScriptBuilder::with_mock_libraries()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test 1: Transaction WITH authenticator calling trigger procedure 1 (should succeed)
     let tx_context_with_auth_1 = mock_chain
@@ -207,7 +207,7 @@ fn test_rpo_falcon_acl_with_allow_unauthorized_output_notes() -> anyhow::Result<
     assert_eq!(slot_1, Word::from([2u32, 1, 1, 0]));
 
     let tx_script_no_trigger =
-        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
+        ScriptBuilder::with_mock_libraries()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test: Transaction WITHOUT authenticator calling non-trigger procedure (should succeed)
     // This tests that when allow_unauthorized_output_notes=true, transactions without
@@ -243,7 +243,7 @@ fn test_rpo_falcon_acl_with_disallow_unauthorized_input_notes() -> anyhow::Resul
     assert_eq!(slot_1, Word::from([2u32, 1, 0, 0]));
 
     let tx_script_no_trigger =
-        ScriptBuilder::with_mock_account_library()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
+        ScriptBuilder::with_mock_libraries()?.compile_tx_script(TX_SCRIPT_NO_TRIGGER)?;
 
     // Test: Transaction WITHOUT authenticator calling non-trigger procedure but consuming input
     // notes This should FAIL because allow_unauthorized_input_notes=false and we're consuming

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -44,10 +44,7 @@ fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         Default::default(),
     )?;
     let assets = NoteAssets::new(vec![sent_asset]).unwrap();
-    let note_script = ScriptBuilder::with_kernel_library()
-        .unwrap()
-        .compile_note_script("begin nop end")
-        .unwrap();
+    let note_script = ScriptBuilder::default().compile_note_script("begin nop end").unwrap();
     let serial_num = RpoRandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
 
@@ -110,10 +107,7 @@ fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
     let assets = NoteAssets::new(vec![Asset::Fungible(
         FungibleAsset::new(sender_basic_fungible_faucet_account.id(), 10).unwrap(),
     )])?;
-    let note_script = ScriptBuilder::with_kernel_library()
-        .unwrap()
-        .compile_note_script("begin nop end")
-        .unwrap();
+    let note_script = ScriptBuilder::default().compile_note_script("begin nop end").unwrap();
     let serial_num = RpoRandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteInputs::default());
 


### PR DESCRIPTION
Follow-up to https://github.com/0xMiden/miden-base/pull/1732 to rename the kernel and script builder APIs to be consistent with each other and to capture the fact that multiple mock libraries are now involved.

Also removes `ScriptBuilder::with_kernel_library`, which we don't actually need. This builder is used to assemble note and tx scripts, but those can never legally use the kernel library directly, they have to call kernel procedures, and so all of those could actually be replaced with `ScriptBuilder::default`.

The interesting parts of this PR are in `crates/miden-lib/src/transaction/mod.rs` and `crates/miden-lib/src/utils/script_builder.rs`.