### PR TITLE
Add `build_recipient` procedure

### DIFF
--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -2,6 +2,7 @@ use.miden::kernel_proc_offsets
 use.std::crypto::hashes::rpo
 use.std::mem
 use.miden::contracts::wallets::basic->wallet
+use.miden::tx
 
 # ERRORS
 # =================================================================================================
@@ -206,9 +207,39 @@ export.compute_inputs_commitment
     # => [inputs_ptr, num_inputs, pad_inputs_flag]
 
     exec.rpo::prepare_hasher_state
-
     exec.rpo::hash_memory_with_state
     # => [COMMITMENT]
+end
+
+#! Builds the recipient hash from note inputs, script root, and serial number.
+#!
+#! This procedure computes the commitment to the note inputs and then builds the recipient
+#! hash using the provided script root and serial number.
+#!
+#! Inputs:  [inputs_ptr, num_inputs, SERIAL_NUM, SCRIPT_ROOT]
+#! Outputs: [RECIPIENT]
+#!
+#! Where:
+#! - inputs_ptr is the memory address where the note inputs are stored.
+#! - num_inputs is the number of input values.
+#! - SCRIPT_ROOT is the script root of the note.
+#! - SERIAL_NUM is the serial number of the note.
+#! - RECIPIENT is the computed recipient hash.
+#!
+#! Panics if:
+#! - inputs_ptr is not word-aligned (i.e., is not a multiple of 4).
+#! - num_inputs is greater than 128.
+#!
+#! Invocation: exec
+export.build_recipient
+    exec.compute_inputs_commitment
+    # => [INPUTS_HASH, SERIAL_NUM, SCRIPT_ROOT]
+
+    movdnw.2
+    # => [SERIAL_NUM, SCRIPT_ROOT, INPUTS_HASH]
+
+    exec.tx::build_recipient_hash
+    # => [RECIPIENT]
 end
 
 #! Returns the script root of the note currently being processed.


### PR DESCRIPTION
This PR adds the `build_recipient` procedure which makes it simplier to compute the `RECIPIENT` digest of a given note. 

Resolves #1781