### PR TITLE
fix: Miscellaneous Note Consumption Checker clean up

### DIFF
--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -7,13 +7,14 @@ use miden_lib::testing::note::NoteBuilder;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::Word;
 use miden_objects::account::{Account, AccountId};
-use miden_objects::asset::FungibleAsset;
+use miden_objects::asset::{Asset, FungibleAsset};
 use miden_objects::note::{Note, NoteType};
 use miden_objects::testing::account_id::{
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_SENDER,
 };
+use miden_objects::transaction::OutputNote;
 use miden_processor::ExecutionError;
 use miden_processor::crypto::RpoRandomCoin;
 use miden_tx::auth::UnreachableAuth;
@@ -68,11 +69,11 @@ async fn check_note_consumability_well_known_notes_success() -> anyhow::Result<(
         TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
-    let execution_check_result = notes_checker
+    let consumption_info = notes_checker
         .check_notes_consumability(target_account_id, block_ref, input_notes, tx_args)
         .await?;
 
-    assert_matches!(execution_check_result, NoteConsumptionInfo { successful, failed, .. } => {
+    assert_matches!(consumption_info, NoteConsumptionInfo { successful, failed, .. } => {
         assert_eq!(successful.len(), notes.len());
         successful.iter().zip(notes.iter()).for_each(|(success, note)| {
             assert_eq!(success, note);
@@ -109,11 +110,11 @@ async fn check_note_consumability_custom_notes_success(
         .with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
-    let execution_check_result = notes_checker
+    let consumption_info = notes_checker
         .check_notes_consumability(account_id, block_ref, input_notes, tx_args)
         .await?;
 
-    assert_matches!(execution_check_result, NoteConsumptionInfo { successful, failed, .. }=> {
+    assert_matches!(consumption_info, NoteConsumptionInfo { successful, failed, .. }=> {
         if notes.is_empty() {
             assert!(successful.is_empty());
             assert!(failed.is_empty());
@@ -192,12 +193,12 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
         TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
-    let execution_check_result = notes_checker
+    let consumption_info = notes_checker
         .check_notes_consumability(account_id, block_ref, input_notes, tx_args)
         .await?;
 
     assert_matches!(
-        execution_check_result,
+        consumption_info,
         NoteConsumptionInfo {
             successful,
             failed
@@ -267,12 +268,12 @@ async fn check_note_consumability_epilogue_failure() -> anyhow::Result<()> {
         TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
-    let execution_check_result = notes_checker
+    let consumption_info = notes_checker
         .check_notes_consumability(account_id, block_ref, input_notes, tx_args)
         .await?;
 
     assert_matches!(
-       execution_check_result,
+       consumption_info,
        NoteConsumptionInfo {
            successful,
            failed
@@ -280,6 +281,118 @@ async fn check_note_consumability_epilogue_failure() -> anyhow::Result<()> {
            assert!(successful.is_empty());
            assert_eq!(failed.len(), 1);
        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_note_consumability_epilogue_failure_with_new_combination() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    let successful_note_1 = builder.add_p2id_note(
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
+        account.id(),
+        &[FungibleAsset::mock(10)],
+        NoteType::Public,
+    )?;
+    let successful_note_2 = builder.add_p2id_note(
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
+        account.id(),
+        &[FungibleAsset::mock(145)],
+        NoteType::Public,
+    )?;
+    let successful_note_3 = builder.add_p2id_note(
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
+        account.id(),
+        &[FungibleAsset::mock(250)],
+        NoteType::Public,
+    )?;
+    let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+    let failing_note_1 = NoteBuilder::new(
+        sender,
+        ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
+    )
+    .code("begin push.1 drop push.0 div end")
+    .dynamically_linked_libraries([TransactionKernel::library()])
+    .build()?;
+
+    // Create a note that causes epilogue failure.
+    let note_asset0 = FungibleAsset::mock(200).unwrap_fungible();
+    let note_asset1 = FungibleAsset::mock(500).unwrap_fungible();
+    let fail_epilogue_note = NoteBuilder::new(account.id(), &mut rand::rng())
+        .add_assets([Asset::from(note_asset0.add(note_asset1)?)])
+        .build()?;
+    builder.add_note(OutputNote::Full(fail_epilogue_note.clone()));
+
+    let mock_chain = builder.build()?;
+    let tx_context = mock_chain
+        .build_tx_context(
+            TxContextInput::Account(account),
+            &[],
+            &[
+                successful_note_1.clone(),
+                fail_epilogue_note.clone(),
+                successful_note_2.clone(),
+                failing_note_1.clone(),
+                successful_note_3.clone(),
+            ],
+        )?
+        .build()?;
+
+    let input_notes = tx_context.input_notes().clone();
+    let account_id = tx_context.account().id();
+    let block_ref = tx_context.tx_inputs().block_header().block_num();
+    let tx_args = tx_context.tx_args().clone();
+
+    // Use an auth that fails in order to force an epilogue failure.
+    let executor =
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
+    let notes_checker = NoteConsumptionChecker::new(&executor);
+
+    let consumption_info = notes_checker
+        .check_notes_consumability(account_id, block_ref, input_notes, tx_args)
+        .await?;
+
+    assert_matches!(
+        consumption_info,
+        NoteConsumptionInfo {
+            successful,
+            failed
+        } => {
+                // First failing note should be the note that does not cause epilogue failure.
+                assert_matches!(
+                    failed.first().expect("first failed notes should exist"),
+                    FailedNote {
+                        note,
+                        error: Some(TransactionExecutorError::TransactionProgramExecutionFailed(
+                            ExecutionError::DivideByZero { .. }))
+                    } => {
+                        assert_eq!(
+                            note.id(),
+                            failing_note_1.id(),
+                        );
+                    }
+                );
+                // Second failing note should be the note that causes epilogue failure.
+                assert_matches!(
+                    failed.get(1).expect("second failed note should exist"),
+                    FailedNote {
+                        note,
+                        error: None,
+                    } => {
+                        assert_eq!(
+                            note.id(),
+                            fail_epilogue_note.id(),
+                        );
+                    }
+                );
+                // Successful notes.
+                assert_eq!(
+                    [successful[0].id(), successful[1].id(), successful[2].id()],
+                    [successful_note_1.id(), successful_note_2.id(), successful_note_3.id()],
+                );
+            }
     );
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -85,7 +85,6 @@ async fn check_note_consumability_well_known_notes_success() -> anyhow::Result<(
 }
 
 #[rstest::rstest]
-#[case::empty(vec![])]
 #[case::one(vec![create_p2any_note(ACCOUNT_ID_SENDER.try_into().unwrap(), &[FungibleAsset::mock(100)])])]
 #[tokio::test]
 async fn check_note_consumability_custom_notes_success(

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -32,7 +32,7 @@ use crate::{Auth, MockChain, TransactionContextBuilder, TxContextInput};
 
 #[tokio::test]
 async fn check_note_consumability_well_known_notes_success() -> anyhow::Result<()> {
-    let (_, authenticator) = Auth::BasicAuth.build_component();
+    let (_, authenticator) = Auth::IncrNonce.build_component();
     let p2id_note = create_p2id_note(
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE.try_into().unwrap(),
@@ -64,9 +64,8 @@ async fn check_note_consumability_well_known_notes_success() -> anyhow::Result<(
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let tx_args = tx_context.tx_args().clone();
 
-    let executor = TransactionExecutor::new(&tx_context)
-        .with_authenticator(tx_context.authenticator().unwrap())
-        .with_tracing();
+    let executor =
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker
@@ -128,7 +127,7 @@ async fn check_note_consumability_custom_notes_success(
 #[tokio::test]
 async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
-    let account = builder.add_existing_wallet(Auth::BasicAuth)?;
+    let account = builder.add_existing_wallet(Auth::IncrNonce)?;
 
     let sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 
@@ -189,8 +188,8 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
     let block_ref = tx_context.tx_inputs().block_header().block_num();
     let tx_args = tx_context.tx_args().clone();
 
-    let executor = TransactionExecutor::new(&tx_context)
-        .with_authenticator(tx_context.authenticator().unwrap());
+    let executor =
+        TransactionExecutor::<'_, '_, _, UnreachableAuth>::new(&tx_context).with_tracing();
     let notes_checker = NoteConsumptionChecker::new(&executor);
 
     let execution_check_result = notes_checker

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -27,6 +27,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NoteCheckerError {
+    #[error("invalid input note count {0})")]
+    InvalidInputNoteCount(u16),
     #[error("transaction preparation failed: {0}")]
     TransactionPreparationFailed(#[source] TransactionExecutorError),
     #[error("transaction execution prologue failed: {0}")]

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -198,15 +198,14 @@ where
             }
 
             // Try adding each remaining note to the current successful combination.
-            let mut test_notes = successful_notes.clone();
             for (idx, note) in remaining_notes.iter().enumerate() {
-                test_notes.push(note.clone());
+                successful_notes.push(note.clone());
 
                 match self
                     .try_execute_notes(
                         target_account_id,
                         block_ref,
-                        InputNotes::<InputNote>::new_unchecked(test_notes.clone()),
+                        InputNotes::<InputNote>::new_unchecked(successful_notes.clone()),
                         tx_args,
                     )
                     .await
@@ -215,13 +214,12 @@ where
                         // This combination succeeded; remove the most recently added note from
                         // the remaining set.
                         remaining_notes.remove(idx);
-                        successful_notes = test_notes;
                         break;
                     },
                     _ => {
                         // This combination failed; remove the last note from the test set and
                         // continue to next note.
-                        test_notes.pop();
+                        successful_notes.pop();
                     },
                 }
             }


### PR DESCRIPTION
## Context

In #1721 there were a few comments to follow up on, namely:
- [Reduce cloning](https://github.com/0xMiden/miden-base/pull/1721#discussion_r2302521702)
- [Untested codepath](https://github.com/0xMiden/miden-base/pull/1721#discussion_r2302855316)
- [Overzealous auth](https://github.com/0xMiden/miden-base/pull/1721#discussion_r2302798589)
- [Checker upper bound](https://github.com/0xMiden/miden-base/pull/1721#discussion_r2302806940)

## Changes

- Add error condition for input note count into checker (must be 1-20)
- Reduce auth overhead in benchmarks and tests
- Add tests for epilogue failure, new combination of notes code path