### PR TITLE
Cached account data getters [part 2]

### DIFF
--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -231,7 +231,7 @@ export.account_get_initial_code_commitment
     # => [INIT_CODE_COMMITMENT, pad(12)]
 end
 
-#! Gets the account code commitment of the current account.
+#! Computes the latest account code commitment of the current account.
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [CODE_COMMITMENT, pad(12)]
@@ -240,13 +240,13 @@ end
 #! - CODE_COMMITMENT is the commitment of the account code.
 #!
 #! Invocation: dynexec
-export.account_get_code_commitment
+export.account_compute_code_commitment
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin drop drop
     # => [pad(16)]
 
-    # get the account code commitment
-    exec.account::get_code_commitment
+    # compute the account code commitment
+    exec.account::compute_code_commitment
     # => [CODE_COMMITMENT, pad(16)]
 
     # truncate the stack

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -315,15 +315,18 @@ export.memory::get_init_account_storage_commitment->get_initial_storage_commitme
 #! - INIT_ACCOUNT_CODE_COMMITMENT is the initial account code commitment.
 export.memory::get_init_account_code_commitment->get_initial_code_commitment
 
-#! Gets the code commitment of the current account.
+#! Computes the code commitment of the current account.
 #!
 #! Inputs:  []
 #! Outputs: [CODE_COMMITMENT]
 #!
 #! Where:
-#! - CODE_COMMITMENT is the commitment of the account code.
-export.get_code_commitment
-    # get the code commitment
+#! - CODE_COMMITMENT is the current commitment of the account code.
+export.compute_code_commitment
+    # recompute the code commitment (if outdated) and store it in the memory
+    exec.recompute_code_commitment
+
+    # return the code commitment
     exec.memory::get_acct_code_commitment
     # => [CODE_COMMITMENT]
 end
@@ -1316,6 +1319,69 @@ proc.recompute_storage_commitment
         # update the storage commitment dirty flag
         push.0 
         exec.memory::set_native_account_storage_commitment_dirty_flag
+        # => []
+    end
+end
+
+#! Computes the account code commitment by hashing the procedures data and updates the code
+#! commitment in memory to the newly computed code commitment.
+#!
+#! Inputs:  []
+#! Outputs: []
+proc.recompute_code_commitment
+    # First we should determine whether the code commitment should be recomputed. We should do so
+    # if the current account is native and the code commitment is outdated (the dirty flag equals
+    # 1). Otherwise the commitment value is guaranteed to be up-to-date.
+    exec.memory::get_recompute_code_commitment_flag
+    # => [should_recompute_code_commitment]
+
+    if.true
+        # get number of account procedures
+        exec.memory::get_num_account_procedures
+        # => [num_procedures]
+
+        # check if there are any procedures
+        dup neq.0
+        # => [has_procedures, num_procedures]
+
+        # only loop and hash over procedures if there are any
+        if.true
+            # setup start and end ptr
+            mul.8 exec.memory::get_acct_procedures_section_ptr dup movdn.2 add swap
+            # => [start_ptr, end_ptr]
+
+            # pad stack to read and hash from memory
+            padw padw padw
+            # => [PAD, PAD, PAD, start_ptr, end_ptr]
+
+            # hash elements from memory
+            exec.rpo::absorb_double_words_from_memory
+            # => [PERM, PERM, PERM, start_ptr, end_ptr]
+
+            # extract the digest
+            exec.rpo::squeeze_digest
+            # => [DIGEST, end_ptr, end_ptr]
+
+            # clean stack
+            movup.4 drop movup.4 drop
+            # => [DIGEST]
+
+            # set new account code commitment
+            exec.memory::set_acct_code_commitment dropw
+            # => []
+        else
+            # if no procedures left in the account, set the code commitment to the EMPTY_WORD
+            padw exec.memory::set_acct_code_commitment
+            # => [EMPTY_WORD, num_procedures]
+
+            # clear the stack
+            dropw drop
+            # => []
+        end
+
+        # update the code commitment dirty flag
+        push.0 
+        exec.memory::set_native_account_code_commitment_dirty_flag
         # => []
     end
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -48,6 +48,15 @@ const.NEW_CODE_ROOT_PTR=20
 # made to the account storage since the last re-computation, and 0 otherwise.
 const.NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR=24
 
+# TODO: make sure to update this flag when the ability to modify the code will be implemented.
+#
+# The memory address at which the dirty flag of the code commitment of the native account is 
+# stored. 
+# 
+# This binary flag specifies whether the commitment is outdated: it holds 1 if some changes were 
+# made to the account code since the last re-computation, and 0 otherwise.
+const.NATIVE_ACCT_CODE_COMMITMENT_DIRTY_FLAG_PTR=24
+
 # The memory address at which the absolute expiration block number is stored.
 const.TX_EXPIRATION_BLOCK_NUM_PTR=28
 
