### PR TITLE
Make source manager a filed in transaction executor

### DIFF
--- a/crates/miden-objects/src/lib.rs
+++ b/crates/miden-objects/src/lib.rs
@@ -56,6 +56,7 @@ pub use miden_crypto::word::{LexicographicWord, Word, WordError};
 
 pub mod assembly {
     pub use miden_assembly::ast::{Module, ModuleKind, ProcedureName, QualifiedProcedureName};
+    pub use miden_assembly::debuginfo::SourceManagerSync;
     pub use miden_assembly::{
         Assembler,
         DefaultSourceManager,

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -63,7 +63,7 @@ async fn check_note_consumability_well_known_notes_success() -> anyhow::Result<(
     let tx_args = tx_context.tx_args().clone();
 
     let executor =
-        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context, None).with_tracing();
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker
@@ -102,7 +102,7 @@ async fn check_note_consumability_custom_notes_success(
     let tx_args = tx_context.tx_args().clone();
 
     let executor =
-        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context, None).with_tracing();
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker
@@ -179,7 +179,7 @@ async fn check_note_consumability_failure() -> anyhow::Result<()> {
     let tx_args = tx_context.tx_args().clone();
 
     let executor =
-        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context, None).with_tracing();
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -166,9 +166,10 @@ async fn consuming_note_created_in_future_block_fails() -> anyhow::Result<()> {
     // Attempt to execute a transaction against reference block 1 with the note created in block 11
     // - which should fail.
     let tx_context = mock_chain.build_tx_context(account.id(), &[], &[])?.build()?;
-    let source_manager = tx_context.source_manager();
 
-    let tx_executor = TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context, None);
+    let tx_executor = TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context)
+        .with_source_manager(tx_context.source_manager());
+
     // Try to execute with block_ref==1
     let error = tx_executor
         .execute_transaction(
@@ -176,7 +177,6 @@ async fn consuming_note_created_in_future_block_fails() -> anyhow::Result<()> {
             BlockNumber::from(1),
             InputNotes::new(vec![input_note]).unwrap(),
             TransactionArgs::default(),
-            source_manager,
         )
         .await;
 
@@ -975,6 +975,7 @@ async fn advice_inputs_from_transaction_witness_are_sufficient_to_reexecute_tran
             acct_procedure_index_map,
             None,
             tx_inputs.block_header().fee_parameters(),
+            Arc::new(DefaultSourceManager::default()),
         )
     };
     let advice_inputs = advice_inputs.into_advice_inputs();
@@ -1400,7 +1401,6 @@ async fn execute_tx_view_script() -> anyhow::Result<()> {
     ";
 
     let source = NamedSource::new("test::module_1", test_module_source);
-    let source_manager = Arc::new(DefaultSourceManager::default());
     let assembler = TransactionKernel::assembler();
 
     let library = assembler.assemble_library([source]).unwrap();
@@ -1426,17 +1426,10 @@ async fn execute_tx_view_script() -> anyhow::Result<()> {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let advice_inputs = tx_context.tx_args().advice_inputs().clone();
 
-    let executor = TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context, None);
+    let executor = TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context);
 
     let stack_outputs = executor
-        .execute_tx_view_script(
-            account_id,
-            block_ref,
-            tx_script,
-            advice_inputs,
-            Vec::default(),
-            source_manager,
-        )
+        .execute_tx_view_script(account_id, block_ref, tx_script, advice_inputs, Vec::default())
         .await?;
 
     assert_eq!(stack_outputs[..3], [Felt::new(7), Felt::new(2), ONE]);

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -246,9 +246,7 @@ impl TransactionContextBuilder {
         // TODO: SourceManager.
         let source_manager =
             alloc::sync::Arc::new(miden_objects::assembly::DefaultSourceManager::default())
-                as alloc::sync::Arc<
-                    dyn miden_objects::assembly::SourceManager + Send + Sync + 'static,
-                >;
+                as alloc::sync::Arc<dyn miden_objects::assembly::SourceManagerSync + 'static>;
 
         let tx_inputs = match self.transaction_inputs {
             Some(tx_inputs) => tx_inputs,

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -7,7 +7,7 @@ use miden_lib::errors::TransactionKernelError;
 use miden_lib::transaction::TransactionEvent;
 use miden_objects::account::{AccountDelta, PartialAccount};
 use miden_objects::assembly::debuginfo::Location;
-use miden_objects::assembly::{DefaultSourceManager, SourceFile, SourceManager, SourceSpan};
+use miden_objects::assembly::{SourceFile, SourceManagerSync, SourceSpan};
 use miden_objects::asset::FungibleAsset;
 use miden_objects::block::FeeParameters;
 use miden_objects::transaction::{InputNote, InputNotes, OutputNote};
@@ -61,6 +61,10 @@ where
 
     /// The balance of the native asset in the account at the beginning of transaction execution.
     initial_native_asset: FungibleAsset,
+
+    /// The source manager to track source code file span information, improving any MASM related
+    /// error messages.
+    source_manager: Arc<dyn SourceManagerSync>,
 }
 
 impl<'store, 'auth, STORE, AUTH> TransactionExecutorHost<'store, 'auth, STORE, AUTH>
@@ -80,6 +84,7 @@ where
         acct_procedure_index_map: AccountProcedureIndexMap,
         authenticator: Option<&'auth AUTH>,
         fee_parameters: &FeeParameters,
+        source_manager: Arc<dyn SourceManagerSync>,
     ) -> Self {
         // TODO: Once we have lazy account loading, this should be loaded in on_tx_fee_computed to
         // avoid the use of PartialVault entirely, which in the future, may or may not track
@@ -117,6 +122,7 @@ where
             authenticator,
             generated_signatures: BTreeMap::new(),
             initial_native_asset,
+            source_manager,
         }
     }
 
