### PR TITLE
ci: add scheduled workflow to run benchmarks weekly

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,36 @@
+name: Benchmarks
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"   # Every Sunday at 00:00 UTC
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "benchmarks @ ${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  run-benchmarks:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Update Rust toolchain
+        run: rustup update --no-self-update
+      - name: Run benchmarks
+        run: cargo bench --all
+      # Optional: upload Criterion output as an artifact for later inspection
+      - name: Upload benchmark reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-reports
+          path: |
+            target/criterion/**/*
+            !target/criterion/**/debug


### PR DESCRIPTION
## Summary
This PR adds a scheduled GitHub Actions workflow to run the project's benchmarks
periodically.

## Details
- New workflow file `.github/workflows/benchmarks.yml`
- Runs `cargo bench --all` every Sunday at 00:00 UTC
- Allows manual triggering via `workflow_dispatch`
- Uploads Criterion outputs as artifacts for later inspection

## Notes
- This PR focuses only on periodically running benchmarks and storing their results.
- "Abnormal results flagging" (e.g., detecting performance regressions) is not
  included here and can be added in a follow-up PR.

Closes #1671