@@ -1219,6 +1228,45 @@ export.get_recompute_storage_commitment_flag
     # commitment should be recomputed only if the account is native and the commitment is outdated
     and
     # => [should_recompute_storage_commitment]
+end
+
+#! Sets the dirty flag for the native account code commitment.
+#!
+#! This binary flag specifies whether the code commitment stored in the native account data is
+#! outdated.
+#!
+#! Inputs:  [dirty_flag]
+#! Outputs: []
+#!
+#! Where:
+#! - dirty_flag is the flag indicating whether the code commitment is outdated.
+export.set_native_account_code_commitment_dirty_flag
+    push.NATIVE_ACCT_CODE_COMMITMENT_DIRTY_FLAG_PTR mem_store
+    # => []
+end
+
+#! Returns the flag indicating whether the account code commitment should be recomputed.
+#!
+#! This flag equals 1 if the current account is native and the code commitment is outdated.
+#!
+#! Inputs:  []
+#! Outputs: [should_recompute_code_commitment]
+#!
+#! Where:
+#! - should_recompute_code_commitment is the flag indicating whether the code commitment should be 
+#!   recomputed.
+export.get_recompute_code_commitment_flag
+    # get the is_native_account flag
+    exec.is_native_account
+    # => [is_native_account]
+
+    # get the code commitment dirty flag
+    mem_load.NATIVE_ACCT_CODE_COMMITMENT_DIRTY_FLAG_PTR
+    # => [dirty_flag, is_native_account]
+
+    # commitment should be recomputed only if the account is native and the commitment is outdated
+    and
+    # => [should_recompute_code_commitment]
 end
 
 #! Sets the transaction expiration block number.

--- a/crates/miden-lib/asm/miden/account.masm
+++ b/crates/miden-lib/asm/miden/account.masm
@@ -325,7 +325,7 @@ export.get_initial_code_commitment
     # => [INIT_CODE_COMMITMENT]
 end
 
-#! Gets the account code commitment of the current account.
+#! Computes the latest account code commitment of the current account.
 #!
 #! Inputs:  []
 #! Outputs: [CODE_COMMITMENT]
@@ -334,8 +334,8 @@ end
 #! - CODE_COMMITMENT is the commitment of the account code.
 #!
 #! Invocation: exec
-export.get_code_commitment
-    exec.kernel_proc_offsets::account_get_code_commitment_offset
+export.compute_code_commitment
+    exec.kernel_proc_offsets::account_compute_code_commitment_offset
     # => [offset]
 
     # pad the stack

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -15,7 +15,7 @@ const.ACCOUNT_INCR_NONCE_OFFSET=4                     # mutator
 
 # Code
 const.ACCOUNT_GET_INITIAL_CODE_COMMITMENT_OFFSET=5
-const.ACCOUNT_GET_CODE_COMMITMENT_OFFSET=6
+const.ACCOUNT_COMPUTE_CODE_COMMITMENT_OFFSET=6
 
 # Storage
 const.ACCOUNT_GET_INITIAL_STORAGE_COMMITMENT_OFFSET=7
@@ -180,16 +180,16 @@ export.account_get_initial_code_commitment_offset
     push.ACCOUNT_GET_INITIAL_CODE_COMMITMENT_OFFSET
 end
 
