### PR TITLE
feat: remove bech32 types from public NetworkID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add `Address` type to represent account-id based addresses ([#1713](https://github.com/0xMiden/miden-base/pull/1713)).
 - Add `asset_vault::peek_balance` ([#1745](https://github.com/0xMiden/miden-base/pull/1745)).
 - Add `get_auth_scheme` method to `AccountComponentInterface` and `AccountInterface` for better authentication scheme extraction ([#1759](https://github.com/0xMiden/miden-base/pull/1759)).
-- Add `CustomHRP` in `NetworkID` ([#1787](https://github.com/0xMiden/miden-base/pull/1787)).
+- Add `CustomNetworkId` in `NetworkID` ([#1787](https://github.com/0xMiden/miden-base/pull/1787)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add `Address` type to represent account-id based addresses ([#1713](https://github.com/0xMiden/miden-base/pull/1713)).
 - Add `asset_vault::peek_balance` ([#1745](https://github.com/0xMiden/miden-base/pull/1745)).
 - Add `get_auth_scheme` method to `AccountComponentInterface` and `AccountInterface` for better authentication scheme extraction ([#1759](https://github.com/0xMiden/miden-base/pull/1759)).
+- Add `CustomHRP` in `NetworkID` ([#1787](https://github.com/0xMiden/miden-base/pull/1787)).
 
 ### Changes
 

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -7,7 +7,7 @@ pub use id_prefix::AccountIdPrefix;
 mod seed;
 
 mod network_id;
-pub use network_id::{CustomHrp, NetworkId};
+pub use network_id::{CustomNetworkId, NetworkId};
 
 mod account_type;
 pub use account_type::AccountType;

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -7,7 +7,7 @@ pub use id_prefix::AccountIdPrefix;
 mod seed;
 
 mod network_id;
-pub use network_id::NetworkId;
+pub use network_id::{CustomHrp, NetworkId};
 
 mod account_type;
 pub use account_type::AccountType;

--- a/crates/miden-objects/src/account/account_id/network_id.rs
+++ b/crates/miden-objects/src/account/account_id/network_id.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
+use alloc::str::FromStr;
 use alloc::string::ToString;
-use core::str::FromStr;
 
 use bech32::Hrp;
 
@@ -25,14 +25,18 @@ impl CustomNetworkId {
 
     /// Returns the string representation of this custom HRP.
     pub fn as_str(&self) -> &str {
-        &self.hrp.as_str()
+        self.hrp.as_str()
     }
+}
+
+impl FromStr for CustomNetworkId {
+    type Err = NetworkIdError;
 
     /// Creates a [`CustomNetworkId`] from a String.
     /// # Errors
     ///
     /// Returns an error if the string is not a valid HRP according to bech32 rules
-    pub(crate) fn from_str(hrp_str: &str) -> Result<Self, NetworkIdError> {
+    fn from_str(hrp_str: &str) -> Result<Self, Self::Err> {
         Ok(CustomNetworkId {
             hrp: Hrp::parse(hrp_str)
                 .map_err(|source| NetworkIdError::NetworkIdParseError(source.to_string().into()))?,
@@ -42,7 +46,7 @@ impl CustomNetworkId {
 
 impl core::fmt::Display for CustomNetworkId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(&self.as_str())
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/miden-objects/src/account/account_id/network_id.rs
+++ b/crates/miden-objects/src/account/account_id/network_id.rs
@@ -6,50 +6,6 @@ use bech32::Hrp;
 
 use crate::errors::NetworkIdError;
 
-/// A wrapper around HRP for custom network identifiers.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CustomNetworkId {
-    hrp: Hrp,
-}
-
-impl CustomNetworkId {
-    /// Creates a new [`CustomNetworkId`] from a [`bech32::Hrp`].
-    pub fn from_hrp(hrp: Hrp) -> Self {
-        CustomNetworkId { hrp }
-    }
-
-    /// Converts this [`CustomNetworkId`] to a [`bech32::Hrp`].
-    pub(crate) fn as_hrp(&self) -> Hrp {
-        self.hrp
-    }
-
-    /// Returns the string representation of this custom HRP.
-    pub fn as_str(&self) -> &str {
-        self.hrp.as_str()
-    }
-}
-
-impl FromStr for CustomNetworkId {
-    type Err = NetworkIdError;
-
-    /// Creates a [`CustomNetworkId`] from a String.
-    /// # Errors
-    ///
-    /// Returns an error if the string is not a valid HRP according to bech32 rules
-    fn from_str(hrp_str: &str) -> Result<Self, Self::Err> {
-        Ok(CustomNetworkId {
-            hrp: Hrp::parse(hrp_str)
-                .map_err(|source| NetworkIdError::NetworkIdParseError(source.to_string().into()))?,
-        })
-    }
-}
-
-impl core::fmt::Display for CustomNetworkId {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
 // This is essentially a wrapper around [`bech32::Hrp`] but that type does not actually appear in
 // the public API since that crate does not have a stable release.
 
@@ -147,6 +103,53 @@ impl FromStr for NetworkId {
 }
 
 impl core::fmt::Display for NetworkId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// CUSTOM NETWORK ID
+// ================================================================================================
+
+/// A wrapper around HRP for custom network identifiers.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CustomNetworkId {
+    hrp: Hrp,
+}
+
+impl CustomNetworkId {
+    /// Creates a new [`CustomNetworkId`] from a [`bech32::Hrp`].
+    pub(crate) fn from_hrp(hrp: Hrp) -> Self {
+        CustomNetworkId { hrp }
+    }
+
+    /// Converts this [`CustomNetworkId`] to a [`bech32::Hrp`].
+    pub(crate) fn as_hrp(&self) -> Hrp {
+        self.hrp
+    }
+
+    /// Returns the string representation of this custom HRP.
+    pub fn as_str(&self) -> &str {
+        self.hrp.as_str()
+    }
+}
+
+impl FromStr for CustomNetworkId {
+    type Err = NetworkIdError;
+
+    /// Creates a [`CustomNetworkId`] from a String.
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a valid HRP according to bech32 rules
+    fn from_str(hrp_str: &str) -> Result<Self, Self::Err> {
+        Ok(CustomNetworkId {
+            hrp: Hrp::parse(hrp_str)
+                .map_err(|source| NetworkIdError::NetworkIdParseError(source.to_string().into()))?,
+        })
+    }
+}
+
+impl core::fmt::Display for CustomNetworkId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.as_str())
     }

--- a/crates/miden-objects/src/account/account_id/network_id.rs
+++ b/crates/miden-objects/src/account/account_id/network_id.rs
@@ -111,7 +111,7 @@ impl core::fmt::Display for NetworkId {
 // CUSTOM NETWORK ID
 // ================================================================================================
 
-/// A wrapper around HRP for custom network identifiers.
+/// A wrapper around bech32 HRP(human-readable part) for custom network identifiers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CustomNetworkId {
     hrp: Hrp,

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -17,6 +17,7 @@ pub use account_id::{
     AccountIdVersion,
     AccountStorageMode,
     AccountType,
+    CustomHrp,
     NetworkId,
 };
 

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -17,7 +17,7 @@ pub use account_id::{
     AccountIdVersion,
     AccountStorageMode,
     AccountType,
-    CustomHrp,
+    CustomNetworkId,
     NetworkId,
 };
 

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -325,6 +325,7 @@ impl TryFrom<[u8; AccountIdAddress::SERIALIZED_SIZE]> for AccountIdAddress {
 #[cfg(test)]
 mod tests {
     use alloc::boxed::Box;
+    use alloc::str::FromStr;
 
     use assert_matches::assert_matches;
     use bech32::{Bech32, NoChecksum};

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -325,10 +325,10 @@ impl TryFrom<[u8; AccountIdAddress::SERIALIZED_SIZE]> for AccountIdAddress {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use bech32::{Bech32, Hrp, NoChecksum};
+    use bech32::{Bech32, NoChecksum};
 
     use super::*;
-    use crate::account::AccountType;
+    use crate::account::{AccountType, CustomHrp};
     use crate::testing::account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, AccountIdBuilder};
 
     /// Tests that an account ID address can be encoded and decoded.
@@ -343,8 +343,8 @@ mod tests {
         let rng = &mut rand::rng();
         for network_id in [
             NetworkId::Mainnet,
-            NetworkId::Custom(Hrp::parse("custom").unwrap()),
-            NetworkId::Custom(Hrp::parse(longest_possible_hrp).unwrap()),
+            NetworkId::Custom(CustomHrp::new("custom").unwrap()),
+            NetworkId::Custom(CustomHrp::new(longest_possible_hrp).unwrap()),
         ] {
             for (idx, account_id) in [
                 AccountIdBuilder::new()
@@ -367,7 +367,7 @@ mod tests {
                     AccountIdAddress::new(account_id, AddressInterface::BasicWallet);
                 let address = Address::from(account_id_address);
 
-                let bech32_string = address.to_bech32(network_id);
+                let bech32_string = address.to_bech32(network_id.clone());
                 let (decoded_network_id, decoded_address) =
                     Address::from_bech32(&bech32_string).unwrap();
 

--- a/crates/miden-objects/src/address/mod.rs
+++ b/crates/miden-objects/src/address/mod.rs
@@ -324,11 +324,13 @@ impl TryFrom<[u8; AccountIdAddress::SERIALIZED_SIZE]> for AccountIdAddress {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+
     use assert_matches::assert_matches;
     use bech32::{Bech32, NoChecksum};
 
     use super::*;
-    use crate::account::{AccountType, CustomHrp};
+    use crate::account::{AccountType, CustomNetworkId};
     use crate::testing::account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, AccountIdBuilder};
 
     /// Tests that an account ID address can be encoded and decoded.
@@ -343,8 +345,8 @@ mod tests {
         let rng = &mut rand::rng();
         for network_id in [
             NetworkId::Mainnet,
-            NetworkId::Custom(CustomHrp::new("custom").unwrap()),
-            NetworkId::Custom(CustomHrp::new(longest_possible_hrp).unwrap()),
+            NetworkId::Custom(Box::new(CustomNetworkId::from_str("custom").unwrap())),
+            NetworkId::Custom(Box::new(CustomNetworkId::from_str(longest_possible_hrp).unwrap())),
         ] {
             for (idx, account_id) in [
                 AccountIdBuilder::new()


### PR DESCRIPTION
Fixes #1758


One downside of this is `NetworkID` no longer derives `Copy` trait