### PR TITLE
refactor: Remove TransactionContext::execute_blocking and migrate to …

### DIFF
--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -31,8 +31,6 @@ itertools   = { default-features = false, features = ["use_alloc"], version = "0
 rand        = { features = ["os_rng", "small_rng"], workspace = true }
 rand_chacha = { default-features = false, version = "0.9" }
 thiserror   = { workspace = true }
-# TODO: We should be able to remove this once we remove `TransactionContext::execute_blocking`
-tokio      = { features = ["macros", "rt"], workspace = true }
 winterfell = { version = "0.13" }
 
 [dev-dependencies]
@@ -40,4 +38,5 @@ anyhow            = { features = ["backtrace", "std"], workspace = true }
 assert_matches    = { workspace = true }
 miden-objects     = { features = ["std"], workspace = true }
 rstest            = { workspace = true }
+tokio             = { features = ["macros", "rt"], workspace = true }
 winter-rand-utils = { version = "0.13" }

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -27,8 +27,8 @@ use crate::kernel_tests::block::utils::generate_conditional_tx;
 use crate::{AccountState, Auth, MockChain, ProvenTransactionExt};
 
 /// Tests that we can build empty blocks.
-#[test]
-fn proposed_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proposed_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     let TestSetup { chain, .. } = setup_chain(2);
 
     let block_inputs = BlockInputs::new(
@@ -50,8 +50,8 @@ fn proposed_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
 
 /// Tests that a proposed block from two batches with one transaction each can be successfully
 /// built.
-#[test]
-fn proposed_block_basic_success() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proposed_block_basic_success() -> anyhow::Result<()> {
     let TestSetup { mut chain, mut accounts, mut txs, .. } = setup_chain(2);
     let account0 = accounts.remove(&0).unwrap();
     let account1 = accounts.remove(&1).unwrap();
@@ -109,8 +109,8 @@ fn proposed_block_basic_success() -> anyhow::Result<()> {
 }
 
 /// Tests that account updates are correctly aggregated into a block-level account update.
-#[test]
-fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
     // We need authentication because we're modifying accounts with the input notes.
     let TestSetup { mut chain, mut accounts, .. } = setup_chain(2);
     let asset = generate_fungible_asset(
@@ -180,8 +180,8 @@ fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<()> {
 }
 
 /// Tests that unauthenticated notes can be authenticated when inclusion proofs are provided.
-#[test]
-fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, mut accounts, .. } = setup_chain(3);
     let account0 = accounts.remove(&0).unwrap();
     let account1 = accounts.remove(&1).unwrap();
@@ -231,8 +231,8 @@ fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result<()> {
 }
 
 /// Tests that a batch that expires at the block being proposed is still accepted.
-#[test]
-fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
     let TestSetup { mut chain, mut accounts, .. } = setup_chain(2);
     let block1_num = chain.block_header(1).block_num();
     let account0 = accounts.remove(&0).unwrap();
@@ -262,8 +262,8 @@ fn proposed_block_with_batch_at_expiration_limit() -> anyhow::Result<()> {
 /// Tests that a NOOP transaction with state commitments X -> X against account A can appear
 /// in one batch while another batch contains a state-updating transaction with state commitments X
 /// -> Y against the same account A. Both batches are in the same block.
-#[test]
-fn noop_tx_and_state_updating_tx_against_same_account_in_same_block() -> anyhow::Result<()> {
+#[tokio::test]
+async fn noop_tx_and_state_updating_tx_against_same_account_in_same_block() -> anyhow::Result<()> {
     let account_builder = Account::builder(rand::rng().random())
         .storage_mode(AccountStorageMode::Public)
         .with_component(MockAccountComponent::with_empty_slots());

--- a/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proven_block_success.rs
@@ -31,8 +31,8 @@ use crate::utils::create_spawn_note;
 
 /// Tests the outputs of a proven block with transactions that consume notes, create output notes
 /// and modify the account's state.
-#[test]
-fn proven_block_success() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proven_block_success() -> anyhow::Result<()> {
     // Setup test with notes that produce output notes, in order to test the block note tree root
     // computation.
     // --------------------------------------------------------------------------------------------
@@ -61,10 +61,10 @@ fn proven_block_success() -> anyhow::Result<()> {
     chain.add_pending_note(OutputNote::Full(input_note3.clone()));
     chain.prove_next_block()?;
 
-    let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[input_note0.id()]);
-    let tx1 = generate_tx_with_authenticated_notes(&mut chain, account1.id(), &[input_note1.id()]);
-    let tx2 = generate_tx_with_authenticated_notes(&mut chain, account2.id(), &[input_note2.id()]);
-    let tx3 = generate_tx_with_authenticated_notes(&mut chain, account3.id(), &[input_note3.id()]);
+    let tx0 = generate_tx_with_authenticated_notes(&mut chain, account0.id(), &[input_note0.id()]).await;
+    let tx1 = generate_tx_with_authenticated_notes(&mut chain, account1.id(), &[input_note1.id()]).await;
+    let tx2 = generate_tx_with_authenticated_notes(&mut chain, account2.id(), &[input_note2.id()]).await;
+    let tx3 = generate_tx_with_authenticated_notes(&mut chain, account3.id(), &[input_note3.id()]).await;
 
     let batch0 = generate_batch(&mut chain, [tx0.clone(), tx1.clone()].to_vec());
     let batch1 = generate_batch(&mut chain, [tx2.clone(), tx3.clone()].to_vec());
@@ -203,8 +203,8 @@ fn proven_block_success() -> anyhow::Result<()> {
 ///
 /// We also test that the batch note tree containing the output generating transactions is a subtree
 /// of the subtree of the overall block note tree computed from the block's output notes.
-#[test]
-fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
     let TestSetup { mut chain, mut accounts, .. } = setup_chain(4);
     let account0 = accounts.remove(&0).unwrap();
     let account1 = accounts.remove(&1).unwrap();
@@ -345,8 +345,8 @@ fn proven_block_erasing_unauthenticated_notes() -> anyhow::Result<()> {
 }
 
 /// Tests that we can build empty blocks.
-#[test]
-fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
+#[tokio::test]
+async fn proven_block_succeeds_with_empty_batches() -> anyhow::Result<()> {
     // Setup a chain with a non-empty nullifier tree by consuming some notes.
     // --------------------------------------------------------------------------------------------
 

--- a/crates/miden-testing/src/kernel_tests/block/utils.rs
+++ b/crates/miden-testing/src/kernel_tests/block/utils.rs
@@ -86,7 +86,7 @@ pub fn generate_fungible_asset(amount: u64, faucet_id: AccountId) -> Asset {
     FungibleAsset::new(faucet_id, amount).unwrap().into()
 }
 
-pub fn generate_executed_tx_with_authenticated_notes(
+pub async fn generate_executed_tx_with_authenticated_notes(
     chain: &MockChain,
     input: impl Into<TxContextInput>,
     notes: &[NoteId],
@@ -96,15 +96,15 @@ pub fn generate_executed_tx_with_authenticated_notes(
         .expect("failed to build tx context")
         .build()
         .unwrap();
-    tx_context.execute_blocking().unwrap()
+    tx_context.execute().await.unwrap()
 }
 
-pub fn generate_tx_with_authenticated_notes(
+pub async fn generate_tx_with_authenticated_notes(
     chain: &mut MockChain,
     account_id: AccountId,
     notes: &[NoteId],
 ) -> ProvenTransaction {
-    let executed_tx = generate_executed_tx_with_authenticated_notes(chain, account_id, notes);
+    let executed_tx = generate_executed_tx_with_authenticated_notes(chain, account_id, notes).await.await;
     ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
@@ -113,7 +113,7 @@ pub fn generate_tx_with_authenticated_notes(
 /// - if `modify_storage` is false, it does nothing (NOOP).
 ///
 /// To make this transaction (always) non-empty, it consumes one "noop note", which does nothing.
-pub fn generate_conditional_tx(
+pub async fn generate_conditional_tx(
     chain: &mut MockChain,
     input: impl Into<TxContextInput>,
     modify_storage: bool,
@@ -138,11 +138,11 @@ pub fn generate_conditional_tx(
         .auth_args(auth_args.into())
         .build()
         .unwrap();
-    tx_context.execute_blocking().unwrap()
+    tx_context.execute().await.unwrap()
 }
 
 /// Generates a transaction that expires at the given block number.
-pub fn generate_tx_with_expiration(
+pub async fn generate_tx_with_expiration(
     chain: &mut MockChain,
     input: impl Into<TxContextInput>,
     expiration_block: BlockNumber,
@@ -157,11 +157,11 @@ pub fn generate_tx_with_expiration(
         .tx_script(update_expiration_tx_script(expiration_delta.as_u32() as u16))
         .build()
         .unwrap();
-    let executed_tx = tx_context.execute_blocking().unwrap();
+    let executed_tx = tx_context.execute().await.unwrap();
     ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 
-pub fn generate_tx_with_unauthenticated_notes(
+pub async fn generate_tx_with_unauthenticated_notes(
     chain: &mut MockChain,
     account_id: AccountId,
     notes: &[Note],
@@ -171,7 +171,7 @@ pub fn generate_tx_with_unauthenticated_notes(
         .expect("failed to build tx context")
         .build()
         .unwrap();
-    let executed_tx = tx_context.execute_blocking().unwrap();
+    let executed_tx = tx_context.execute().await.unwrap();
     ProvenTransaction::from_executed_transaction_mocked(executed_tx)
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -52,8 +52,8 @@ use crate::{Auth, MockChain, TransactionContextBuilder};
 ///
 /// In order to make the account delta empty but the transaction still legal, we consume a note
 /// without assets.
-#[test]
-fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
+#[tokio::test]
+async fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let account = builder.add_existing_mock_account(Auth::Noop)?;
     let p2any_note =
@@ -64,7 +64,7 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
         .build_tx_context(account.id(), &[p2any_note.id()], &[])
         .expect("failed to build tx context")
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
 
     assert_eq!(executed_tx.account_delta().nonce_delta(), ZERO);
@@ -75,15 +75,15 @@ fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
 }
 
 /// Tests that a noop transaction with [`Auth::IncrNonce`] results in a nonce delta of 1.
-#[test]
-fn delta_nonce() -> anyhow::Result<()> {
+#[tokio::test]
+async fn delta_nonce() -> anyhow::Result<()> {
     let TestSetup { mock_chain, account_id } = setup_test([], [])?;
 
     let executed_tx = mock_chain
         .build_tx_context(account_id, &[], &[])
         .expect("failed to build tx context")
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
 
     assert_eq!(executed_tx.account_delta().nonce_delta(), Felt::new(1));
@@ -97,8 +97,8 @@ fn delta_nonce() -> anyhow::Result<()> {
 /// - Slot 1: EMPTY_WORD -> [3,4,5,6]               -> Delta: [3,4,5,6]
 /// - Slot 2: [1,3,5,7]  -> [1,3,5,7]               -> Delta: None
 /// - Slot 3: [1,3,5,7]  -> [2,3,4,5] -> [1,3,5,7]  -> Delta: None
-#[test]
-fn storage_delta_for_value_slots() -> anyhow::Result<()> {
+#[tokio::test]
+async fn storage_delta_for_value_slots() -> anyhow::Result<()> {
     let slot_0_init_value = Word::from([2, 4, 6, 8u32]);
     let slot_0_tmp_value = Word::from([3, 4, 5, 6u32]);
     let slot_0_final_value = EMPTY_WORD;
@@ -177,7 +177,7 @@ fn storage_delta_for_value_slots() -> anyhow::Result<()> {
         .expect("failed to build tx context")
         .tx_script(tx_script)
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
 
     let storage_values_delta = executed_tx
@@ -204,8 +204,8 @@ fn storage_delta_for_value_slots() -> anyhow::Result<()> {
 /// - Slot 2: key5: [1,2,3,4]  -> [2,3,4,5] -> [1,2,3,4] -> Delta: None
 ///   - key5 and key4 are the same scenario, but in different slots. In particular, slot 2's delta
 ///     map will be empty after normalization and so it shouldn't be present in the delta at all.
-#[test]
-fn storage_delta_for_map_slots() -> anyhow::Result<()> {
+#[tokio::test]
+async fn storage_delta_for_map_slots() -> anyhow::Result<()> {
     // Test with random keys to make sure the ordering in the MASM and Rust implementations
     // matches.
     let key0 = rand_value::<Word>();
@@ -327,7 +327,7 @@ fn storage_delta_for_map_slots() -> anyhow::Result<()> {
         .build_tx_context(account_id, &[], &[])?
         .tx_script(tx_script)
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
     let maps_delta = executed_tx.account_delta().storage().maps();
 
@@ -357,8 +357,8 @@ fn storage_delta_for_map_slots() -> anyhow::Result<()> {
 /// - Asset2 is increased by 200 and decreased by 100 -> Delta: 100.
 /// - Asset3 is decreased by [`FungibleAsset::MAX_AMOUNT`] -> Delta: -MAX_AMOUNT.
 /// - Asset4 is increased by [`FungibleAsset::MAX_AMOUNT`] -> Delta: MAX_AMOUNT.
-#[test]
-fn fungible_asset_delta() -> anyhow::Result<()> {
+#[tokio::test]
+async fn fungible_asset_delta() -> anyhow::Result<()> {
     // Test with random IDs to make sure the ordering in the MASM and Rust implementations
     // matches.
     let faucet0: AccountId = AccountIdBuilder::new()
@@ -434,7 +434,7 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
         .build_tx_context(account_id, &added_notes.iter().map(Note::id).collect::<Vec<_>>(), &[])?
         .tx_script(tx_script)
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
 
     let mut added_assets = executed_tx
@@ -476,8 +476,8 @@ fn fungible_asset_delta() -> anyhow::Result<()> {
 /// - Asset1 is removed from the vault -> Delta: Remove.
 /// - Asset2 is added and removed -> Delta: No Change.
 /// - Asset3 is removed and added -> Delta: No Change.
-#[test]
-fn non_fungible_asset_delta() -> anyhow::Result<()> {
+#[tokio::test]
+async fn non_fungible_asset_delta() -> anyhow::Result<()> {
     let mut rng = rand::rng();
     // Test with random IDs to make sure the ordering in the MASM and Rust implementations
     // matches.
@@ -541,7 +541,7 @@ fn non_fungible_asset_delta() -> anyhow::Result<()> {
         .build_tx_context(account_id, &added_notes.iter().map(Note::id).collect::<Vec<_>>(), &[])?
         .tx_script(tx_script)
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute transaction")?;
 
     let mut added_assets = executed_tx
@@ -568,8 +568,8 @@ fn non_fungible_asset_delta() -> anyhow::Result<()> {
 
 /// Tests that adding and removing assets and updating value and map storage slots results in the
 /// correct delta.
-#[test]
-fn asset_and_storage_delta() -> anyhow::Result<()> {
+#[tokio::test]
+async fn asset_and_storage_delta() -> anyhow::Result<()> {
     let account_assets = AssetVault::mock().assets().collect::<Vec<Asset>>();
 
     let account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
@@ -734,7 +734,7 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
     // expected delta
     // --------------------------------------------------------------------------------------------
     // execute the transaction and get the witness
-    let executed_transaction = tx_context.execute_blocking()?;
+    let executed_transaction = tx_context.execute().await?;
 
     // nonce delta
     // --------------------------------------------------------------------------------------------
@@ -795,8 +795,8 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
 
 /// Tests that adding a fungible asset with amount zero to the account vault works and does not
 /// result in an account delta entry.
-#[test]
-fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::Result<()> {
+#[tokio::test]
+async fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
     let input_note = builder.add_p2id_note(
@@ -810,7 +810,7 @@ fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::Result<
     let tx = chain
         .build_tx_context(account, &[input_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute().await?;
 
     assert!(tx.account_delta().vault().is_empty());
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -18,8 +18,8 @@ pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_
 /// This test creates an account with a conditional auth component that expects specific
 /// auth arguments [97, 98, 99] to not error out. When the correct arguments are provided,
 /// the nonce is incremented (because of `incr_nonce_flag`).
-#[test]
-fn test_auth_procedure_args() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_auth_procedure_args() -> anyhow::Result<()> {
     let account =
         Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, ConditionalAuthComponent);
 
@@ -32,7 +32,7 @@ fn test_auth_procedure_args() -> anyhow::Result<()> {
 
     let tx_context = TransactionContextBuilder::new(account).auth_args(auth_args.into()).build()?;
 
-    tx_context.execute_blocking().context("failed to execute transaction")?;
+    tx_context.execute().await.context("failed to execute transaction")?;
 
     Ok(())
 }
@@ -42,8 +42,8 @@ fn test_auth_procedure_args() -> anyhow::Result<()> {
 /// This test creates an account with a conditional auth component that expects specific
 /// auth arguments [97, 98, 99, incr_nonce_flag]. When incorrect arguments are provided
 /// (in this case [101, 102, 103]), the transaction should fail with an appropriate error message.
-#[test]
-fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
     let account =
         Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, ConditionalAuthComponent);
 
@@ -57,7 +57,7 @@ fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
 
     let tx_context = TransactionContextBuilder::new(account).auth_args(auth_args.into()).build()?;
 
-    let execution_result = tx_context.execute_blocking();
+    let execution_result = tx_context.execute().await;
 
     assert_transaction_executor_error!(execution_result, ERR_WRONG_ARGS);
 
@@ -65,8 +65,8 @@ fn test_auth_procedure_args_wrong_inputs() -> anyhow::Result<()> {
 }
 
 /// Tests that attempting to call the auth procedure manually from user code fails.
-#[test]
-fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
     let (auth_component, _) = Auth::IncrNonce.build_component();
 
     let account = AccountBuilder::new([42; 32])
@@ -87,7 +87,7 @@ fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
 
     let tx_context = TransactionContextBuilder::new(account).tx_script(tx_script).build()?;
 
-    let execution_result = tx_context.execute_blocking();
+    let execution_result = tx_context.execute().await;
 
     assert_transaction_executor_error!(
         execution_result,

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -486,8 +486,8 @@ fn test_epilogue_increment_nonce_success() -> anyhow::Result<()> {
 }
 
 /// Tests that changing the account state without incrementing the nonce results in an error.
-#[test]
-fn epilogue_fails_on_account_state_change_without_nonce_increment() -> anyhow::Result<()> {
+#[tokio::test]
+async fn epilogue_fails_on_account_state_change_without_nonce_increment() -> anyhow::Result<()> {
     let code = "
         use.mock::account
 
@@ -507,7 +507,8 @@ fn epilogue_fails_on_account_state_change_without_nonce_increment() -> anyhow::R
     let result = TransactionContextBuilder::with_noop_auth_account()
         .tx_script(tx_script)
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(
         result,
@@ -517,11 +518,11 @@ fn epilogue_fails_on_account_state_change_without_nonce_increment() -> anyhow::R
     Ok(())
 }
 
-#[test]
-fn test_epilogue_execute_empty_transaction() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_epilogue_execute_empty_transaction() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_noop_auth_account().build()?;
 
-    let result = tx_context.execute_blocking();
+    let result = tx_context.execute().await;
 
     assert_transaction_executor_error!(result, ERR_EPILOGUE_EXECUTED_TRANSACTION_IS_EMPTY);
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -45,8 +45,8 @@ use crate::{TransactionContextBuilder, assert_execution_error, assert_transactio
 // FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
 
-#[test]
-fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     let tx_context = TransactionContextBuilder::with_fungible_faucet(
         faucet_id.into(),
@@ -101,8 +101,8 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
 }
 
 /// Tests that minting a fungible asset on a non-faucet account fails.
-#[test]
-fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+#[tokio::test]
+async fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let account = setup_non_faucet_account()?;
 
     let code = format!(
@@ -121,14 +121,14 @@ fn mint_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
         .build()?
-        .execute_blocking();
+        .execute().await;
     assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
     Ok(())
 }
 
-#[test]
-fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         10u32.into(),
@@ -155,8 +155,8 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
     let code = format!(
         "
         use.mock::faucet
@@ -176,7 +176,7 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
     )
     .tx_script(tx_script)
     .build()?
-    .execute_blocking();
+    .execute().await;
 
     assert_transaction_executor_error!(
         result,
@@ -188,8 +188,8 @@ fn test_mint_fungible_asset_fails_saturate_max_amount() -> anyhow::Result<()> {
 // NON-FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
 
-#[test]
-fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     let tx_context =
         TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
             .build()?;
@@ -242,8 +242,8 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_non_fungible_faucet(
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
     )
@@ -271,8 +271,8 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 }
 
 /// Tests that minting a non-fungible asset on a non-faucet account fails.
-#[test]
-fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+#[tokio::test]
+async fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let account = setup_non_faucet_account()?;
 
     let code = format!(
@@ -291,14 +291,14 @@ fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
         .build()?
-        .execute_blocking();
+        .execute().await;
     assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
     Ok(())
 }
 
-#[test]
-fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<()> {
     let tx_context =
         TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
             .build()?;
@@ -329,8 +329,8 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<(
 // FUNGIBLE FAUCET BURN TESTS
 // ================================================================================================
 
-#[test]
-fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
     let tx_context = {
         let account = Account::mock_fungible_faucet(
             ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
@@ -395,8 +395,8 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
 }
 
 /// Tests that burning a fungible asset on a non-faucet account fails.
-#[test]
-fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+#[tokio::test]
+async fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let account = setup_non_faucet_account()?;
 
     let code = format!(
@@ -415,14 +415,14 @@ fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
         .build()?
-        .execute_blocking();
+        .execute().await;
     assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
     Ok(())
 }
 
-#[test]
-fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         Felt::try_from(FUNGIBLE_FAUCET_INITIAL_BALANCE).unwrap(),
@@ -452,8 +452,8 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),
@@ -487,8 +487,8 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
 // NON-FUNGIBLE FAUCET BURN TESTS
 // ================================================================================================
 
-#[test]
-fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     let tx_context =
         TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
             .build()?;
@@ -556,8 +556,8 @@ fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
     let tx_context =
         TransactionContextBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
             .build()?;
@@ -586,8 +586,8 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
 }
 
 /// Tests that burning a non-fungible asset on a non-faucet account fails.
-#[test]
-fn burn_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+#[tokio::test]
+async fn burn_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let account = setup_non_faucet_account()?;
 
     let code = format!(
@@ -606,14 +606,14 @@ fn burn_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
     let result = TransactionContextBuilder::new(account)
         .tx_script(tx_script)
         .build()?
-        .execute_blocking();
+        .execute().await;
     assert_transaction_executor_error!(result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
 
     Ok(())
 }
 
-#[test]
-fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
     let non_fungible_asset_burnt = NonFungibleAsset::mock(&[1, 2, 3]);
 
     // Run code from a different non-fungible asset issuer
@@ -646,8 +646,8 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
 // IS NON FUNGIBLE ASSET ISSUED TESTS
 // ================================================================================================
 
-#[test]
-fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
     // NON_FUNGIBLE_ASSET_DATA_2 is "issued" during the mock faucet creation, so it is already in
     // the map of issued assets.
     let tx_context =
@@ -691,8 +691,8 @@ fn test_is_non_fungible_asset_issued_succeeds() -> anyhow::Result<()> {
 // GET TOTAL ISSUANCE TESTS
 // ================================================================================================
 
-#[test]
-fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_total_issuance_succeeds() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_fungible_faucet(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         Felt::new(FUNGIBLE_FAUCET_INITIAL_BALANCE),

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -17,8 +17,8 @@ use crate::{Auth, MockChain};
 // ================================================================================================
 
 /// Tests that a simple wallet account can be created with non-zero fees.
-#[test]
-fn create_account_with_fees() -> anyhow::Result<()> {
+#[tokio::test]
+async fn create_account_with_fees() -> anyhow::Result<()> {
     let note_amount = 10_000;
 
     let mut builder = MockChain::builder().verification_base_fee(50);
@@ -29,7 +29,7 @@ fn create_account_with_fees() -> anyhow::Result<()> {
     let tx = chain
         .build_tx_context(account, &[fee_note.id()], &[])?
         .build()?
-        .execute_blocking()
+        .execute().await
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
@@ -53,8 +53,8 @@ fn create_account_with_fees() -> anyhow::Result<()> {
 
 /// Tests that the transaction executor host aborts the transaction if the balance of the native
 /// asset in the account does not cover the computed fee.
-#[test]
-fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> {
+#[tokio::test]
+async fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> {
     let account_amount = 100;
     let note_amount = 100;
     let native_asset_id = AccountId::try_from(ACCOUNT_ID_NATIVE_ASSET_FAUCET)?;
@@ -70,7 +70,7 @@ fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> 
     let err = chain
         .build_tx_context(account, &[fee_note.id()], &[])?
         .build()?
-        .execute_blocking()
+        .execute().await
         .unwrap_err();
 
     assert_matches!(
@@ -88,11 +88,11 @@ fn tx_host_aborts_if_account_balance_does_not_cover_fee() -> anyhow::Result<()> 
 ///
 /// TODO: Once smt::set supports multiple leaves, this case should be tested explicitly here.
 #[rstest::rstest]
-#[case::create_account_no_storage(create_account_no_storage_no_fees()?)]
-#[case::mutate_account_with_storage(mutate_account_with_storage()?)]
-#[case::create_output_notes(create_output_notes()?)]
-#[test]
-fn num_tx_cycles_after_compute_fee_are_less_than_estimated(
+#[case::create_account_no_storage(create_account_no_storage_no_fees().await.await?)]
+#[case::mutate_account_with_storage(mutate_account_with_storage().await.await?)]
+#[case::create_output_notes(create_output_notes().await.await?)]
+#[tokio::test]
+async fn num_tx_cycles_after_compute_fee_are_less_than_estimated(
     #[case] tx: ExecutedTransaction,
 ) -> anyhow::Result<()> {
     // These constants should always be updated together with the equivalent constants in
@@ -110,19 +110,19 @@ fn num_tx_cycles_after_compute_fee_are_less_than_estimated(
 }
 
 /// Returns a transaction that creates an account without storage and 0 fees.
-fn create_account_no_storage_no_fees() -> anyhow::Result<ExecutedTransaction> {
+async fn create_account_no_storage_no_fees().await -> anyhow::Result<ExecutedTransaction> {
     let mut builder = MockChain::builder();
     let account = builder.create_new_wallet(Auth::IncrNonce)?;
     builder
         .build()?
         .build_tx_context(account, &[], &[])?
         .build()?
-        .execute_blocking()
+        .execute().await
         .map_err(From::from)
 }
 
 /// Returns a transaction that mutates an account with storage and consumes a note.
-fn mutate_account_with_storage() -> anyhow::Result<ExecutedTransaction> {
+async fn mutate_account_with_storage().await.await -> anyhow::Result<ExecutedTransaction> {
     let native_asset_id = AccountId::try_from(ACCOUNT_ID_NATIVE_ASSET_FAUCET)?;
     let native_asset = FungibleAsset::new(native_asset_id, 10_000)?;
     let mut builder =
@@ -145,12 +145,12 @@ fn mutate_account_with_storage() -> anyhow::Result<ExecutedTransaction> {
         .build()?
         .build_tx_context(account, &[p2id_note.id()], &[])?
         .build()?
-        .execute_blocking()
+        .execute().await
         .map_err(From::from)
 }
 
 /// Returns a transaction that consumes two notes and creates two notes.
-fn create_output_notes() -> anyhow::Result<ExecutedTransaction> {
+async fn create_output_notes().await.await -> anyhow::Result<ExecutedTransaction> {
     let native_asset_id = AccountId::try_from(ACCOUNT_ID_NATIVE_ASSET_FAUCET)?;
     let native_asset = FungibleAsset::new(native_asset_id, 10_000)?;
     let mut builder =
@@ -186,6 +186,6 @@ fn create_output_notes() -> anyhow::Result<ExecutedTransaction> {
             OutputNote::Full(output_note1),
         ])
         .build()?
-        .execute_blocking()
+        .execute().await
         .map_err(From::from)
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
@@ -10,8 +10,8 @@ use crate::TxContextInput;
 /// Check that the assets number and assets commitment obtained from the
 /// `input_note::get_assets_info` procedure is correct for each note with zero, one and two
 /// different assets.
-#[test]
-fn test_get_asset_info() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_asset_info() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
@@ -88,15 +88,15 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
 
 /// Check that recipient and metadata of a note with one asset obtained from the
 /// `input_note::get_recipient` procedure is correct.
-#[test]
-fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
@@ -142,15 +142,15 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
 
 /// Check that the assets number and assets data obtained from the `input_note::get_assets`
 /// procedure is correct for each note with zero, one and two different assets.
-#[test]
-fn test_get_assets() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_assets() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
@@ -237,7 +237,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -52,8 +52,8 @@ use crate::{
     assert_transaction_executor_error,
 };
 
-#[test]
-fn test_get_sender_no_sender() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_sender_no_sender() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
     // calling get_sender should return sender
     let code = "
@@ -78,8 +78,8 @@ fn test_get_sender_no_sender() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_sender() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_sender() -> anyhow::Result<()> {
     let tx_context = {
         let account =
             Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, Auth::IncrNonce);
@@ -115,8 +115,8 @@ fn test_get_sender() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_vault_data() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_vault_data() -> anyhow::Result<()> {
     let tx_context = {
         let mut builder = MockChain::builder();
         let account = builder.add_existing_wallet(crate::Auth::BasicAuth)?;
@@ -188,8 +188,8 @@ fn test_get_vault_data() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_assets() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_assets() -> anyhow::Result<()> {
     // Creates a mockchain with an account and a note that it can consume
     let tx_context = {
         let mut builder = MockChain::builder();
@@ -325,8 +325,8 @@ fn test_get_assets() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_inputs() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_inputs() -> anyhow::Result<()> {
     // Creates a mockchain with an account and a note that it can consume
     let tx_context = {
         let mut builder = MockChain::builder();
@@ -415,8 +415,8 @@ fn test_get_inputs() -> anyhow::Result<()> {
 /// Previously this setup was leading to the incorrect number of note input values computed during
 /// the `get_inputs` procedure, see the
 /// [issue #1363](https://github.com/0xMiden/miden-base/issues/1363) for more details.
-#[test]
-fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
     let sender_id = ACCOUNT_ID_SENDER
         .try_into()
         .context("failed to convert ACCOUNT_ID_SENDER to account ID")?;
@@ -488,8 +488,8 @@ fn test_get_exactly_8_inputs() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_note_setup() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_note_setup() -> anyhow::Result<()> {
     let tx_context = {
         let mut builder = MockChain::builder();
         let account = builder.add_existing_wallet(Auth::BasicAuth)?;
@@ -530,8 +530,8 @@ fn test_note_setup() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_note_script_and_note_args() -> miette::Result<()> {
+#[tokio::test]
+async fn test_note_script_and_note_args() -> miette::Result<()> {
     let mut tx_context = {
         let mut builder = MockChain::builder();
         let account = builder.add_existing_wallet(Auth::BasicAuth).map_err(|err| miette!(err))?;
@@ -632,8 +632,8 @@ fn note_setup_memory_assertions(process: &Process) {
     );
 }
 
-#[test]
-fn test_get_note_serial_number() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_note_serial_number() -> anyhow::Result<()> {
     let tx_context = {
         let mut builder = MockChain::builder();
         let account = builder.add_existing_wallet(Auth::BasicAuth)?;
@@ -671,8 +671,8 @@ fn test_get_note_serial_number() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_inputs_hash() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_inputs_hash() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let code = "
@@ -768,8 +768,8 @@ fn test_get_inputs_hash() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_current_script_root() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_current_script_root() -> anyhow::Result<()> {
     let tx_context = {
         let mut builder = MockChain::builder();
         let account = builder.add_existing_wallet(Auth::BasicAuth)?;
@@ -807,8 +807,8 @@ fn test_get_current_script_root() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_build_note_metadata() -> miette::Result<()> {
+#[tokio::test]
+async fn test_build_note_metadata() -> miette::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
 
     let sender = tx_context.account().id();
@@ -872,8 +872,8 @@ fn test_build_note_metadata() -> miette::Result<()> {
 }
 
 /// This serves as a test that setting a custom timestamp on mock chain blocks works.
-#[test]
-pub fn test_timelock() -> anyhow::Result<()> {
+#[tokio::test]
+pub async fn test_timelock() -> anyhow::Result<()> {
     const TIMESTAMP_ERROR: MasmError = MasmError::from_static_str("123");
 
     let code = format!(
@@ -931,7 +931,7 @@ pub fn test_timelock() -> anyhow::Result<()> {
         .with_source_manager(source_manager.clone())
         .tx_inputs(tx_inputs.clone())
         .build()?;
-    let result = tx_context.execute_blocking();
+    let result = tx_context.execute().await;
     assert_transaction_executor_error!(result, TIMESTAMP_ERROR);
 
     // Consume note where lock timestamp matches the block timestamp.
@@ -943,7 +943,7 @@ pub fn test_timelock() -> anyhow::Result<()> {
     let tx_inputs =
         mock_chain.get_transaction_inputs(account.clone(), None, &[timelock_note.id()], &[])?;
     let tx_context = TransactionContextBuilder::new(account).tx_inputs(tx_inputs).build()?;
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
@@ -953,8 +953,8 @@ pub fn test_timelock() -> anyhow::Result<()> {
 ///
 /// Previously this setup was leading to the values collision in the advice map, see the
 /// [issue #1267](https://github.com/0xMiden/miden-base/issues/1267) for more details.
-#[test]
-fn test_public_key_as_note_input() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_public_key_as_note_input() -> anyhow::Result<()> {
     let mut rng = ChaCha20Rng::from_seed(Default::default());
     let sec_key = SecretKey::with_rng(&mut rng);
     // this value will be used both as public key in the RPO component of the target account and as
@@ -997,6 +997,6 @@ fn test_public_key_as_note_input() -> anyhow::Result<()> {
         .authenticator(authenticator)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -25,8 +25,8 @@ use crate::{Auth, MockChain};
 /// - Right after the previous check to make sure it returns the same commitment from the cached
 ///   data.
 /// - After adding the second `asset_1` to the note.
-#[test]
-fn test_get_asset_info() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_asset_info() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     let fungible_asset_0 = Asset::Fungible(
@@ -162,15 +162,15 @@ fn test_get_asset_info() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
 
 /// Check that recipient and metadata of a note with one asset obtained from the
 /// `output_note::get_recipient` procedure is correct.
-#[test]
-fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     let account =
@@ -235,15 +235,15 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
 
 /// Check that the assets number and assets data obtained from the `output_note::get_assets`
 /// procedure is correct for each note with zero, one and two different assets.
-#[test]
-fn test_get_assets() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_assets() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
@@ -342,7 +342,7 @@ fn test_get_assets() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -95,8 +95,8 @@ use crate::utils::{create_p2any_note, create_spawn_note};
 use crate::{Auth, MockChain, TransactionContextBuilder, assert_execution_error};
 
 /// Tests that executing a transaction with a foreign account whose inputs are stale fails.
-#[test]
-fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
+#[tokio::test]
+async fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
     // Create a chain with an account
     let mut builder = MockChain::builder();
     let native_account = builder.add_existing_wallet(Auth::IncrNonce)?;
@@ -114,7 +114,7 @@ fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
     let tx = mock_chain
         .build_tx_context(new_account, &[], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute().await?;
     mock_chain.add_pending_executed_transaction(&tx)?;
     mock_chain.prove_next_block()?;
 
@@ -124,7 +124,7 @@ fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])?
         .foreign_accounts(vec![inputs])
         .build()?
-        .execute_blocking();
+        .execute().await;
 
     assert_matches::assert_matches!(
         transaction,
@@ -188,8 +188,8 @@ async fn consuming_note_created_in_future_block_fails() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_create_note() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
     let account_id = tx_context.account().id();
 
@@ -261,8 +261,8 @@ fn test_create_note() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_create_note_with_invalid_tag() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note_with_invalid_tag() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let invalid_tag = Felt::new((NoteType::Public as u64) << 62);
@@ -305,8 +305,8 @@ fn note_creation_script(tag: Felt) -> String {
     )
 }
 
-#[test]
-fn test_create_note_too_many_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note_too_many_notes() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let code = format!(
@@ -343,8 +343,8 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_get_output_notes_commitment() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_get_output_notes_commitment() -> anyhow::Result<()> {
     let tx_context = {
         let account =
             Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, Auth::IncrNonce);
@@ -523,8 +523,8 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_create_note_and_add_asset() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note_and_add_asset() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?;
@@ -586,8 +586,8 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let faucet = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?;
@@ -680,8 +680,8 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let recipient = Word::from([0, 1, 2, 3u32]);
@@ -736,8 +736,8 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
 }
 
 /// Tests that creating a note with a fungible asset with amount zero works.
-#[test]
-fn creating_note_with_fungible_asset_amount_zero_works() -> anyhow::Result<()> {
+#[tokio::test]
+async fn creating_note_with_fungible_asset_amount_zero_works() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
     let output_note = builder.add_p2id_note(
@@ -752,13 +752,13 @@ fn creating_note_with_fungible_asset_amount_zero_works() -> anyhow::Result<()> {
     chain
         .build_tx_context(account, &[input_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute().await?;
 
     Ok(())
 }
 
-#[test]
-fn test_build_recipient_hash() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_build_recipient_hash() -> anyhow::Result<()> {
     let tx_context = {
         let account =
             Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, Auth::IncrNonce);
@@ -848,8 +848,8 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
 // BLOCK TESTS
 // ================================================================================================
 
-#[test]
-fn test_block_procedures() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_block_procedures() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     let code = "
@@ -990,8 +990,8 @@ async fn advice_inputs_from_transaction_witness_are_sufficient_to_reexecute_tran
     Ok(())
 }
 
-#[test]
-fn executed_transaction_output_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn executed_transaction_output_notes() -> anyhow::Result<()> {
     let executor_account =
         Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, IncrNonceAuthComponent);
     let account_id = executor_account.id();
@@ -1177,7 +1177,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
         ])
         .build()?;
 
-    let executed_transaction = tx_context.execute_blocking()?;
+    let executed_transaction = tx_context.execute().await?;
 
     // output notes
     // --------------------------------------------------------------------------------------------
@@ -1230,8 +1230,8 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
 /// Tests that a transaction consuming and creating one note can emit an abort event in its auth
 /// component to result in a [`TransactionExecutorError::Unauthorized`] error.
-#[test]
-fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
+#[tokio::test]
+async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let source_code = format!(
         "
       use.miden::auth
@@ -1296,7 +1296,7 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let input_notes = tx_context.input_notes().clone();
     let output_notes = OutputNotes::new(vec![OutputNote::Partial(output_note.into())])?;
 
-    let error = tx_context.execute_blocking().unwrap_err();
+    let error = tx_context.execute().await.unwrap_err();
 
     assert_matches!(error, TransactionExecutorError::Unauthorized(tx_summary) => {
         assert!(tx_summary.account_delta().vault().is_empty());
@@ -1314,8 +1314,8 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
 
 /// Tests that a transaction consuming and creating one note with basic authentication correctly
 /// signs the transaction summary.
-#[test]
-fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> {
+#[tokio::test]
+async fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let account = builder.add_existing_mock_account(Auth::BasicAuth)?;
     let mut rng = RpoRandomCoin::new(Word::empty());
@@ -1333,7 +1333,7 @@ fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> {
     let tx = chain
         .build_tx_context(account.id(), &[spawn_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute().await?;
 
     let summary = TransactionSummary::new(
         tx.account_delta().clone(),
@@ -1424,8 +1424,8 @@ async fn execute_tx_view_script() -> anyhow::Result<()> {
 // ================================================================================================
 
 /// Tests transaction script inputs.
-#[test]
-fn test_tx_script_inputs() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_tx_script_inputs() -> anyhow::Result<()> {
     let tx_script_input_key = Word::from([9999, 8888, 9999, 8888u32]);
     let tx_script_input_value = Word::from([9, 8, 7, 6u32]);
     let tx_script_src = format!(
@@ -1454,14 +1454,14 @@ fn test_tx_script_inputs() -> anyhow::Result<()> {
         .extend_advice_map([(tx_script_input_key, tx_script_input_value.to_vec())])
         .build()?;
 
-    tx_context.execute_blocking().context("failed to execute transaction")?;
+    tx_context.execute().await.context("failed to execute transaction")?;
 
     Ok(())
 }
 
 /// Tests transaction script arguments.
-#[test]
-fn test_tx_script_args() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_tx_script_args() -> anyhow::Result<()> {
     let tx_script_args = Word::from([1, 2, 3, 4u32]);
 
     let tx_script_src = r#"
@@ -1500,15 +1500,15 @@ fn test_tx_script_args() -> anyhow::Result<()> {
         .tx_script_args(tx_script_args)
         .build()?;
 
-    tx_context.execute_blocking()?;
+    tx_context.execute().await?;
 
     Ok(())
 }
 
 // Tests that advice map from the account code and transaction script gets correctly passed as
 // part of the transaction advice inputs
-#[test]
-fn inputs_created_correctly() -> anyhow::Result<()> {
+#[tokio::test]
+async fn inputs_created_correctly() -> anyhow::Result<()> {
     let account_code_script = r#"
             adv_map.A([6,7,8,9])=[10,11,12,13]
 
@@ -1572,7 +1572,7 @@ fn inputs_created_correctly() -> anyhow::Result<()> {
         Felt::new(1u64),
     );
     let tx_context = crate::TransactionContextBuilder::new(account).tx_script(tx_script).build()?;
-    _ = tx_context.execute_blocking()?;
+    _ = tx_context.execute().await?;
 
     Ok(())
 }

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -104,7 +104,7 @@ use crate::{MockChainBuilder, TransactionContextBuilder};
 /// // The target account is a new account so we move it into the build_tx_context, since the
 /// // chain's committed accounts do not yet contain it.
 /// let tx_context = mock_chain.build_tx_context(target, &[note.id()], &[])?.build()?;
-/// let executed_transaction = tx_context.execute_blocking()?;
+/// let executed_transaction = tx_context.execute().await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -141,7 +141,7 @@ use crate::{MockChainBuilder, TransactionContextBuilder};
 /// let transaction = mock_chain
 ///     .build_tx_context(receiver.id(), &[note.id()], &[])?
 ///     .build()?
-///     .execute_blocking()?;
+///     .execute().await?;
 ///
 /// // Add the transaction to the mock chain's "mempool" of pending transactions.
 /// mock_chain.add_pending_executed_transaction(&transaction);
@@ -1393,8 +1393,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn private_account_state_update() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn private_account_state_update() -> anyhow::Result<()> {
         let faucet_id = ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into()?;
         let account_builder = AccountBuilder::new([4; 32])
             .storage_mode(AccountStorageMode::Private)
@@ -1423,7 +1423,7 @@ mod tests {
         let tx = mock_chain
             .build_tx_context(TxContextInput::Account(account), &[], &[note_1])?
             .build()?
-            .execute_blocking()?;
+            .execute().await?;
 
         mock_chain.add_pending_executed_transaction(&tx)?;
         mock_chain.prove_next_block()?;
@@ -1437,8 +1437,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn mock_chain_serialization() {
+    #[tokio::test]
+    async fn mock_chain_serialization() {
         let mut builder = MockChain::builder();
 
         let mut notes = vec![];
@@ -1474,7 +1474,7 @@ mod tests {
                 .unwrap()
                 .build()
                 .unwrap()
-                .execute_blocking()
+                .execute().await
                 .unwrap();
             chain.add_pending_executed_transaction(&tx).unwrap();
             chain.prove_next_block().unwrap();

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -141,17 +141,7 @@ impl TransactionContext {
         tx_executor.execute_transaction(account_id, block_num, notes, tx_args).await
     }
 
-    /// Executes the transaction through a [TransactionExecutor]
-    ///
-    /// TODO: This is a temporary workaround to avoid having to update each test to use tokio::test.
-    /// Eventually we should get rid of this method and use tokio::test + execute, but for the POC
-    /// stage this is easier.
-    pub fn execute_blocking(self) -> Result<ExecutedTransaction, TransactionExecutorError> {
-        tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap()
-            .block_on(self.execute())
-    }
+
 
     pub fn account(&self) -> &Account {
         self.tx_inputs.account()

--- a/crates/miden-testing/tests/scripts/fee.rs
+++ b/crates/miden-testing/tests/scripts/fee.rs
@@ -14,8 +14,8 @@ use crate::prove_and_verify_transaction;
 /// This is an interesting test case because the prover needs to apply the fee asset to the account
 /// delta in order to prove the correct delta commitment. Once we have other tests with fees, this
 /// test may become obsolete.
-#[test]
-fn prove_account_creation_with_fees() -> anyhow::Result<()> {
+#[tokio::test]
+async fn prove_account_creation_with_fees() -> anyhow::Result<()> {
     let amount = 10_000;
     let mut builder = MockChain::builder().verification_base_fee(50);
     let account = builder.create_new_wallet(Auth::IncrNonce)?;
@@ -25,7 +25,8 @@ fn prove_account_creation_with_fees() -> anyhow::Result<()> {
     let tx = chain
         .build_tx_context(account, &[fee_note.id()], &[])?
         .build()?
-        .execute_blocking()
+        .execute()
+        .await
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -20,8 +20,8 @@ use crate::prove_and_verify_transaction;
 
 /// We test the Pay to script with 2 assets to test the loop inside the script.
 /// So we create a note containing two assets that can only be consumed by the target account.
-#[test]
-fn p2id_script_multiple_assets() -> anyhow::Result<()> {
+#[tokio::test]
+async fn p2id_script_multiple_assets() -> anyhow::Result<()> {
     // Create assets
     let fungible_asset_1: Asset = FungibleAsset::mock(123);
     let fungible_asset_2: Asset =
@@ -50,7 +50,8 @@ fn p2id_script_multiple_assets() -> anyhow::Result<()> {
     let executed_transaction = mock_chain
         .build_tx_context(target_account.id(), &[note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     // vault delta
     let target_account_after: Account = Account::from_parts(
@@ -74,7 +75,8 @@ fn p2id_script_multiple_assets() -> anyhow::Result<()> {
     let executed_transaction_2 = mock_chain
         .build_tx_context(malicious_account.id(), &[], &[note])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     // Check that we got the expected result - TransactionExecutorError
     assert_transaction_executor_error!(executed_transaction_2, ERR_P2ID_TARGET_ACCT_MISMATCH);
@@ -82,8 +84,8 @@ fn p2id_script_multiple_assets() -> anyhow::Result<()> {
 }
 
 /// Consumes an existing note with a new account
-#[test]
-fn prove_consume_note_with_new_account() -> anyhow::Result<()> {
+#[tokio::test]
+async fn prove_consume_note_with_new_account() -> anyhow::Result<()> {
     // Create assets
     let fungible_asset: Asset = FungibleAsset::mock(123);
 
@@ -110,7 +112,8 @@ fn prove_consume_note_with_new_account() -> anyhow::Result<()> {
     let executed_transaction = mock_chain
         .build_tx_context(target_account.clone(), &[note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     // Apply delta to the target account to verify it is no longer new
     let target_account_after: Account = Account::from_parts(
@@ -131,8 +134,8 @@ fn prove_consume_note_with_new_account() -> anyhow::Result<()> {
 
 /// Consumes two existing notes (with an asset from a faucet for a combined total of 123 tokens)
 /// with a basic account
-#[test]
-fn prove_consume_multiple_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn prove_consume_multiple_notes() -> anyhow::Result<()> {
     let fungible_asset_1: Asset = FungibleAsset::mock(100);
     let fungible_asset_2: Asset = FungibleAsset::mock(23);
 
@@ -157,7 +160,7 @@ fn prove_consume_multiple_notes() -> anyhow::Result<()> {
         .build_tx_context(account.id(), &[note_1.id(), note_2.id()], &[])?
         .build()?;
 
-    let executed_transaction = tx_context.execute_blocking()?;
+    let executed_transaction = tx_context.execute().await?;
 
     account.apply_delta(executed_transaction.account_delta())?;
     let resulting_asset = account.vault().assets().next().unwrap();
@@ -171,8 +174,8 @@ fn prove_consume_multiple_notes() -> anyhow::Result<()> {
 }
 
 /// Consumes two existing notes and creates two other notes in the same transaction
-#[test]
-fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     let mut account =
@@ -267,7 +270,7 @@ fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
         .tx_script(tx_script)
         .build()?;
 
-    let executed_transaction = tx_context.execute_blocking()?;
+    let executed_transaction = tx_context.execute().await?;
 
     assert_eq!(executed_transaction.output_notes().num_notes(), 2);
 

--- a/crates/miden-testing/tests/scripts/p2ide.rs
+++ b/crates/miden-testing/tests/scripts/p2ide.rs
@@ -15,8 +15,8 @@ use miden_objects::note::{Note, NoteType};
 use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 
 /// Test that the P2IDE note works like a regular P2ID note
-#[test]
-fn p2ide_script_success_without_reclaim_or_timelock() -> anyhow::Result<()> {
+#[tokio::test]
+async fn p2ide_script_success_without_reclaim_or_timelock() -> anyhow::Result<()> {
     let reclaim_height = None; // if 0, means it is not reclaimable
     let timelock_height = None; // if 0 means it is not timelocked
 
@@ -33,7 +33,8 @@ fn p2ide_script_success_without_reclaim_or_timelock() -> anyhow::Result<()> {
     let executed_transaction_1 = mock_chain
         .build_tx_context(malicious_account.id(), &[], slice::from_ref(&p2ide_note))?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(executed_transaction_1, ERR_P2IDE_RECLAIM_DISABLED);
 
@@ -41,7 +42,8 @@ fn p2ide_script_success_without_reclaim_or_timelock() -> anyhow::Result<()> {
     let executed_transaction_2 = mock_chain
         .build_tx_context(target_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let target_account_after: Account = Account::from_parts(
         target_account.id(),
@@ -59,8 +61,8 @@ fn p2ide_script_success_without_reclaim_or_timelock() -> anyhow::Result<()> {
 }
 
 /// Test that the P2IDE note can have a timelock that unlocks before the reclaim block height
-#[test]
-fn p2ide_script_success_timelock_unlock_before_reclaim_height() -> anyhow::Result<()> {
+#[tokio::test]
+async fn p2ide_script_success_timelock_unlock_before_reclaim_height() -> anyhow::Result<()> {
     let reclaim_height = Some(BlockNumber::from(5u32));
     let timelock_height = None;
 
@@ -78,7 +80,8 @@ fn p2ide_script_success_timelock_unlock_before_reclaim_height() -> anyhow::Resul
     let executed_transaction_1 = mock_chain
         .build_tx_context(target_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let target_account_after: Account = Account::from_parts(
         target_account.id(),
@@ -97,10 +100,10 @@ fn p2ide_script_success_timelock_unlock_before_reclaim_height() -> anyhow::Resul
 
 /// Test that the P2IDE note can have a timelock set and reclaim functionality
 /// disabled.
-#[test]
-fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
+#[tokio::test]
+async fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
     let reclaim_height = None;
-    let timelock_height = BlockNumber::from(5u32);
+    let timelock_height = Some(BlockNumber::from(5u32));
     let P2ideTestSetup {
         mut mock_chain,
         fungible_asset,
@@ -108,33 +111,35 @@ fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
         target_account,
         p2ide_note,
         ..
-    } = setup_p2ide_test(reclaim_height, Some(timelock_height))?;
+    } = setup_p2ide_test(reclaim_height, timelock_height)?;
 
     mock_chain.prove_until_block(10u32).context("failed to prove multiple blocks")?;
 
     // ───────────────────── reclaim attempt (sender) → FAIL ────────────
     let early_reclaim = mock_chain
         .build_tx_context_at(
-            timelock_height.as_u32() - 1,
+            timelock_height.unwrap().as_u32() - 1,
             sender_account.id(),
             &[p2ide_note.id()],
             &[],
         )?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_reclaim, ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED);
 
     // ───────────────────── early spend attempt (target)  → FAIL ─────────────
     let early_spend = mock_chain
         .build_tx_context_at(
-            timelock_height.as_u32() - 1,
+            timelock_height.unwrap().as_u32() - 1,
             target_account.id(),
             &[p2ide_note.id()],
             &[],
         )?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_spend, ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED);
 
@@ -142,7 +147,8 @@ fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
     let early_reclaim = mock_chain
         .build_tx_context(sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_reclaim, ERR_P2IDE_RECLAIM_DISABLED);
 
@@ -150,7 +156,8 @@ fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
     let final_tx = mock_chain
         .build_tx_context(target_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let target_after = Account::from_parts(
         target_account.id(),
@@ -169,10 +176,10 @@ fn p2ide_script_timelocked_reclaim_disabled() -> anyhow::Result<()> {
 /// before the timelock expires. Creating a P2IDE note with a reclaim block height that is
 /// less than the timelock block height would be the same as creating a P2IDE note
 /// where the reclaim block height is equal to the timelock block height
-#[test]
-fn p2ide_script_reclaim_fails_before_timelock_expiry() -> anyhow::Result<()> {
-    let reclaim_height = BlockNumber::from(1u32);
-    let timelock_height = BlockNumber::from(5u32);
+#[tokio::test]
+async fn p2ide_script_reclaim_fails_before_timelock_expiry() -> anyhow::Result<()> {
+    let reclaim_height = Some(BlockNumber::from(1u32));
+    let timelock_height = Some(BlockNumber::from(5u32));
 
     let P2ideTestSetup {
         mut mock_chain,
@@ -180,15 +187,16 @@ fn p2ide_script_reclaim_fails_before_timelock_expiry() -> anyhow::Result<()> {
         sender_account,
         p2ide_note,
         ..
-    } = setup_p2ide_test(Some(reclaim_height), Some(timelock_height))?;
+    } = setup_p2ide_test(reclaim_height, timelock_height)?;
 
-    mock_chain.prove_until_block(reclaim_height + 4)?;
+    mock_chain.prove_until_block(reclaim_height.unwrap() + 4)?;
 
     // CONSTRUCT AND EXECUTE TX (Failure - sender_account tries to reclaim)
     let executed_transaction_1 = mock_chain
         .build_tx_context_at(1, sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(
         executed_transaction_1,
@@ -197,9 +205,10 @@ fn p2ide_script_reclaim_fails_before_timelock_expiry() -> anyhow::Result<()> {
 
     // CONSTRUCT AND EXECUTE TX (Success - sender_account)
     let executed_transaction_2 = mock_chain
-        .build_tx_context_at(timelock_height, sender_account.id(), &[p2ide_note.id()], &[])?
+        .build_tx_context_at(timelock_height.unwrap(), sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let sender_account_after: Account = Account::from_parts(
         sender_account.id(),
@@ -218,10 +227,10 @@ fn p2ide_script_reclaim_fails_before_timelock_expiry() -> anyhow::Result<()> {
 }
 
 /// Test that the P2IDE note can have timelock and reclaim functionality
-#[test]
-fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
-    let reclaim_height = BlockNumber::from(10u32);
-    let timelock_height = BlockNumber::from(7u32);
+#[tokio::test]
+async fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
+    let reclaim_height = Some(BlockNumber::from(10u32));
+    let timelock_height = Some(BlockNumber::from(7u32));
 
     let P2ideTestSetup {
         mut mock_chain,
@@ -231,13 +240,14 @@ fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
         malicious_account,
         p2ide_note,
         ..
-    } = setup_p2ide_test(Some(reclaim_height), Some(timelock_height))?;
+    } = setup_p2ide_test(reclaim_height, timelock_height)?;
 
     // ───────────────────── early reclaim attempt (sender) → FAIL ────────────
     let early_reclaim = mock_chain
         .build_tx_context(sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_reclaim, ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED);
 
@@ -245,29 +255,32 @@ fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
     let early_spend = mock_chain
         .build_tx_context(target_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_spend, ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED);
 
     // ───────────────────── advance chain past timelock height ──────────────────────
-    mock_chain.prove_until_block(timelock_height + 1)?;
+    mock_chain.prove_until_block(timelock_height.unwrap() + 1)?;
 
     // ───────────────────── early reclaim attempt (sender) → FAIL ────────────
     let early_reclaim = mock_chain
         .build_tx_context(sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_reclaim, ERR_P2IDE_RECLAIM_HEIGHT_NOT_REACHED);
 
     // ───────────────────── advance chain past reclaim height ──────────────────────
-    mock_chain.prove_until_block(reclaim_height + 1)?;
+    mock_chain.prove_until_block(reclaim_height.unwrap() + 1)?;
 
     // CONSTRUCT AND EXECUTE TX (Failure - Malicious Account)
     let executed_transaction_1 = mock_chain
         .build_tx_context(malicious_account.id(), &[], slice::from_ref(&p2ide_note))?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(
         executed_transaction_1,
@@ -278,7 +291,8 @@ fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
     let final_tx = mock_chain
         .build_tx_context(target_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let target_after = Account::from_parts(
         target_account.id(),
@@ -294,10 +308,10 @@ fn p2ide_script_reclaimable_timelockable() -> anyhow::Result<()> {
 }
 
 /// Test that the P2IDE note can be reclaimed after timelock
-#[test]
-fn p2ide_script_reclaim_success_after_timelock() -> anyhow::Result<()> {
-    let reclaim_height = BlockNumber::from(5);
-    let timelock_height = BlockNumber::from(3);
+#[tokio::test]
+async fn p2ide_script_reclaim_success_after_timelock() -> anyhow::Result<()> {
+    let reclaim_height = Some(BlockNumber::from(5));
+    let timelock_height = Some(BlockNumber::from(3));
 
     let P2ideTestSetup {
         mut mock_chain,
@@ -305,24 +319,26 @@ fn p2ide_script_reclaim_success_after_timelock() -> anyhow::Result<()> {
         sender_account,
         p2ide_note,
         ..
-    } = setup_p2ide_test(Some(reclaim_height), Some(timelock_height))?;
+    } = setup_p2ide_test(reclaim_height, timelock_height)?;
 
     // ───────────────────── early reclaim attempt (sender) → FAIL ────────────
     let early_reclaim = mock_chain
         .build_tx_context(sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking();
+        .execute()
+        .await;
 
     assert_transaction_executor_error!(early_reclaim, ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED);
 
     // ───────────────────── advance chain past reclaim height ──────────────────────
-    mock_chain.prove_until_block(reclaim_height + 1)?;
+    mock_chain.prove_until_block(reclaim_height.unwrap() + 1)?;
 
     // ───────────────────── sender reclaims successfully ───────────────────────
     let final_tx = mock_chain
         .build_tx_context(sender_account.id(), &[p2ide_note.id()], &[])?
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     let sender_after = Account::from_parts(
         sender_account.id(),

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -24,8 +24,8 @@ use miden_testing::{Auth, MockChain};
 /// has the [`BasicWallet`][wallet] interface.
 ///
 /// [wallet]: miden_lib::account::interface::AccountComponentInterface::BasicWallet
-#[test]
-fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
     let sent_asset = FungibleAsset::mock(10);
 
     let mut builder = MockChain::builder();
@@ -64,7 +64,8 @@ fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         .tx_script(send_note_transaction_script)
         .extend_expected_output_notes(vec![OutputNote::Full(note)])
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
 
     // assert that the removed asset is in the delta
     let mut removed_assets: BTreeMap<_, _> = executed_transaction
@@ -87,8 +88,8 @@ fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
 /// has the [`BasicFungibleFaucet`][faucet] interface.
 ///
 /// [faucet]: miden_lib::account::interface::AccountComponentInterface::BasicFungibleFaucet
-#[test]
-fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let sender_basic_fungible_faucet_account =
         builder.add_existing_faucet(Auth::BasicAuth, "POL", 200, None)?;
@@ -127,6 +128,7 @@ fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
         .tx_script(send_note_transaction_script)
         .extend_expected_output_notes(vec![OutputNote::Full(note)])
         .build()?
-        .execute_blocking()?;
+        .execute()
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
- Remove `TransactionContext::execute_blocking` method completely
- Convert all tests to use `async TransactionContext::execute` with `#[tokio::test]`
- Move tokio dependency from main dependencies to dev-dependencies in miden-testing
- Update all test functions to be async and use .await properly
- Convert helper functions to async where needed
- Fix import paths and method calls throughout test suite