### PR TITLE
feat: add `TransactionExecutorError::InsufficientFee`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - [BREAKING] Update `account::get_storage_commitment` procedure to `account::compute_storage_commitment`([#1763](https://github.com/0xMiden/miden-base/pull/1763)).
 - Implement caching for the account storage commitment (([#1763](https://github.com/0xMiden/miden-base/pull/1763))).
 - [BREAKING] Merge the current and initial account code commitment procedures into one ([#1776](https://github.com/0xMiden/miden-base/pull/1776)).
+- Add `TransactionExecutorError::InsufficientFunds` variant([#1786](https://github.com/0xMiden/miden-base/pull/1786)).
 
 ## 0.10.1 (2025-08-02)
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use assert_matches::assert_matches;
-use miden_lib::errors::TransactionKernelError;
 use miden_objects::account::AccountId;
 use miden_objects::asset::FungibleAsset;
 use miden_objects::testing::account_id::ACCOUNT_ID_NATIVE_ASSET_FAUCET;
@@ -74,8 +73,8 @@ fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> 
         execution_error
     ) => {
         assert_matches!(execution_error, ExecutionError::EventError { error, .. } => {
-            let kernel_error = error.downcast_ref::<TransactionKernelError>().unwrap();
-            assert_matches!(kernel_error, TransactionKernelError::InsufficientFee {
+            let kernel_error = error.downcast_ref::<TransactionExecutorError>().unwrap();
+            assert_matches!(kernel_error, TransactionExecutorError::InsufficientFee {
                 account_balance,
                 tx_fee: _
             } => {

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -4,7 +4,6 @@ use miden_objects::account::AccountId;
 use miden_objects::asset::FungibleAsset;
 use miden_objects::testing::account_id::ACCOUNT_ID_NATIVE_ASSET_FAUCET;
 use miden_objects::{self, Felt, Word};
-use miden_processor::ExecutionError;
 use miden_tx::TransactionExecutorError;
 
 use crate::{Auth, MockChain};
@@ -69,21 +68,10 @@ fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> 
         .execute_blocking()
         .unwrap_err();
 
-    assert_matches!(err, TransactionExecutorError::TransactionProgramExecutionFailed(
-        execution_error
-    ) => {
-        assert_matches!(execution_error, ExecutionError::EventError { error, .. } => {
-            let kernel_error = error.downcast_ref::<TransactionExecutorError>().unwrap();
-            assert_matches!(kernel_error, TransactionExecutorError::InsufficientFee {
-                account_balance,
-                tx_fee: _
-            } => {
-                // Make sure the host computes the correct account balance based on the initial
-                // value in the account and the amount added throughout transaction execution.
-                assert_eq!(*account_balance, account_amount + note_amount);
-            });
-        })
-    });
+    assert_matches!(
+        err,
+        TransactionExecutorError::InsufficientFee { account_balance: _, tx_fee: _ }
+    );
 
     Ok(())
 }

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -58,6 +58,10 @@ pub enum TransactionExecutorError {
     },
     #[error("expected account nonce delta to be {expected}, found {actual}")]
     InconsistentAccountNonceDelta { expected: Felt, actual: Felt },
+    #[error(
+        "native asset amount {account_balance} in the account vault is not sufficient to cover the transaction fee of {tx_fee}"
+    )]
+    InsufficientFee { account_balance: u64, tx_fee: u64 },
     #[error("account witness provided for account ID {0} is invalid")]
     InvalidAccountWitness(AccountId, #[source] SmtProofError),
     #[error(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -23,7 +23,6 @@ use miden_processor::{
     ProcessState,
 };
 
-use crate::AccountProcedureIndexMap;
 use crate::auth::{SigningInputs, TransactionAuthenticator};
 use crate::host::{
     ScriptMastForestStore,
@@ -32,6 +31,7 @@ use crate::host::{
     TransactionEventHandling,
     TransactionProgress,
 };
+use crate::{AccountProcedureIndexMap, TransactionExecutorError};
 
 /// The transaction executor host is responsible for handling [`FutureMaybeSend`] requests made by
 /// the transaction kernel during execution. In particular, it responds to signature generation
@@ -159,7 +159,7 @@ where
     fn on_tx_fee_computed(
         &self,
         fee_asset: FungibleAsset,
-    ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
+    ) -> Result<Vec<AdviceMutation>, TransactionExecutorError> {
         // Compute the current balance of the native asset in the account based on the initial value
         // and the delta.
         let current_native_asset = {
@@ -194,7 +194,7 @@ where
 
         // Return an error if the balance in the account does not cover the fee.
         if current_native_asset.amount() < fee_asset.amount() {
-            return Err(TransactionKernelError::InsufficientFee {
+            return Err(TransactionExecutorError::InsufficientFee {
                 account_balance: current_native_asset.amount(),
                 tx_fee: fee_asset.amount(),
             });

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -23,6 +23,7 @@ use miden_processor::{
     ProcessState,
 };
 
+use crate::AccountProcedureIndexMap;
 use crate::auth::{SigningInputs, TransactionAuthenticator};
 use crate::host::{
     ScriptMastForestStore,
@@ -31,7 +32,6 @@ use crate::host::{
     TransactionEventHandling,
     TransactionProgress,
 };
-use crate::{AccountProcedureIndexMap, TransactionExecutorError};
 
 /// The transaction executor host is responsible for handling [`FutureMaybeSend`] requests made by
 /// the transaction kernel during execution. In particular, it responds to signature generation
@@ -159,7 +159,7 @@ where
     fn on_tx_fee_computed(
         &self,
         fee_asset: FungibleAsset,
-    ) -> Result<Vec<AdviceMutation>, TransactionExecutorError> {
+    ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
         // Compute the current balance of the native asset in the account based on the initial value
         // and the delta.
         let current_native_asset = {
@@ -194,7 +194,7 @@ where
 
         // Return an error if the balance in the account does not cover the fee.
         if current_native_asset.amount() < fee_asset.amount() {
-            return Err(TransactionExecutorError::InsufficientFee {
+            return Err(TransactionKernelError::InsufficientFee {
                 account_balance: current_native_asset.amount(),
                 tx_fee: fee_asset.amount(),
             });

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -587,6 +587,12 @@ fn map_execution_error(exec_err: ExecutionError) -> TransactionExecutorError {
                 Some(TransactionKernelError::Unauthorized(summary)) => {
                     TransactionExecutorError::Unauthorized(summary.clone())
                 },
+                Some(TransactionKernelError::InsufficientFee { account_balance, tx_fee }) => {
+                    TransactionExecutorError::InsufficientFee {
+                        account_balance: *account_balance,
+                        tx_fee: *tx_fee,
+                    }
+                },
                 _ => TransactionExecutorError::TransactionProgramExecutionFailed(exec_err),
             }
         },


### PR DESCRIPTION
Fixes #1772 

- Adds new variant `TransactionExecutionError::InsufficientFunds`
- Returns this error in `on_tx_fee_computed`
- update test to check correct error


Note: Should we remove the `TransactionKernelError::InsufficientFunds` variant?