### PR TITLE
use `std::word` for word equality checks

### DIFF
--- a/crates/miden-lib/asm/account_components/no_auth.masm
+++ b/crates/miden-lib/asm/account_components/no_auth.masm
@@ -1,4 +1,5 @@
 use.miden::account
+use.std::word
 
 #! Increment the nonce only if the account commitment has changed
 #!
@@ -19,8 +20,7 @@ export.auth__no_auth
     exec.account::compute_current_commitment
     # => [CURRENT_COMMITMENT, INITIAL_COMMITMENT, pad(16)]
 
-    # TODO: use std::word::eq when it becomes available
-    eqw not movdn.8 dropw dropw
+    exec.word::eq not
     # => [has_account_state_changed, pad(16)]
 
     # if the account has been updated, increment the nonce

--- a/crates/miden-lib/asm/account_components/rpo_falcon_512_acl.masm
+++ b/crates/miden-lib/asm/account_components/rpo_falcon_512_acl.masm
@@ -4,6 +4,7 @@
 
 use.miden::account
 use.miden::tx
+use.std::word
 
 # CONSTANTS
 # ================================================================================================
@@ -133,7 +134,7 @@ export.auth__tx_rpo_falcon512_acl.2
         exec.account::compute_current_commitment
         # => [CURRENT_COMMITMENT, INITIAL_COMMITMENT, pad(16)]
 
-        eqw not movdn.8 dropw dropw
+        exec.word::eq not
         # => [has_account_state_changed, pad(16)]
 
         if.true

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -437,6 +437,7 @@ export.finalize_transaction.8
     # ------ Assert that account was changed or notes were consumed ------
 
     # check if the account delta commitment is the EMPTY_WORD, which is the case when the delta
+    # is empty, i.e. the account did not change in this transaction
     dupw exec.word::eqz
     # => [is_delta_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -438,7 +438,7 @@ export.finalize_transaction.8
 
     # check if the account delta commitment is the EMPTY_WORD, which is the case when the delta
     # is empty, i.e. the account did not change in this transaction
-    dupw exec.word::eqz
+    exec.word::testz
     # => [is_delta_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
 
     # assert that if the delta commitment is empty, the transaction had input notes,

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -7,6 +7,7 @@ use.$kernel::note
 use.$kernel::tx
 
 use.std::crypto::hashes::rpo
+use.std::word
 
 # ERRORS
 # =================================================================================================
@@ -436,19 +437,16 @@ export.finalize_transaction.8
     # ------ Assert that account was changed or notes were consumed ------
 
     # check if the account delta commitment is the EMPTY_WORD, which is the case when the delta
-    # is empty, i.e. the account did not change in this transaction
-    # TODO: Use std::word in the future (#1658).
-    padw eqw movdn.4 dropw
+    dupw exec.word::eqz
     # => [is_delta_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
 
     # assert that if the delta commitment is empty, the transaction had input notes,
     # otherwise this transaction is considered empty, which is not allowed
-    exec.memory::get_input_notes_commitment padw
-    # => [EMPTY_WORD, INPUT_NOTES_COMMITMENT, is_delta_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
+    exec.memory::get_input_notes_commitment
+    # => [INPUT_NOTES_COMMITMENT, is_delta_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
 
     # if the input notes commitment is an empty word there were no input notes in this transaction
-    # TODO: Use std::word in the future (#1658).
-    eqw movdn.8 dropw dropw and
+    exec.word::eqz and
     # => [is_delta_commitment_and_input_notes_commitment_empty, ACCOUNT_DELTA_COMMITMENT, FINAL_ACCOUNT_COMMITMENT]
 
     # assert that either the account was changed or notes were consumed

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -1,6 +1,7 @@
 use.std::mem
 use.std::collections::mmr
 use.std::crypto::hashes::rpo
+use.std::word
 
 use.$kernel::account
 use.$kernel::account_id