-#! Returns the offset of the `account_get_code_commitment` kernel procedure.
+#! Returns the offset of the `account_compute_code_commitment` kernel procedure.
 #!
 #! Inputs:  []
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_get_code_commitment` kernel procedure required to get
-#!   the address where this procedure is stored.
-export.account_get_code_commitment_offset
-    push.ACCOUNT_GET_CODE_COMMITMENT_OFFSET
+#! - proc_offset is the offset of the `account_compute_code_commitment` kernel procedure required to
+#!   get the address where this procedure is stored.
+export.account_compute_code_commitment_offset
+    push.ACCOUNT_COMPUTE_CODE_COMMITMENT_OFFSET
 end
 
 #! Returns the offset of the `account_get_initial_storage_commitment` kernel procedure.

--- a/crates/miden-lib/src/testing/mock_account_code.rs
+++ b/crates/miden-lib/src/testing/mock_account_code.rs
@@ -67,8 +67,8 @@ const MOCK_ACCOUNT_CODE: &str = "
 
     # Stack:  [pad(16)]
     # Output: [CODE_COMMITMENT, pad(12)]
-    export.get_code
-        exec.account::get_code_commitment
+    export.compute_code_commitment
+        exec.account::compute_code_commitment
         # => [CODE_COMMITMENT, pad(12)]
     end
 

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -98,6 +98,13 @@ pub const NEW_CODE_ROOT_PTR: MemoryAddress = 20;
 /// made to the account storage since the last re-computation, and 0 otherwise.
 pub const NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR: MemoryAddress = 24;
 
+/// The memory address at which the dirty flag of the code commitment of the native account is
+/// stored.
+///
+/// This binary flag specifies whether the commitment is outdated: it holds 1 if some changes were
+/// made to the account code since the last re-computation, and 0 otherwise.
+pub const NATIVE_ACCT_CODE_COMMITMENT_DIRTY_FLAG_PTR: MemoryAddress = 25;
+
 /// The memory address at which the transaction expiration block number is stored.
 pub const TX_EXPIRATION_BLOCK_NUM_PTR: MemoryAddress = 28;
 

--- a/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
+++ b/crates/miden-lib/src/transaction/procedures/kernel_v0.rs
@@ -19,8 +19,8 @@ pub const KERNEL0_PROCEDURES: [Word; 49] = [
     word!("0x90ab0ffff9d2b91b9c28963e5caac1d48f24dab3a97ecbd3d9b7ae73c37da7c6"),
     // account_get_initial_code_commitment
     word!("0xcaff9917337053663a67166ce738a1fcfc14c364085e26ed7cd360f7e9aef46b"),
-    // account_get_code_commitment
-    word!("0x9747eb2383e5a92a948ffd27f3b9b829591da0e65209137da53cc19771b35882"),
+    // account_compute_code_commitment
+    word!("0x46af8168abdfedff015c815598ce6a285aa18f55b0b58e511ed480a8f9386345"),
     // account_get_initial_storage_commitment
     word!("0x5932cb0394cc85330e65e4c0325bb869ec1d08b295c310f7375076a98b143d57"),
     // account_compute_storage_commitment

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -143,36 +143,6 @@ pub fn compute_current_commitment() -> miette::Result<()> {
     Ok(())
 }
 
-// ACCOUNT CODE TESTS
-// ================================================================================================
-
-// TODO: add the current code commitment obtainment once we will have updatable code
-#[test]
-pub fn test_get_code_commitment() -> miette::Result<()> {
-    let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
-    let account = tx_context.account();
-
-    let code = format!(
-        r#"
-        use.$kernel::prologue
-        use.$kernel::account
-        begin
-            exec.prologue::prepare_transaction
-
-            # get the initial code commitment
-            exec.account::get_initial_code_commitment
-            push.{expected_code_commitment}
-            assert_eqw.err="actual code commitment is not equal to the expected one"
-        end
-        "#,
-        expected_code_commitment = account.code().commitment()
-    );
-
-    tx_context.execute_code(&code)?;
-
-    Ok(())
-}
-
 // ACCOUNT ID TESTS
 // ================================================================================================
 
@@ -348,6 +318,62 @@ fn test_is_faucet_procedure() -> miette::Result<()> {
             "Rust and MASM is_faucet diverged for account_id {account_id}"
         );
     }
+
+    Ok(())
+}
+
+// ACCOUNT CODE TESTS
+// ================================================================================================
+
+#[test]
+pub fn test_get_initial_code_commitment() -> miette::Result<()> {
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
+    let account = tx_context.account();
+
+    let code = format!(
+        r#"
+        use.$kernel::prologue
+        use.$kernel::account
+        begin
+            exec.prologue::prepare_transaction
+
+            # get the initial code commitment
+            exec.account::get_initial_code_commitment
+            push.{expected_code_commitment}
+            assert_eqw.err="actual code commitment is not equal to the expected one"
+        end
+        "#,
+        expected_code_commitment = account.code().commitment()
+    );
+
+    tx_context.execute_code(&code)?;
+
+    Ok(())
+}
+
+// TODO: update this test once the ability to change the account code will be implemented
+#[test]
+pub fn test_compute_code_commitment() -> miette::Result<()> {
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
+    let account = tx_context.account();
+
+    let code = format!(
+        r#"
+        use.$kernel::prologue
+        use.$kernel::account
+        begin
+            exec.prologue::prepare_transaction
+
+            # compute the current code commitment
+            exec.account::compute_code_commitment
+            push.{expected_code_commitment}
+            assert_eqw.err="actual code commitment is not equal to the expected one"
+        end
+        "#,
+        expected_code_commitment = account.code().commitment()
+    );
+
+    tx_context.execute_code(&code)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR is a second (and final) part in a sequence of cached account data getters PRs.

It implements getter procedure for the current account code commitment — the commitment value (if outdated) is recomputed every time the getter is called.
In addition a dirty flag for the native account code commitment was added, which allows to recompute the commitment only in case the code was updated (changing of the account procedures is not implemented yet, this is for the future).

Part of https://github.com/0xMiden/miden-base/issues/1537 and https://github.com/0xMiden/miden-base/issues/77.