### PR TITLE
fix: invalid bool-to-u32 conversion in ACL auth component

### DIFF
--- a/crates/miden-lib/src/account/auth/mod.rs
+++ b/crates/miden-lib/src/account/auth/mod.rs
@@ -187,8 +187,8 @@ impl From<AuthRpoFalcon512Acl> for AccountComponent {
         let num_procs = falcon.config.auth_trigger_procedures.len() as u32;
         storage_slots.push(StorageSlot::Value(Word::from([
             num_procs,
-            u32::from(falcon.config.allow_unauthorized_output_notes),
-            u32::from(falcon.config.allow_unauthorized_input_notes),
+            falcon.config.allow_unauthorized_output_notes as u32,
+            falcon.config.allow_unauthorized_input_notes as u32,
             0,
         ])));
 


### PR DESCRIPTION
Replace u32::from(bool) with explicit casts for ACL flags in AuthRpoFalcon512Acl slot 1 assembly. Ensures flags are stored as 0/1 u32 values consistent with tests and documentation. Verified with lints.