@@ -230,10 +236,9 @@ where
         &self,
         location: &Location,
     ) -> (SourceSpan, Option<Arc<SourceFile>>) {
-        // TODO: Replace with proper call to source manager once the host owns it.
-        let stub_source_manager = DefaultSourceManager::default();
-        let maybe_file = stub_source_manager.get_by_uri(location.uri());
-        let span = stub_source_manager.location_to_span(location.clone()).unwrap_or_default();
+        let source_manager = self.source_manager.as_ref();
+        let maybe_file = source_manager.get_by_uri(location.uri());
+        let span = source_manager.location_to_span(location.clone()).unwrap_or_default();
         (span, maybe_file)
     }
 }

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use miden_lib::errors::TransactionKernelError;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::AccountId;
-use miden_objects::assembly::SourceManager;
+use miden_objects::assembly::{DefaultSourceManager, SourceManagerSync};
 use miden_objects::block::{BlockHeader, BlockNumber};
 use miden_objects::note::{Note, NoteScript};
 use miden_objects::transaction::{
@@ -82,6 +82,7 @@ impl NoteConsumptionInfo {
 pub struct TransactionExecutor<'store, 'auth, STORE: 'store, AUTH: 'auth> {
     data_store: &'store STORE,
     authenticator: Option<&'auth AUTH>,
+    source_manager: Arc<dyn SourceManagerSync>,
     exec_options: ExecutionOptions,
 }
 
@@ -90,17 +91,20 @@ where
     STORE: DataStore + 'store + Sync,
     AUTH: TransactionAuthenticator + 'auth + Sync,
 {
-    // CONSTRUCTOR
+    // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [TransactionExecutor] instance with the specified [DataStore] and
-    /// [TransactionAuthenticator].
-    pub fn new(data_store: &'store STORE, authenticator: Option<&'auth AUTH>) -> Self {
+    /// Creates a new [TransactionExecutor] instance with the specified [DataStore].
+    ///
+    /// The created executor will have not authenticator our source manager set, and tracing and
+    /// debug mode will be turned off.
+    pub fn new(data_store: &'store STORE) -> Self {
         const _: () = assert!(MIN_TX_EXECUTION_CYCLES <= MAX_TX_EXECUTION_CYCLES);
 
         Self {
             data_store,
-            authenticator,
+            authenticator: None,
+            source_manager: Arc::new(DefaultSourceManager::default()),
             exec_options: ExecutionOptions::new(
                 Some(MAX_TX_EXECUTION_CYCLES),
                 MIN_TX_EXECUTION_CYCLES,
@@ -111,20 +115,42 @@ where
         }
     }
 
-    /// Creates a new [TransactionExecutor] instance with the specified [DataStore],
-    /// [TransactionAuthenticator] and [ExecutionOptions].
+    /// Adds the specified [TransactionAuthenticator] to the executor.
     ///
-    /// The specified cycle values (`max_cycles` and `expected_cycles`) in the [ExecutionOptions]
-    /// must be within the range [`MIN_TX_EXECUTION_CYCLES`] and [`MAX_TX_EXECUTION_CYCLES`].
+    /// This will overwrite any previously set authenticator.
+    pub fn with_authenticator(mut self, authenticator: &'auth AUTH) -> Self {
+        self.authenticator = Some(authenticator);
+        self
+    }
+
+    /// Adds the specified source manager to the executor.
+    ///
+    /// The `source_manager` is used to map potential errors back to their source code. To get the
+    /// most value out of it, use the same source manager as was used with the
+    /// [`Assembler`](miden_objects::assembly::Assembler) that assembled the Miden Assembly code
+    /// that should be debugged, e.g. account components, note scripts or transaction scripts.
+    ///
+    /// This will overwrite any previously set source manager.
+    pub fn with_source_manager(mut self, source_manager: Arc<dyn SourceManagerSync>) -> Self {
+        self.source_manager = source_manager;
+        self
+    }
+
+    /// Sets the [ExecutionOptions] for the executor to the provided options.
+    ///
+    /// # Errors
+    /// Returns an error if the specified cycle values (`max_cycles` and `expected_cycles`) in
+    /// the [ExecutionOptions] are not within the range [`MIN_TX_EXECUTION_CYCLES`] and
+    /// [`MAX_TX_EXECUTION_CYCLES`].
     pub fn with_options(
-        data_store: &'store STORE,
-        authenticator: Option<&'auth AUTH>,
+        mut self,
         exec_options: ExecutionOptions,
     ) -> Result<Self, TransactionExecutorError> {
         validate_num_cycles(exec_options.max_cycles())?;
         validate_num_cycles(exec_options.expected_cycles())?;
 
-        Ok(Self { data_store, authenticator, exec_options })
+        self.exec_options = exec_options;
+        Ok(self)
     }
 
     /// Puts the [TransactionExecutor] into debug mode.
@@ -160,13 +186,6 @@ where
     /// provided `notes` were created. Then, it executes the transaction program and creates an
     /// [`ExecutedTransaction`].
     ///
-    /// The `source_manager` is used to map potential errors back to their source code. To get the
-    /// most value out of it, use the source manager from the
-    /// [`Assembler`](miden_objects::assembly::Assembler) that assembled the Miden Assembly code
-    /// that should be debugged, e.g. account components, note scripts or transaction scripts. If
-    /// no error-to-source mapping is desired, a default source manager can be passed, e.g.
-    /// [`DefaultSourceManager::default`](miden_objects::assembly::DefaultSourceManager::default).
-    ///
     /// # Errors:
     ///
     /// Returns an error if:
@@ -180,8 +199,6 @@ where
         block_ref: BlockNumber,
         notes: InputNotes<InputNote>,
         tx_args: TransactionArgs,
-        // TODO: SourceManager: Pass source manager to host once refactored.
-        _source_manager: Arc<dyn SourceManager + Send + Sync>,
     ) -> Result<ExecutedTransaction, TransactionExecutorError> {
         let mut ref_blocks = validate_input_notes(&notes, block_ref)?;
         ref_blocks.insert(block_ref);
@@ -226,6 +243,7 @@ where
             acct_procedure_index_map,
             self.authenticator,
             tx_inputs.block_header().fee_parameters(),
+            self.source_manager.clone(),
         );
 
         let advice_inputs = advice_inputs.into_advice_inputs();
@@ -253,13 +271,6 @@ where
     /// Executes an arbitrary script against the given account and returns the stack state at the
     /// end of execution.
     ///
-    /// The `source_manager` is used to map potential errors back to their source code. To get the
-    /// most value out of it, use the source manager from the
-    /// [`Assembler`](miden_objects::assembly::Assembler) that assembled the Miden Assembly code
-    /// that should be debugged, e.g. account components, note scripts or transaction scripts. If
-    /// no error-to-source mapping is desired, a default source manager can be passed, e.g.
-    /// [`DefaultSourceManager::default`](miden_objects::assembly::DefaultSourceManager::default).
-    ///
     /// # Errors:
     /// Returns an error if:
     /// - If required data can not be fetched from the [DataStore].
@@ -272,8 +283,6 @@ where
         tx_script: TransactionScript,
         advice_inputs: AdviceInputs,
         foreign_account_inputs: Vec<AccountInputs>,
-        // TODO: SourceManager: Pass source manager to host once refactored.
-        _source_manager: Arc<dyn SourceManager + Send + Sync>,
     ) -> Result<[Felt; 16], TransactionExecutorError> {
         let ref_blocks = [block_ref].into_iter().collect();
         let (account, seed, ref_block, mmr) = self
@@ -311,6 +320,7 @@ where
             acct_procedure_index_map,
             self.authenticator,
             tx_inputs.block_header().fee_parameters(),
+            self.source_manager.clone(),
         );
 
         let advice_inputs = advice_inputs.into_advice_inputs();
@@ -393,6 +403,7 @@ where
             acct_procedure_index_map,
             self.authenticator,
             tx_inputs.block_header().fee_parameters(),
+            self.source_manager.clone(),
         );
         let advice_inputs = advice_inputs.into_advice_inputs();
 


### PR DESCRIPTION
This PR extracts `TransactionExecutor`-related changes form https://github.com/0xMiden/miden-base/pull/1749 without making any significant changes to the tests. The main changes are:

- Removed `source_manager` parameter from `execute_transaction()` and `execute_tx_view_script()` method. Instead, source manager is now specified at construction time of transaction executor.
- Transform `TransactionExecutor` constructors into a builder pattern.
- Added source manager to the `TransactionExecutorHost` to make sure `get_label_and_source_file()` method works correctly.

@igamigo - would be great to confirm that these changes are not causing any issues for the client (including the WebClient).