### PR TITLE
chore: use original crate names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ miden-tx              = { default-features = false, path = "crates/miden-tx", ve
 miden-tx-batch-prover = { default-features = false, path = "crates/miden-tx-batch-prover", version = "0.11" }
 
 # Miden dependencies
-assembly         = { default-features = false, package = "miden-assembly", version = "0.17" }
+miden-assembly   = { default-features = false, version = "0.17" }
 miden-core       = { default-features = false, version = "0.17" }
 miden-crypto     = { default-features = false, version = "0.15.6" }
 miden-processor  = { default-features = false, version = "0.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ miden-tx-batch-prover = { default-features = false, path = "crates/miden-tx-batc
 
 # Miden dependencies
 assembly         = { default-features = false, package = "miden-assembly", version = "0.17" }
+miden-core       = { default-features = false, version = "0.17" }
 miden-crypto     = { default-features = false, version = "0.15.6" }
+miden-processor  = { default-features = false, version = "0.17" }
 miden-prover     = { default-features = false, version = "0.17" }
 miden-stdlib     = { default-features = false, version = "0.17" }
 miden-utils-sync = { default-features = false, version = "0.17" }
 miden-verifier   = { default-features = false, version = "0.17" }
-vm-core          = { default-features = false, package = "miden-core", version = "0.17" }
-vm-processor     = { default-features = false, package = "miden-processor", version = "0.17" }
 
 # External dependencies
 assert_matches = { default-features = false, version = "1.5" }

--- a/bin/bench-prover/Cargo.toml
+++ b/bin/bench-prover/Cargo.toml
@@ -16,7 +16,7 @@ miden-testing = { workspace = true }
 miden-tx      = { workspace = true }
 
 # Miden dependencies
-vm-processor = { workspace = true }
+miden-processor = { workspace = true }
 
 # External dependencies
 anyhow     = "1.0"

--- a/bin/bench-tx/Cargo.toml
+++ b/bin/bench-tx/Cargo.toml
@@ -21,7 +21,7 @@ miden-testing = { workspace = true }
 miden-tx      = { features = ["testing"], workspace = true }
 
 # Miden dependencies
-vm-processor = { workspace = true }
+miden-processor = { workspace = true }
 
 # External dependencies
 anyhow      = { features = ["backtrace", "std"], version = "1.0" }

--- a/crates/miden-lib/Cargo.toml
+++ b/crates/miden-lib/Cargo.toml
@@ -16,15 +16,15 @@ version                = "0.11.0"
 
 [features]
 default         = ["std"]
-std             = ["assembly/std", "miden-objects/std", "miden-stdlib/std", "vm-processor/std"]
+std             = ["assembly/std", "miden-objects/std", "miden-processor/std", "miden-stdlib/std"]
 testing         = ["miden-objects/testing"]
 with-debug-info = ["miden-stdlib/with-debug-info"]
 
 [dependencies]
-miden-objects = { workspace = true }
-miden-stdlib  = { workspace = true }
-thiserror     = { workspace = true }
-vm-processor  = { workspace = true }
+miden-objects   = { workspace = true }
+miden-processor = { workspace = true }
+miden-stdlib    = { workspace = true }
+thiserror       = { workspace = true }
 
 [build-dependencies]
 assembly     = { workspace = true }
@@ -33,7 +33,7 @@ regex        = { version = "1.11" }
 walkdir      = { version = "2.5" }
 
 [dev-dependencies]
-anyhow         = "1.0"
-assert_matches = { workspace = true }
-miden-objects  = { features = ["testing"], workspace = true }
-vm-processor   = { features = ["testing"], workspace = true }
+anyhow          = "1.0"
+assert_matches  = { workspace = true }
+miden-objects   = { features = ["testing"], workspace = true }
+miden-processor = { features = ["testing"], workspace = true }

--- a/crates/miden-lib/Cargo.toml
+++ b/crates/miden-lib/Cargo.toml
@@ -16,7 +16,7 @@ version                = "0.11.0"
 
 [features]
 default         = ["std"]
-std             = ["assembly/std", "miden-objects/std", "miden-processor/std", "miden-stdlib/std"]
+std             = ["miden-assembly/std", "miden-objects/std", "miden-processor/std", "miden-stdlib/std"]
 testing         = ["miden-objects/testing"]
 with-debug-info = ["miden-stdlib/with-debug-info"]
 
@@ -27,10 +27,10 @@ miden-stdlib    = { workspace = true }
 thiserror       = { workspace = true }
 
 [build-dependencies]
-assembly     = { workspace = true }
-miden-stdlib = { workspace = true }
-regex        = { version = "1.11" }
-walkdir      = { version = "2.5" }
+miden-assembly = { workspace = true }
+miden-stdlib   = { workspace = true }
+regex          = { version = "1.11" }
+walkdir        = { version = "2.5" }
 
 [dev-dependencies]
 anyhow          = "1.0"

--- a/crates/miden-lib/build.rs
+++ b/crates/miden-lib/build.rs
@@ -6,9 +6,16 @@ use std::io::{self};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use assembly::diagnostics::{IntoDiagnostic, Result, WrapErr};
-use assembly::utils::Serializable;
-use assembly::{Assembler, DefaultSourceManager, KernelLibrary, Library, LibraryNamespace, Report};
+use miden_assembly::diagnostics::{IntoDiagnostic, Result, WrapErr};
+use miden_assembly::utils::Serializable;
+use miden_assembly::{
+    Assembler,
+    DefaultSourceManager,
+    KernelLibrary,
+    Library,
+    LibraryNamespace,
+    Report,
+};
 use regex::Regex;
 use walkdir::WalkDir;
 

--- a/crates/miden-lib/src/account/wallets/mod.rs
+++ b/crates/miden-lib/src/account/wallets/mod.rs
@@ -151,7 +151,7 @@ mod tests {
 
     use miden_objects::crypto::dsa::rpo_falcon512;
     use miden_objects::{ONE, Word};
-    use vm_processor::utils::{Deserializable, Serializable};
+    use miden_processor::utils::{Deserializable, Serializable};
 
     use super::{Account, AccountStorageMode, AccountType, AuthScheme, create_basic_wallet};
     use crate::account::wallets::BasicWallet;

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -25,21 +25,21 @@ std = [
   "assembly/std",
   "dep:serde",
   "dep:toml",
+  "miden-core/std",
   "miden-crypto/std",
+  "miden-processor/std",
   "miden-verifier/std",
-  "vm-core/std",
-  "vm-processor/std",
 ]
 testing = ["dep:rand", "dep:rand_xoshiro", "dep:winter-rand-utils"]
 
 [dependencies]
 # Miden dependencies
 assembly          = { workspace = true }
+miden-core        = { workspace = true }
 miden-crypto      = { workspace = true }
+miden-processor   = { workspace = true }
 miden-utils-sync  = { workspace = true }
 miden-verifier    = { workspace = true }
-vm-core           = { workspace = true }
-vm-processor      = { workspace = true }
 winter-rand-utils = { optional = true, version = "0.13" }
 
 # External dependencies

--- a/crates/miden-objects/Cargo.toml
+++ b/crates/miden-objects/Cargo.toml
@@ -22,9 +22,9 @@ bench = false
 [features]
 default = ["std"]
 std = [
-  "assembly/std",
   "dep:serde",
   "dep:toml",
+  "miden-assembly/std",
   "miden-core/std",
   "miden-crypto/std",
   "miden-processor/std",
@@ -34,7 +34,7 @@ testing = ["dep:rand", "dep:rand_xoshiro", "dep:winter-rand-utils"]
 
 [dependencies]
 # Miden dependencies
-assembly          = { workspace = true }
+miden-assembly    = { workspace = true }
 miden-core        = { workspace = true }
 miden-crypto      = { workspace = true }
 miden-processor   = { workspace = true }

--- a/crates/miden-objects/src/account/account_id/account_type.rs
+++ b/crates/miden-objects/src/account/account_id/account_type.rs
@@ -62,7 +62,7 @@ impl rand::distr::Distribution<AccountType> for rand::distr::StandardUniform {
 // ================================================================================================
 
 impl Serializable for AccountType {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write_u8(*self as u8);
     }
 }

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -20,10 +20,10 @@ use alloc::string::{String, ToString};
 use core::fmt;
 
 pub use id_version::AccountIdVersion;
+use miden_core::Felt;
+use miden_core::utils::{ByteReader, Deserializable, Serializable};
 use miden_crypto::utils::hex_to_bytes;
-use vm_core::Felt;
-use vm_core::utils::{ByteReader, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_processor::DeserializationError;
 
 use crate::errors::AccountIdError;
 use crate::{AccountError, Word};
@@ -458,7 +458,7 @@ impl fmt::Display for AccountId {
 // ================================================================================================
 
 impl Serializable for AccountId {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         match self {
             AccountId::V0(account_id) => {
                 account_id.write_into(target);

--- a/crates/miden-objects/src/account/account_id/v0/mod.rs
+++ b/crates/miden-objects/src/account/account_id/v0/mod.rs
@@ -377,7 +377,7 @@ impl TryFrom<u128> for AccountIdV0 {
 // ================================================================================================
 
 impl Serializable for AccountIdV0 {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         let bytes: [u8; 15] = (*self).into();
         bytes.write_into(target);
     }

--- a/crates/miden-objects/src/account/account_id/v0/prefix.rs
+++ b/crates/miden-objects/src/account/account_id/v0/prefix.rs
@@ -2,9 +2,9 @@ use alloc::string::{String, ToString};
 use core::fmt;
 use core::hash::Hash;
 
-use vm_core::Felt;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_core::Felt;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_processor::DeserializationError;
 
 use crate::account::account_id::v0::{self, validate_prefix};
 use crate::account::{AccountIdVersion, AccountStorageMode, AccountType};

--- a/crates/miden-objects/src/account/builder/mod.rs
+++ b/crates/miden-objects/src/account/builder/mod.rs
@@ -266,8 +266,8 @@ impl AccountBuilder {
 mod tests {
     use std::sync::LazyLock;
 
-    use assembly::{Assembler, Library};
     use assert_matches::assert_matches;
+    use miden_assembly::{Assembler, Library};
     use miden_core::FieldElement;
 
     use super::*;

--- a/crates/miden-objects/src/account/builder/mod.rs
+++ b/crates/miden-objects/src/account/builder/mod.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use vm_core::FieldElement;
+use miden_core::FieldElement;
 
 use crate::account::{
     Account,
@@ -187,7 +187,7 @@ impl AccountBuilder {
     /// - Authentication component is missing.
     /// - Multiple authentication procedures are found.
     /// - The number of [`StorageSlot`](crate::account::StorageSlot)s of all components exceeds 255.
-    /// - [`MastForest::merge`](vm_processor::MastForest::merge) fails on the given components.
+    /// - [`MastForest::merge`](miden_processor::MastForest::merge) fails on the given components.
     /// - If duplicate assets were added to the builder (only under the `testing` feature).
     /// - If the vault is not empty on new accounts (only under the `testing` feature).
     pub fn build(mut self) -> Result<(Account, Word), AccountError> {
@@ -268,7 +268,7 @@ mod tests {
 
     use assembly::{Assembler, Library};
     use assert_matches::assert_matches;
-    use vm_core::FieldElement;
+    use miden_core::FieldElement;
 
     use super::*;
     use crate::account::StorageSlot;

--- a/crates/miden-objects/src/account/code/header.rs
+++ b/crates/miden-objects/src/account/code/header.rs
@@ -1,10 +1,10 @@
 use alloc::vec::Vec;
 
-use vm_core::{
+use miden_core::{
     Felt,
     utils::{Deserializable, Serializable},
 };
-use vm_processor::Digest;
+use miden_processor::Digest;
 
 use super::{AccountCode, build_procedure_commitment, procedures_as_elements};
 use crate::account::AccountProcedureInfo;
@@ -65,15 +65,15 @@ impl From<AccountCode> for AccountCodeHeader {
 }
 
 impl Serializable for AccountCodeHeader {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write(&self.procedures);
     }
 }
 
 impl Deserializable for AccountCodeHeader {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let procedures: Vec<AccountProcedureInfo> = source.read()?;
         let commitment = build_procedure_commitment(&procedures);
 

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -2,8 +2,8 @@ use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use vm_core::mast::MastForest;
-use vm_core::prettier::PrettyPrint;
+use miden_core::mast::MastForest;
+use miden_core::prettier::PrettyPrint;
 
 use super::{
     AccountError,
@@ -297,8 +297,8 @@ impl Deserializable for AccountCode {
 // ================================================================================================
 
 impl PrettyPrint for AccountCode {
-    fn render(&self) -> vm_core::prettier::Document {
-        use vm_core::prettier::*;
+    fn render(&self) -> miden_core::prettier::Document {
+        use miden_core::prettier::*;
         let mut partial = Document::Empty;
         let len_procedures = self.num_procedures();
 
@@ -450,7 +450,7 @@ mod tests {
 
     use assembly::Assembler;
     use assert_matches::assert_matches;
-    use vm_core::Word;
+    use miden_core::Word;
 
     use super::{AccountCode, Deserializable, Serializable};
     use crate::AccountError;

--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -448,8 +448,8 @@ pub(crate) fn procedures_as_elements(procedures: &[AccountProcedureInfo]) -> Vec
 #[cfg(test)]
 mod tests {
 
-    use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_assembly::Assembler;
     use miden_core::Word;
 
     use super::{AccountCode, Deserializable, Serializable};
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_account_component_multiple_auth_procedures() {
-        use assembly::Assembler;
+        use miden_assembly::Assembler;
 
         let code_with_multiple_auth = "
             use.miden::account

--- a/crates/miden-objects/src/account/code/procedure.rs
+++ b/crates/miden-objects/src/account/code/procedure.rs
@@ -1,9 +1,9 @@
 use alloc::string::ToString;
 use alloc::sync::Arc;
 
-use vm_core::mast::MastForest;
-use vm_core::prettier::PrettyPrint;
-use vm_processor::{MastNode, MastNodeId};
+use miden_core::mast::MastForest;
+use miden_core::prettier::PrettyPrint;
+use miden_processor::{MastNode, MastNodeId};
 
 use super::Felt;
 use crate::utils::serde::{
@@ -197,8 +197,8 @@ impl PrintableProcedure {
 }
 
 impl PrettyPrint for PrintableProcedure {
-    fn render(&self) -> vm_core::prettier::Document {
-        use vm_core::prettier::*;
+    fn render(&self) -> miden_core::prettier::Document {
+        use miden_core::prettier::*;
 
         indent(
             4,
@@ -214,8 +214,8 @@ impl PrettyPrint for PrintableProcedure {
 #[cfg(test)]
 mod tests {
 
+    use miden_core::Felt;
     use miden_crypto::utils::{Deserializable, Serializable};
-    use vm_core::Felt;
 
     use crate::account::{AccountCode, AccountProcedureInfo};
 

--- a/crates/miden-objects/src/account/component/mod.rs
+++ b/crates/miden-objects/src/account/component/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use assembly::ast::QualifiedProcedureName;
 use assembly::{Assembler, Library, Parse};
-use vm_processor::MastForest;
+use miden_processor::MastForest;
 
 mod template;
 pub use template::*;

--- a/crates/miden-objects/src/account/component/mod.rs
+++ b/crates/miden-objects/src/account/component/mod.rs
@@ -1,8 +1,8 @@
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
-use assembly::ast::QualifiedProcedureName;
-use assembly::{Assembler, Library, Parse};
+use miden_assembly::ast::QualifiedProcedureName;
+use miden_assembly::{Assembler, Library, Parse};
 use miden_processor::MastForest;
 
 mod template;

--- a/crates/miden-objects/src/account/component/template/mod.rs
+++ b/crates/miden-objects/src/account/component/template/mod.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::str::FromStr;
 
-use assembly::Library;
+use miden_assembly::Library;
 use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_processor::DeserializationError;
 use semver::Version;
@@ -109,7 +109,7 @@ impl Deserializable for AccountComponentTemplate {
 /// #     AccountComponent, AccountComponentMetadata, StorageEntry,
 /// #     StorageValueName,
 /// #     AccountComponentTemplate, FeltRepresentation, WordRepresentation, TemplateType},
-/// #     assembly::Assembler, Felt};
+/// #     miden_assembly::Assembler, Felt};
 /// # use miden_objects::account::InitStorageData;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let first_felt = FeltRepresentation::from(Felt::new(0u64));
@@ -330,8 +330,8 @@ mod tests {
     use std::collections::BTreeSet;
     use std::string::ToString;
 
-    use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_assembly::Assembler;
     use miden_core::utils::{Deserializable, Serializable};
     use miden_core::{Felt, FieldElement};
     use semver::Version;

--- a/crates/miden-objects/src/account/component/template/mod.rs
+++ b/crates/miden-objects/src/account/component/template/mod.rs
@@ -4,9 +4,9 @@ use alloc::vec::Vec;
 use core::str::FromStr;
 
 use assembly::Library;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_processor::DeserializationError;
 use semver::Version;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
 
 use super::AccountType;
 use crate::errors::AccountComponentTemplateError;
@@ -60,16 +60,16 @@ impl AccountComponentTemplate {
 }
 
 impl Serializable for AccountComponentTemplate {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write(&self.metadata);
         target.write(&self.library);
     }
 }
 
 impl Deserializable for AccountComponentTemplate {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         // Read and deserialize the configuration from a TOML string.
         let metadata: AccountComponentMetadata = source.read()?;
         let library = Library::read_from(source)?;
@@ -332,9 +332,9 @@ mod tests {
 
     use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_core::utils::{Deserializable, Serializable};
+    use miden_core::{Felt, FieldElement};
     use semver::Version;
-    use vm_core::utils::{Deserializable, Serializable};
-    use vm_core::{Felt, FieldElement};
 
     use super::FeltRepresentation;
     use crate::AccountError;

--- a/crates/miden-objects/src/account/component/template/mod.rs
+++ b/crates/miden-objects/src/account/component/template/mod.rs
@@ -109,7 +109,7 @@ impl Deserializable for AccountComponentTemplate {
 /// #     AccountComponent, AccountComponentMetadata, StorageEntry,
 /// #     StorageValueName,
 /// #     AccountComponentTemplate, FeltRepresentation, WordRepresentation, TemplateType},
-/// #     miden_assembly::Assembler, Felt};
+/// #     assembly::Assembler, Felt};
 /// # use miden_objects::account::InitStorageData;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let first_felt = FeltRepresentation::from(Felt::new(0u64));

--- a/crates/miden-objects/src/account/component/template/storage/mod.rs
+++ b/crates/miden-objects/src/account/component/template/storage/mod.rs
@@ -377,7 +377,7 @@ mod tests {
     use core::error::Error;
     use core::panic;
 
-    use assembly::Assembler;
+    use miden_assembly::Assembler;
     use miden_core::utils::{Deserializable, Serializable};
     use miden_core::{EMPTY_WORD, Felt, Word};
     use semver::Version;

--- a/crates/miden-objects/src/account/component/template/storage/mod.rs
+++ b/crates/miden-objects/src/account/component/template/storage/mod.rs
@@ -3,9 +3,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::Range;
 
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_core::{Felt, FieldElement};
-use vm_processor::DeserializationError;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_core::{Felt, FieldElement};
+use miden_processor::DeserializationError;
 
 mod entry_content;
 pub use entry_content::*;
@@ -378,9 +378,9 @@ mod tests {
     use core::panic;
 
     use assembly::Assembler;
+    use miden_core::utils::{Deserializable, Serializable};
+    use miden_core::{EMPTY_WORD, Felt, Word};
     use semver::Version;
-    use vm_core::utils::{Deserializable, Serializable};
-    use vm_core::{EMPTY_WORD, Felt, Word};
 
     use crate::account::component::FieldIdentifier;
     use crate::account::component::template::storage::placeholder::TemplateType;

--- a/crates/miden-objects/src/account/component/template/storage/placeholder.rs
+++ b/crates/miden-objects/src/account/component/template/storage/placeholder.rs
@@ -4,12 +4,12 @@ use alloc::string::{String, ToString};
 use core::error::Error;
 use core::fmt::{self, Display};
 
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_core::{Felt, Word};
 use miden_crypto::dsa::rpo_falcon512::{self};
 use miden_crypto::word::parse_hex_string_as_word;
+use miden_processor::DeserializationError;
 use thiserror::Error;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_core::{Felt, Word};
-use vm_processor::DeserializationError;
 
 use crate::asset::TokenSymbol;
 use crate::utils::sync::LazyLock;

--- a/crates/miden-objects/src/account/component/template/storage/toml.rs
+++ b/crates/miden-objects/src/account/component/template/storage/toml.rs
@@ -3,12 +3,12 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
 
+use miden_core::Felt;
 use serde::de::value::MapAccessDeserializer;
 use serde::de::{self, Error, MapAccess, SeqAccess, Visitor};
 use serde::ser::{SerializeMap, SerializeStruct};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-use vm_core::Felt;
 
 use super::placeholder::TemplateType;
 use super::{

--- a/crates/miden-objects/src/account/delta/mod.rs
+++ b/crates/miden-objects/src/account/delta/mod.rs
@@ -466,8 +466,8 @@ fn validate_nonce(
 mod tests {
 
     use assert_matches::assert_matches;
-    use vm_core::utils::Serializable;
-    use vm_core::{Felt, FieldElement};
+    use miden_core::utils::Serializable;
+    use miden_core::{Felt, FieldElement};
 
     use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
     use crate::account::delta::AccountUpdateDetails;

--- a/crates/miden-objects/src/account/header.rs
+++ b/crates/miden-objects/src/account/header.rs
@@ -148,7 +148,7 @@ impl From<&Account> for AccountHeader {
 }
 
 impl Serializable for AccountHeader {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         self.id.write_into(target);
         self.nonce.write_into(target);
         self.vault_root.write_into(target);
@@ -158,9 +158,9 @@ impl Serializable for AccountHeader {
 }
 
 impl Deserializable for AccountHeader {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let id = AccountId::read_from(source)?;
         let nonce = Felt::read_from(source)?;
         let vault_root = Word::read_from(source)?;
@@ -182,8 +182,8 @@ impl Deserializable for AccountHeader {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::Felt;
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::Felt;
+    use miden_core::utils::{Deserializable, Serializable};
 
     use super::AccountHeader;
     use crate::Word;

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -128,7 +128,7 @@ impl Account {
     /// Creates an account's [`AccountCode`] and [`AccountStorage`] from the provided components.
     ///
     /// This merges all libraries of the components into a single
-    /// [`MastForest`](vm_processor::MastForest) to produce the [`AccountCode`]. For each
+    /// [`MastForest`](miden_processor::MastForest) to produce the [`AccountCode`]. For each
     /// procedure in the resulting forest, the storage offset and size are set so that the
     /// procedure can only access the storage slots of the component in which it was defined and
     /// each component's storage offset is the total number of slots in the previous components.
@@ -165,7 +165,7 @@ impl Account {
     /// - The first component doesn't contain exactly one authentication procedure.
     /// - Other components contain authentication procedures.
     /// - The number of [`StorageSlot`]s of all components exceeds 255.
-    /// - [`MastForest::merge`](vm_processor::MastForest::merge) fails on all libraries.
+    /// - [`MastForest::merge`](miden_processor::MastForest::merge) fails on all libraries.
     pub(super) fn initialize_from_components(
         account_type: AccountType,
         components: &[AccountComponent],

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -442,8 +442,8 @@ fn validate_components_support_account_type(
 mod tests {
     use alloc::vec::Vec;
 
-    use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_assembly::Assembler;
     use miden_crypto::utils::{Deserializable, Serializable};
     use miden_crypto::{Felt, Word};
 

--- a/crates/miden-objects/src/account/partial.rs
+++ b/crates/miden-objects/src/account/partial.rs
@@ -1,5 +1,5 @@
-use vm_core::Felt;
-use vm_core::utils::{Deserializable, Serializable};
+use miden_core::Felt;
+use miden_core::utils::{Deserializable, Serializable};
 
 use super::{Account, AccountCode, AccountId, PartialStorage};
 use crate::asset::PartialVault;
@@ -88,7 +88,7 @@ impl From<&Account> for PartialAccount {
 }
 
 impl Serializable for PartialAccount {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write(self.id);
         target.write(self.nonce);
         target.write(&self.account_code);
@@ -98,9 +98,9 @@ impl Serializable for PartialAccount {
 }
 
 impl Deserializable for PartialAccount {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let account_id = source.read()?;
         let nonce = source.read()?;
         let account_code = source.read()?;

--- a/crates/miden-objects/src/account/storage/header.rs
+++ b/crates/miden-objects/src/account/storage/header.rs
@@ -166,8 +166,8 @@ impl Deserializable for AccountStorageHeader {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::Felt;
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::Felt;
+    use miden_core::utils::{Deserializable, Serializable};
 
     use super::AccountStorageHeader;
     use crate::Word;

--- a/crates/miden-objects/src/account/storage/map/mod.rs
+++ b/crates/miden-objects/src/account/storage/map/mod.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeMap;
 
+use miden_core::EMPTY_WORD;
 use miden_crypto::merkle::EmptySubtreeRoots;
-use vm_core::EMPTY_WORD;
 
 use super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, Word};
 use crate::Hasher;

--- a/crates/miden-objects/src/account/storage/map/partial.rs
+++ b/crates/miden-objects/src/account/storage/map/partial.rs
@@ -1,3 +1,4 @@
+use miden_core::utils::{Deserializable, Serializable};
 use miden_crypto::Word;
 use miden_crypto::merkle::{
     InnerNodeInfo,
@@ -8,7 +9,6 @@ use miden_crypto::merkle::{
     SmtLeaf,
     SmtProof,
 };
-use vm_core::utils::{Deserializable, Serializable};
 
 use crate::account::StorageMap;
 
@@ -97,15 +97,15 @@ impl From<PartialSmt> for PartialStorageMap {
 }
 
 impl Serializable for PartialStorageMap {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write(&self.partial_smt);
     }
 }
 
 impl Deserializable for PartialStorageMap {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let storage: PartialSmt = source.read()?;
         Ok(PartialStorageMap { partial_smt: storage })
     }

--- a/crates/miden-objects/src/account/storage/partial.rs
+++ b/crates/miden-objects/src/account/storage/partial.rs
@@ -1,8 +1,8 @@
 use alloc::collections::{BTreeMap, BTreeSet};
 
+use miden_core::utils::{Deserializable, Serializable};
 use miden_crypto::Word;
 use miden_crypto::merkle::{InnerNodeInfo, SmtLeaf};
-use vm_core::utils::{Deserializable, Serializable};
 
 use super::{AccountStorage, AccountStorageHeader, StorageSlot};
 use crate::AccountError;
@@ -101,16 +101,16 @@ impl From<&AccountStorage> for PartialStorage {
 }
 
 impl Serializable for PartialStorage {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         target.write(&self.header);
         target.write(&self.maps);
     }
 }
 
 impl Deserializable for PartialStorage {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let header: AccountStorageHeader = source.read()?;
         let map_smts: BTreeMap<Word, PartialStorageMap> = source.read()?;
 
@@ -123,8 +123,8 @@ impl Deserializable for PartialStorage {
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
+    use miden_core::Word;
     use miden_crypto::merkle::PartialSmt;
-    use vm_core::Word;
 
     use crate::account::{
         AccountStorage,

--- a/crates/miden-objects/src/account/storage/slot/mod.rs
+++ b/crates/miden-objects/src/account/storage/slot/mod.rs
@@ -1,6 +1,6 @@
-use vm_core::EMPTY_WORD;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_core::EMPTY_WORD;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_processor::DeserializationError;
 
 use super::map::EMPTY_STORAGE_MAP_ROOT;
 use super::{StorageMap, Word};
@@ -121,7 +121,7 @@ impl Deserializable for StorageSlot {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::utils::{Deserializable, Serializable};
 
     use crate::account::AccountStorage;
 

--- a/crates/miden-objects/src/account/storage/slot/type.rs
+++ b/crates/miden-objects/src/account/storage/slot/type.rs
@@ -79,7 +79,7 @@ impl Deserializable for StorageSlotType {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::utils::{Deserializable, Serializable};
 
     use crate::account::StorageSlotType;
 

--- a/crates/miden-objects/src/block/account_tree.rs
+++ b/crates/miden-objects/src/block/account_tree.rs
@@ -1,9 +1,9 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_crypto::merkle::{MerkleError, MutationSet, Smt, SmtLeaf};
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::{DeserializationError, SMT_DEPTH};
+use miden_processor::{DeserializationError, SMT_DEPTH};
 
 use crate::account::{AccountId, AccountIdPrefix};
 use crate::block::AccountWitness;

--- a/crates/miden-objects/src/block/blockchain.rs
+++ b/crates/miden-objects/src/block/blockchain.rs
@@ -1,8 +1,8 @@
 use alloc::collections::BTreeSet;
 
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 use miden_crypto::merkle::{Forest, Mmr, MmrError, MmrPeaks, MmrProof, PartialMmr};
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_processor::DeserializationError;
 
 use crate::Word;
 use crate::block::BlockNumber;

--- a/crates/miden-objects/src/block/header.rs
+++ b/crates/miden-objects/src/block/header.rs
@@ -376,7 +376,7 @@ impl Deserializable for FeeParameters {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use vm_core::Word;
+    use miden_core::Word;
     use winter_rand_utils::rand_value;
 
     use super::*;

--- a/crates/miden-objects/src/block/nullifier_tree.rs
+++ b/crates/miden-objects/src/block/nullifier_tree.rs
@@ -1,9 +1,9 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
-use vm_core::EMPTY_WORD;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_core::EMPTY_WORD;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_processor::DeserializationError;
 
 use crate::Word;
 use crate::block::{BlockNumber, NullifierWitness};

--- a/crates/miden-objects/src/constants.rs
+++ b/crates/miden-objects/src/constants.rs
@@ -1,4 +1,4 @@
-use vm_processor::ExecutionOptions;
+use miden_processor::ExecutionOptions;
 
 /// Depth of the account database tree.
 pub const ACCOUNT_TREE_DEPTH: u8 = 64;

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -5,12 +5,12 @@ use core::error::Error;
 
 use assembly::Report;
 use assembly::diagnostics::reporting::PrintDiagnostic;
+use miden_core::Felt;
+use miden_core::mast::MastForestError;
 use miden_crypto::merkle::MmrError;
 use miden_crypto::utils::HexParseError;
+use miden_processor::DeserializationError;
 use thiserror::Error;
-use vm_core::Felt;
-use vm_core::mast::MastForestError;
-use vm_processor::DeserializationError;
 
 use super::account::AccountId;
 use super::asset::{FungibleAsset, NonFungibleAsset, TokenSymbol};

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -3,8 +3,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::error::Error;
 
-use assembly::Report;
-use assembly::diagnostics::reporting::PrintDiagnostic;
+use miden_assembly::Report;
+use miden_assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_core::Felt;
 use miden_core::mast::MastForestError;
 use miden_crypto::merkle::MmrError;

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -55,8 +55,8 @@ pub use miden_crypto::word;
 pub use miden_crypto::word::{LexicographicWord, Word, WordError};
 
 pub mod assembly {
-    pub use assembly::ast::{Module, ModuleKind, ProcedureName, QualifiedProcedureName};
-    pub use assembly::{
+    pub use miden_assembly::ast::{Module, ModuleKind, ProcedureName, QualifiedProcedureName};
+    pub use miden_assembly::{
         Assembler,
         DefaultSourceManager,
         KernelLibrary,

--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -47,12 +47,12 @@ pub use errors::{
     TransactionOutputError,
     TransactionScriptError,
 };
+pub use miden_core::mast::{MastForest, MastNodeId};
+pub use miden_core::prettier::PrettyPrint;
+pub use miden_core::{EMPTY_WORD, Felt, FieldElement, ONE, StarkField, WORD_SIZE, ZERO};
 pub use miden_crypto::hash::rpo::Rpo256 as Hasher;
 pub use miden_crypto::word;
 pub use miden_crypto::word::{LexicographicWord, Word, WordError};
-pub use vm_core::mast::{MastForest, MastNodeId};
-pub use vm_core::prettier::PrettyPrint;
-pub use vm_core::{EMPTY_WORD, Felt, FieldElement, ONE, StarkField, WORD_SIZE, ZERO};
 
 pub mod assembly {
     pub use assembly::ast::{Module, ModuleKind, ProcedureName, QualifiedProcedureName};
@@ -80,13 +80,13 @@ pub mod crypto {
 }
 
 pub mod utils {
+    pub use miden_core::utils::*;
     pub use miden_crypto::utils::{HexParseError, bytes_to_hex_string, collections, hex_to_bytes};
     pub use miden_crypto::word::parse_hex_string_as_word;
     pub use miden_utils_sync as sync;
-    pub use vm_core::utils::*;
 
     pub mod serde {
-        pub use vm_core::utils::{
+        pub use miden_core::utils::{
             ByteReader,
             ByteWriter,
             Deserializable,
@@ -97,8 +97,8 @@ pub mod utils {
 }
 
 pub mod vm {
+    pub use miden_core::sys_events::SystemEvent;
+    pub use miden_core::{AdviceMap, Program, ProgramInfo};
+    pub use miden_processor::{AdviceInputs, FutureMaybeSend, RowIndex, StackInputs, StackOutputs};
     pub use miden_verifier::ExecutionProof;
-    pub use vm_core::sys_events::SystemEvent;
-    pub use vm_core::{AdviceMap, Program, ProgramInfo};
-    pub use vm_processor::{AdviceInputs, FutureMaybeSend, RowIndex, StackInputs, StackOutputs};
 }

--- a/crates/miden-objects/src/note/details.rs
+++ b/crates/miden-objects/src/note/details.rs
@@ -1,4 +1,4 @@
-use vm_processor::DeserializationError;
+use miden_processor::DeserializationError;
 
 use super::{NoteAssets, NoteId, NoteInputs, NoteRecipient, NoteScript, Nullifier};
 use crate::Word;

--- a/crates/miden-objects/src/note/file.rs
+++ b/crates/miden-objects/src/note/file.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 #[cfg(feature = "std")]
-use vm_core::utils::SliceReader;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_core::utils::SliceReader;
+use miden_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use miden_processor::DeserializationError;
 
 use super::{Note, NoteDetails, NoteId, NoteInclusionProof, NoteTag};
 use crate::block::BlockNumber;
@@ -136,8 +136,8 @@ impl Deserializable for NoteFile {
 mod tests {
     use alloc::vec::Vec;
 
-    use vm_core::Felt;
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::Felt;
+    use miden_core::utils::{Deserializable, Serializable};
 
     use crate::Word;
     use crate::account::AccountId;

--- a/crates/miden-objects/src/note/mod.rs
+++ b/crates/miden-objects/src/note/mod.rs
@@ -1,6 +1,6 @@
 use miden_crypto::Word;
 use miden_crypto::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
-use vm_processor::DeserializationError;
+use miden_processor::DeserializationError;
 
 use crate::account::AccountId;
 use crate::{Felt, Hasher, NoteError, WORD_SIZE, ZERO};

--- a/crates/miden-objects/src/note/nullifier.rs
+++ b/crates/miden-objects/src/note/nullifier.rs
@@ -90,7 +90,7 @@ impl Nullifier {
 
     #[cfg(any(feature = "testing", test))]
     pub fn dummy(n: u64) -> Self {
-        use vm_core::FieldElement;
+        use miden_core::FieldElement;
 
         Self(Word::new([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::new(n)]))
     }

--- a/crates/miden-objects/src/note/script.rs
+++ b/crates/miden-objects/src/note/script.rs
@@ -179,8 +179,8 @@ impl Deserializable for NoteScript {
 // ================================================================================================
 
 impl PrettyPrint for NoteScript {
-    fn render(&self) -> vm_core::prettier::Document {
-        use vm_core::prettier::*;
+    fn render(&self) -> miden_core::prettier::Document {
+        use miden_core::prettier::*;
         let entrypoint = self.mast[self.entrypoint].to_pretty_print(&self.mast);
 
         indent(4, const_text("begin") + nl() + entrypoint.render()) + nl() + const_text("end")

--- a/crates/miden-objects/src/testing/account_code.rs
+++ b/crates/miden-objects/src/testing/account_code.rs
@@ -1,7 +1,7 @@
 // ACCOUNT CODE
 // ================================================================================================
 
-use assembly::Assembler;
+use miden_assembly::Assembler;
 
 use crate::account::{AccountCode, AccountComponent, AccountType};
 use crate::testing::noop_auth_component::NoopAuthComponent;

--- a/crates/miden-objects/src/testing/note.rs
+++ b/crates/miden-objects/src/testing/note.rs
@@ -1,8 +1,8 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use assembly::Assembler;
-use assembly::debuginfo::{SourceLanguage, Uri};
+use miden_assembly::Assembler;
+use miden_assembly::debuginfo::{SourceLanguage, Uri};
 use rand::Rng;
 
 use crate::account::AccountId;

--- a/crates/miden-objects/src/testing/storage.rs
+++ b/crates/miden-objects/src/testing/storage.rs
@@ -2,8 +2,8 @@ use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+use miden_core::{Felt, Word};
 use miden_crypto::EMPTY_WORD;
-use vm_core::{Felt, Word};
 
 use crate::AccountDeltaError;
 use crate::account::{

--- a/crates/miden-objects/src/transaction/inputs/account.rs
+++ b/crates/miden-objects/src/transaction/inputs/account.rs
@@ -96,10 +96,10 @@ impl Deserializable for AccountInputs {
 mod tests {
     use alloc::vec::Vec;
 
+    use miden_core::Felt;
+    use miden_core::utils::{Deserializable, Serializable};
     use miden_crypto::merkle::MerklePath;
-    use vm_core::Felt;
-    use vm_core::utils::{Deserializable, Serializable};
-    use vm_processor::SMT_DEPTH;
+    use miden_processor::SMT_DEPTH;
 
     use crate::account::{Account, AccountCode, AccountId, AccountStorage};
     use crate::asset::AssetVault;

--- a/crates/miden-objects/src/transaction/inputs/notes.rs
+++ b/crates/miden-objects/src/transaction/inputs/notes.rs
@@ -357,8 +357,8 @@ impl Deserializable for InputNote {
 #[cfg(test)]
 mod input_notes_tests {
     use anyhow::Context;
-    use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_assembly::Assembler;
 
     use super::InputNotes;
     use crate::TransactionInputError;

--- a/crates/miden-objects/src/transaction/outputs.rs
+++ b/crates/miden-objects/src/transaction/outputs.rs
@@ -334,8 +334,8 @@ fn build_output_notes_commitment(notes: &[OutputNote]) -> Word {
 #[cfg(test)]
 mod output_notes_tests {
     use anyhow::Context;
-    use assembly::Assembler;
     use assert_matches::assert_matches;
+    use miden_assembly::Assembler;
 
     use super::OutputNotes;
     use crate::TransactionOutputError;

--- a/crates/miden-objects/src/transaction/partial_blockchain.rs
+++ b/crates/miden-objects/src/transaction/partial_blockchain.rs
@@ -276,7 +276,7 @@ impl Default for PartialBlockchain {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::utils::{Deserializable, Serializable};
 
     use super::PartialBlockchain;
     use crate::alloc::vec::Vec;

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -644,8 +644,8 @@ mod tests {
     use alloc::collections::BTreeMap;
 
     use anyhow::Context;
+    use miden_core::utils::Deserializable;
     use miden_verifier::ExecutionProof;
-    use vm_core::utils::Deserializable;
     use winter_air::proof::Proof;
     use winter_rand_utils::rand_value;
 

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -322,8 +322,8 @@ impl Deserializable for TransactionScript {
 
 #[cfg(test)]
 mod tests {
-    use vm_core::AdviceMap;
-    use vm_core::utils::{Deserializable, Serializable};
+    use miden_core::AdviceMap;
+    use miden_core::utils::{Deserializable, Serializable};
 
     use crate::transaction::TransactionArgs;
 

--- a/crates/miden-objects/src/transaction/tx_header.rs
+++ b/crates/miden-objects/src/transaction/tx_header.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use vm_processor::DeserializationError;
+use miden_processor::DeserializationError;
 
 use crate::Word;
 use crate::note::NoteId;

--- a/crates/miden-objects/src/transaction/tx_summary.rs
+++ b/crates/miden-objects/src/transaction/tx_summary.rs
@@ -82,7 +82,7 @@ impl SequentialCommit for TransactionSummary {
 }
 
 impl Serializable for TransactionSummary {
-    fn write_into<W: vm_core::utils::ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
         self.account_delta.write_into(target);
         self.input_notes.write_into(target);
         self.output_notes.write_into(target);
@@ -91,9 +91,9 @@ impl Serializable for TransactionSummary {
 }
 
 impl Deserializable for TransactionSummary {
-    fn read_from<R: vm_core::utils::ByteReader>(
+    fn read_from<R: miden_core::utils::ByteReader>(
         source: &mut R,
-    ) -> Result<Self, vm_processor::DeserializationError> {
+    ) -> Result<Self, miden_processor::DeserializationError> {
         let account_delta = source.read()?;
         let input_notes = source.read()?;
         let output_notes = source.read()?;

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -23,7 +23,7 @@ miden-objects      = { features = ["testing"], workspace = true }
 miden-tx           = { features = ["testing"], workspace = true }
 
 # Miden dependencies
-vm-processor = { workspace = true }
+miden-processor = { workspace = true }
 
 # External dependencies
 anyhow      = { default-features = false, version = "1.0" }

--- a/crates/miden-testing/src/executor.rs
+++ b/crates/miden-testing/src/executor.rs
@@ -3,7 +3,7 @@ use alloc::borrow::ToOwned;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::assembly::SourceManager;
 use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
-use vm_processor::{
+use miden_processor::{
     AdviceInputs,
     DefaultHost,
     ExecutionError,

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -10,7 +10,7 @@ use miden_objects::note::NoteInclusionProof;
 use miden_objects::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
 use miden_objects::transaction::{OutputNote, ProvenTransaction};
 use miden_objects::{MAX_BATCHES_PER_BLOCK, ProposedBlockError};
-use vm_processor::crypto::MerklePath;
+use miden_processor::crypto::MerklePath;
 
 use super::utils::{
     TestSetup,

--- a/crates/miden-testing/src/kernel_tests/tx/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/mod.rs
@@ -22,7 +22,7 @@ use miden_objects::testing::account_id::{
 use miden_objects::testing::storage::prepare_assets;
 use miden_objects::vm::StackInputs;
 use miden_objects::{Felt, Hasher, ONE, Word, ZERO};
-use vm_processor::{ContextId, Process};
+use miden_processor::{ContextId, Process};
 
 use crate::MockChain;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -40,10 +40,10 @@ use miden_objects::testing::account_id::{
 };
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
 use miden_objects::transaction::{ExecutedTransaction, TransactionScript};
+use miden_processor::{EMPTY_WORD, ExecutionError, Word};
 use miden_tx::TransactionExecutorError;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{EMPTY_WORD, ExecutionError, Word};
 
 use super::{Felt, StackInputs, ZERO};
 use crate::executor::CodeExecutor;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -14,6 +14,8 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_SENDER,
 };
 use miden_objects::testing::note::NoteBuilder;
+use miden_processor::ExecutionError;
+use miden_processor::crypto::RpoRandomCoin;
 use miden_tx::auth::UnreachableAuth;
 use miden_tx::{
     FailedNote,
@@ -24,8 +26,6 @@ use miden_tx::{
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::ExecutionError;
-use vm_processor::crypto::RpoRandomCoin;
 
 use crate::utils::create_p2any_note;
 use crate::{Auth, MockChain, TransactionContextBuilder, TxContextInput};

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -34,8 +34,8 @@ use miden_objects::testing::constants::{
 };
 use miden_objects::testing::note::NoteBuilder;
 use miden_objects::transaction::{OutputNote, OutputNotes};
+use miden_processor::{Felt, ONE};
 use rand::rng;
-use vm_processor::{Felt, ONE};
 
 use super::{ZERO, create_mock_notes_procedure};
 use crate::kernel_tests::tx::ProcessMemoryExt;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -5,8 +5,8 @@ use miden_objects::account::AccountId;
 use miden_objects::asset::FungibleAsset;
 use miden_objects::testing::account_id::ACCOUNT_ID_NATIVE_ASSET_FAUCET;
 use miden_objects::{self, Felt, Word};
+use miden_processor::ExecutionError;
 use miden_tx::TransactionExecutorError;
-use vm_processor::ExecutionError;
 
 use crate::{Auth, MockChain};
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -34,9 +34,9 @@ use miden_objects::account::{
 };
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
 use miden_objects::transaction::AccountInputs;
+use miden_processor::{AdviceInputs, Felt};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{AdviceInputs, Felt};
 
 use super::{Process, Word, ZERO};
 use crate::kernel_tests::tx::ProcessMemoryExt;

--- a/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
@@ -5,9 +5,9 @@ use std::string::String;
 
 use anyhow::Context;
 use miden_objects::{EMPTY_WORD, LexicographicWord, Word};
+use miden_processor::{ONE, ProcessState, ZERO};
 use miden_tx::LinkMap;
 use rand::seq::IteratorRandom;
-use vm_processor::{ONE, ProcessState, ZERO};
 use winter_rand_utils::rand_value;
 
 use crate::TransactionContextBuilder;

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -89,10 +89,10 @@ use miden_objects::transaction::{
     TransactionScript,
 };
 use miden_objects::{EMPTY_WORD, WORD_SIZE};
+use miden_processor::{AdviceInputs, Process, Word};
 use miden_tx::TransactionExecutorError;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{AdviceInputs, Process, Word};
 
 use super::{Felt, ZERO};
 use crate::kernel_tests::tx::ProcessMemoryExt;

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -76,6 +76,9 @@ use miden_objects::transaction::{
     TransactionSummary,
 };
 use miden_objects::{FieldElement, Hasher, Word};
+use miden_processor::crypto::RpoRandomCoin;
+use miden_processor::fast::FastProcessor;
+use miden_processor::{AdviceInputs, StackInputs};
 use miden_tx::auth::UnreachableAuth;
 use miden_tx::{
     AccountProcedureIndexMap,
@@ -85,9 +88,6 @@ use miden_tx::{
     TransactionExecutorHost,
     TransactionMastStore,
 };
-use vm_processor::crypto::RpoRandomCoin;
-use vm_processor::fast::FastProcessor;
-use vm_processor::{AdviceInputs, StackInputs};
 
 use super::{Felt, ONE, ZERO};
 use crate::kernel_tests::tx::ProcessMemoryExt;

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -37,12 +37,12 @@ use miden_objects::transaction::{
     TransactionInputs,
 };
 use miden_objects::{MAX_BATCHES_PER_BLOCK, MAX_OUTPUT_NOTES_PER_BATCH, NoteError};
+use miden_processor::crypto::RpoRandomCoin;
+use miden_processor::{DeserializationError, Word};
 use miden_tx::auth::BasicAuthenticator;
 use miden_tx::utils::{ByteReader, Deserializable, Serializable};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use vm_processor::crypto::RpoRandomCoin;
-use vm_processor::{DeserializationError, Word};
 use winterfell::ByteWriter;
 
 use super::note::MockChainNote;

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -34,8 +34,8 @@ use miden_objects::note::{Note, NoteDetails, NoteType};
 use miden_objects::testing::account_id::ACCOUNT_ID_NATIVE_ASSET_FAUCET;
 use miden_objects::transaction::{OrderedTransactionHeaders, OutputNote};
 use miden_objects::{Felt, FieldElement, MAX_OUTPUT_NOTES_PER_BATCH, NoteError, Word, ZERO};
+use miden_processor::crypto::RpoRandomCoin;
 use rand::Rng;
-use vm_processor::crypto::RpoRandomCoin;
 
 use crate::mock_chain::chain::AccountCredentials;
 use crate::utils::{create_p2any_note, create_spawn_note};

--- a/crates/miden-testing/src/mock_chain/note.rs
+++ b/crates/miden-testing/src/mock_chain/note.rs
@@ -1,7 +1,7 @@
 use miden_objects::note::{Note, NoteId, NoteInclusionProof, NoteMetadata};
 use miden_objects::transaction::InputNote;
+use miden_processor::DeserializationError;
 use miden_tx::utils::{ByteReader, Deserializable, Serializable};
-use vm_processor::DeserializationError;
 use winterfell::ByteWriter;
 
 // MOCK CHAIN NOTE

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -8,8 +8,7 @@ use miden_lib::transaction::{TransactionEvent, TransactionEventError};
 use miden_objects::account::{AccountHeader, AccountVaultDelta};
 use miden_objects::assembly::SourceManager;
 use miden_objects::{Felt, Word};
-use miden_tx::{AccountProcedureIndexMap, LinkMap, TransactionMastStore};
-use vm_processor::{
+use miden_processor::{
     AdviceInputs,
     AdviceMutation,
     BaseHost,
@@ -20,6 +19,7 @@ use vm_processor::{
     ProcessState,
     SyncHost,
 };
+use miden_tx::{AccountProcedureIndexMap, LinkMap, TransactionMastStore};
 
 // MOCK HOST
 // ================================================================================================
@@ -35,7 +35,7 @@ pub struct MockHost {
 
 impl MockHost {
     /// Returns a new [MockHost] instance with the provided
-    /// [AdviceInputs](vm_processor::AdviceInputs).
+    /// [AdviceInputs](miden_processor::AdviceInputs).
     pub fn new(
         account: AccountHeader,
         advice_inputs: &AdviceInputs,

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -22,10 +22,10 @@ use miden_objects::transaction::{
     TransactionScript,
 };
 use miden_objects::vm::AdviceMap;
+use miden_processor::{AdviceInputs, Felt, Word};
 use miden_tx::TransactionMastStore;
 use miden_tx::auth::BasicAuthenticator;
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{AdviceInputs, Felt, Word};
 
 use super::TransactionContext;
 use crate::{MockChain, MockChainNote};

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -18,6 +18,15 @@ use miden_objects::transaction::{
     TransactionArgs,
     TransactionInputs,
 };
+use miden_processor::{
+    AdviceInputs,
+    ExecutionError,
+    FutureMaybeSend,
+    MastForest,
+    MastForestStore,
+    Process,
+    Word,
+};
 use miden_tx::auth::BasicAuthenticator;
 use miden_tx::{
     DataStore,
@@ -27,15 +36,6 @@ use miden_tx::{
     TransactionMastStore,
 };
 use rand_chacha::ChaCha20Rng;
-use vm_processor::{
-    AdviceInputs,
-    ExecutionError,
-    FutureMaybeSend,
-    MastForest,
-    MastForestStore,
-    Process,
-    Word,
-};
 
 use crate::MockHost;
 use crate::executor::CodeExecutor;

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -7,9 +7,9 @@ use miden_objects::asset::Asset;
 use miden_objects::note::Note;
 use miden_objects::testing::note::NoteBuilder;
 use miden_objects::testing::storage::prepare_assets;
+use miden_processor::Felt;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-use vm_processor::Felt;
 
 // HELPER MACROS
 // ================================================================================================
@@ -18,7 +18,7 @@ use vm_processor::Felt;
 macro_rules! assert_execution_error {
     ($execution_result:expr, $expected_err:expr) => {
         match $execution_result {
-            Err(vm_processor::ExecutionError::FailedAssertion { label: _, source_file: _, clk: _, err_code, err_msg }) => {
+            Err(miden_processor::ExecutionError::FailedAssertion { label: _, source_file: _, clk: _, err_code, err_msg }) => {
                 if let Some(ref msg) = err_msg {
                   assert_eq!(msg.as_ref(), $expected_err.message(), "error messages did not match");
                 }
@@ -40,7 +40,7 @@ macro_rules! assert_transaction_executor_error {
     ($execution_result:expr, $expected_err:expr) => {
         match $execution_result {
             Err(miden_tx::TransactionExecutorError::TransactionProgramExecutionFailed(
-                vm_processor::ExecutionError::FailedAssertion {
+                miden_processor::ExecutionError::FailedAssertion {
                     label: _,
                     source_file: _,
                     clk: _,

--- a/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
@@ -16,9 +16,9 @@ use miden_objects::testing::account_id::ACCOUNT_ID_SENDER;
 use miden_objects::testing::note::NoteBuilder;
 use miden_objects::transaction::OutputNote;
 use miden_objects::{Felt, FieldElement, Word};
+use miden_processor::ExecutionError;
 use miden_testing::{Auth, MockChain};
 use miden_tx::TransactionExecutorError;
-use vm_processor::ExecutionError;
 
 // CONSTANTS
 // ================================================================================================

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -12,13 +12,13 @@ use miden_objects::note::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipi
 use miden_objects::testing::account_id::ACCOUNT_ID_SENDER;
 use miden_objects::transaction::{ExecutedTransaction, ProvenTransaction};
 use miden_objects::{Word, ZERO};
+use miden_processor::utils::Deserializable;
 use miden_tx::{
     LocalTransactionProver,
     ProvingOptions,
     TransactionVerifier,
     TransactionVerifierError,
 };
-use vm_processor::utils::Deserializable;
 
 // HELPER FUNCTIONS
 // ================================================================================================

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -35,6 +35,6 @@ tokio     = { features = ["rt"], workspace = true }
 
 [dev-dependencies]
 anyhow         = { default-features = false, features = ["backtrace", "std"], version = "1.0" }
-assembly       = { workspace = true }
 assert_matches = { workspace = true }
+miden-assembly = { workspace = true }
 miden-tx       = { features = ["testing"], path = "." }

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -15,8 +15,8 @@ version                = "0.11.0"
 [features]
 concurrent = ["miden-prover/concurrent", "std"]
 default    = ["std"]
-std        = ["miden-lib/std", "miden-objects/std", "miden-prover/std", "miden-verifier/std", "vm-processor/std"]
-testing    = ["miden-lib/testing", "miden-objects/testing", "vm-processor/testing"]
+std        = ["miden-lib/std", "miden-objects/std", "miden-processor/std", "miden-prover/std", "miden-verifier/std"]
+testing    = ["miden-lib/testing", "miden-objects/testing", "miden-processor/testing"]
 
 [dependencies]
 # Workspace dependencies
@@ -24,9 +24,9 @@ miden-lib     = { workspace = true }
 miden-objects = { workspace = true }
 
 # Miden dependencies
-miden-prover   = { workspace = true }
-miden-verifier = { workspace = true }
-vm-processor   = { workspace = true }
+miden-processor = { workspace = true }
+miden-prover    = { workspace = true }
+miden-verifier  = { workspace = true }
 
 # External dependencies
 rand      = { workspace = true }

--- a/crates/miden-tx/src/auth/signatures/mod.rs
+++ b/crates/miden-tx/src/auth/signatures/mod.rs
@@ -2,8 +2,8 @@ use alloc::vec::Vec;
 
 use miden_objects::Hasher;
 use miden_objects::crypto::dsa::rpo_falcon512::{self, Polynomial};
+use miden_processor::{Felt, Word};
 use rand::Rng;
-use vm_processor::{Felt, Word};
 
 use crate::AuthenticationError;
 

--- a/crates/miden-tx/src/auth/tx_authenticator.rs
+++ b/crates/miden-tx/src/auth/tx_authenticator.rs
@@ -8,9 +8,9 @@ use miden_objects::account::AuthSecretKey;
 use miden_objects::crypto::SequentialCommit;
 use miden_objects::transaction::TransactionSummary;
 use miden_objects::{Felt, Hasher, Word};
+use miden_processor::FutureMaybeSend;
 use rand::Rng;
 use tokio::sync::RwLock;
-use vm_processor::FutureMaybeSend;
 
 use super::signatures::get_falcon_signature;
 use crate::errors::AuthenticationError;

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -17,9 +17,9 @@ use miden_objects::{
     TransactionOutputError,
     Word,
 };
+use miden_processor::ExecutionError;
 use miden_verifier::VerificationError;
 use thiserror::Error;
-use vm_processor::ExecutionError;
 
 // TRANSACTION EXECUTOR ERROR
 // ================================================================================================

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -3,7 +3,7 @@ use alloc::collections::BTreeSet;
 use miden_objects::account::{Account, AccountId};
 use miden_objects::block::{BlockHeader, BlockNumber};
 use miden_objects::transaction::PartialBlockchain;
-use vm_processor::{FutureMaybeSend, MastForestStore, Word};
+use miden_processor::{FutureMaybeSend, MastForestStore, Word};
 
 use crate::DataStoreError;
 

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -12,7 +12,7 @@ use miden_objects::asset::FungibleAsset;
 use miden_objects::block::FeeParameters;
 use miden_objects::transaction::{InputNote, InputNotes, OutputNote};
 use miden_objects::{Felt, Hasher, Word};
-use vm_processor::{
+use miden_processor::{
     AdviceMutation,
     AsyncHost,
     BaseHost,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -19,9 +19,9 @@ use miden_objects::transaction::{
 };
 use miden_objects::vm::StackOutputs;
 use miden_objects::{Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
-use vm_processor::fast::FastProcessor;
-use vm_processor::{AdviceInputs, ExecutionError, StackInputs};
-pub use vm_processor::{ExecutionOptions, MastForestStore};
+use miden_processor::fast::FastProcessor;
+use miden_processor::{AdviceInputs, ExecutionError, StackInputs};
+pub use miden_processor::{ExecutionOptions, MastForestStore};
 
 use super::TransactionExecutorError;
 use crate::auth::TransactionAuthenticator;

--- a/crates/miden-tx/src/host/account_procedures.rs
+++ b/crates/miden-tx/src/host/account_procedures.rs
@@ -4,7 +4,7 @@ use miden_lib::transaction::memory::{ACCOUNT_STACK_TOP_PTR, ACCT_CODE_COMMITMENT
 use miden_lib::transaction::{TransactionAdviceInputs, TransactionKernelError};
 use miden_objects::account::{AccountCode, AccountProcedureInfo};
 use miden_objects::transaction::{TransactionArgs, TransactionInputs};
-use vm_processor::AdviceInputs;
+use miden_processor::AdviceInputs;
 
 use super::{BTreeMap, Felt, ProcessState, Word};
 use crate::errors::TransactionHostError;

--- a/crates/miden-tx/src/host/link_map.rs
+++ b/crates/miden-tx/src/host/link_map.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use miden_objects::{Felt, LexicographicWord, Word, ZERO};
-use vm_processor::{AdviceMutation, ContextId, EventError, ProcessState};
+use miden_processor::{AdviceMutation, ContextId, EventError, ProcessState};
 
 // LINK MAP
 // ================================================================================================

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -37,8 +37,7 @@ use miden_objects::transaction::{
 };
 use miden_objects::vm::RowIndex;
 use miden_objects::{Hasher, Word};
-pub use tx_progress::TransactionProgress;
-use vm_processor::{
+use miden_processor::{
     AdviceMutation,
     ContextId,
     EventError,
@@ -48,6 +47,7 @@ use vm_processor::{
     MastForestStore,
     ProcessState,
 };
+pub use tx_progress::TransactionProgress;
 
 use crate::auth::SigningInputs;
 

--- a/crates/miden-tx/src/host/note_builder.rs
+++ b/crates/miden-tx/src/host/note_builder.rs
@@ -11,7 +11,7 @@ use miden_objects::note::{
     NoteScript,
     PartialNote,
 };
-use vm_processor::AdviceProvider;
+use miden_processor::AdviceProvider;
 
 use super::{Felt, OutputNote, TransactionKernelError, Word};
 

--- a/crates/miden-tx/src/host/script_mast_forest_store.rs
+++ b/crates/miden-tx/src/host/script_mast_forest_store.rs
@@ -6,7 +6,7 @@ use miden_objects::assembly::mast::MastForest;
 use miden_objects::note::NoteScript;
 use miden_objects::transaction::TransactionScript;
 use miden_objects::vm::AdviceMap;
-use vm_processor::MastForestStore;
+use miden_processor::MastForestStore;
 
 /// Stores the MAST forests for a set of scripts (both note scripts and transaction scripts).
 ///

--- a/crates/miden-tx/src/prover/mast_store.rs
+++ b/crates/miden-tx/src/prover/mast_store.rs
@@ -7,7 +7,7 @@ use miden_objects::Word;
 use miden_objects::account::AccountCode;
 use miden_objects::assembly::mast::MastForest;
 use miden_objects::utils::sync::RwLock;
-use vm_processor::MastForestStore;
+use miden_processor::MastForestStore;
 
 // TRANSACTION MAST STORE
 // ================================================================================================

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -8,7 +8,7 @@ use miden_objects::account::{AccountDelta, PartialAccount};
 use miden_objects::assembly::debuginfo::Location;
 use miden_objects::assembly::{SourceFile, SourceSpan};
 use miden_objects::transaction::{InputNote, InputNotes, OutputNote};
-use vm_processor::{
+use miden_processor::{
     AdviceMutation,
     BaseHost,
     EventError,


### PR DESCRIPTION
Use original crate names for miden-vm crates rather than renames, e.g. `miden-assembly` instead of `assembly`, as discussed a while back.