@@ -375,8 +376,7 @@ proc.validate_new_account
 
         if.true
             # assert the fungible faucet reserved slot is initialized correctly (EMPTY_WORD)
-            # TODO: Switch to standard library implementation when available (miden-vm/#1483)
-            exec.is_empty_word_dropped not
+            exec.word::eqz not
             assertz.err=ERR_PROLOGUE_NEW_FUNGIBLE_FAUCET_RESERVED_SLOT_MUST_BE_EMPTY
             # => []
 
@@ -419,20 +419,6 @@ proc.validate_new_account
     # ---------------------------------------------------------------------------------------------
     exec.account::validate_procedure_metadata
     # => []
-end
-
-#! Returns whether the input word is equal to EMPTY_WORD as a boolean value.
-#!
-#! This procedure drops the input word.
-#!
-#! Inputs:  [INPUT_WORD]
-#! Outputs: [is_empty]
-#!
-#! Where:
-#! - INPUT_WORD is the word is compared with EMPTY_WORD.
-#! - is_empty is a boolean value that is 1 if INPUT_WORD is equal to EMPTY_WORD, and 0 otherwise.
-proc.is_empty_word_dropped
-    eq.0 swap eq.0 and swap eq.0 and swap eq.0 and
 end
 
 #! Saves the account data to memory and validates it.

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -515,7 +515,7 @@ proc.process_account_data
     # => [INITIAL_ACCOUNT_COMMITMENT, ACCOUNT_COMMITMENT]
 
     # It is a new account if the global input INITIAL_ACCOUNT_COMMITMENT was set to EMPTY_WORD.
-    exec.word::eqz 
+    exec.word::eqz
     # => [is_new, ACCOUNT_COMMITMENT]
 
     # process conditional logic depending on whether the account is new or existing

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -510,12 +510,12 @@ proc.process_account_data
     # Validate the account
     # ---------------------------------------------------------------------------------------------
 
-    # It is a new account if the global input INITIAL_ACCOUNT_COMMITMENT was set to EMPTY_WORD.
-    padw exec.memory::get_init_account_commitment eqw
-    # => [is_new, INITIAL_ACCOUNT_COMMITMENT, EMPTY_WORD, ACCOUNT_COMMITMENT]
+    # Push EMPTY_WORD and get initial account commitment
+    padw exec.memory::get_init_account_commitment
+    # => [INITIAL_ACCOUNT_COMMITMENT, EMPTY_WORD, ACCOUNT_COMMITMENT]
 
-    # clean the stack
-    movdn.8 dropw dropw
+    # It is a new account if the global input INITIAL_ACCOUNT_COMMITMENT was set to EMPTY_WORD.
+    exec.word::eq 
     # => [is_new, ACCOUNT_COMMITMENT]
 
     # process conditional logic depending on whether the account is new or existing

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -510,12 +510,12 @@ proc.process_account_data
     # Validate the account
     # ---------------------------------------------------------------------------------------------
 
-    # Push EMPTY_WORD and get initial account commitment
-    padw exec.memory::get_init_account_commitment
-    # => [INITIAL_ACCOUNT_COMMITMENT, EMPTY_WORD, ACCOUNT_COMMITMENT]
+    # Get initial account commitment
+    exec.memory::get_init_account_commitment
+    # => [INITIAL_ACCOUNT_COMMITMENT, ACCOUNT_COMMITMENT]
 
     # It is a new account if the global input INITIAL_ACCOUNT_COMMITMENT was set to EMPTY_WORD.
-    exec.word::eq 
+    exec.word::eqz 
     # => [is_new, ACCOUNT_COMMITMENT]
 
     # process conditional logic depending on whether the account is new or existing


### PR DESCRIPTION
This small PR resolves a `TODO` comment in the epilogue. Updated to use `word::eqz` as opposed to `padw eqw`.

Adds https://github.com/0xMiden/miden-vm/issues/1483 to miden-base

There are most likely other areas in miden-base that could use `word::eqz`.