### PR TITLE
docs: fix multiple broken links across the repository

### DIFF
--- a/crates/miden-block-prover/README.md
+++ b/crates/miden-block-prover/README.md
@@ -4,4 +4,4 @@ This crate contains tools for executing and proving Miden blocks.
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).

--- a/crates/miden-lib/README.md
+++ b/crates/miden-lib/README.md
@@ -8,4 +8,4 @@ At this point, all implementations listed above are considered to be experimenta
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).

--- a/crates/miden-testing/README.md
+++ b/crates/miden-testing/README.md
@@ -4,4 +4,4 @@ This crate contains tool for testing Miden transactions, batches and blocks.
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).

--- a/crates/miden-tx-batch-prover/README.md
+++ b/crates/miden-tx-batch-prover/README.md
@@ -4,4 +4,4 @@ This crate contains tools for executing and proving Miden transaction batches.
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).

--- a/crates/miden-tx/README.md
+++ b/crates/miden-tx/README.md
@@ -42,4 +42,4 @@ verifier.verify(proven_transaction);
 
 ## License
 
-This project is [MIT licensed](../LICENSE).
+This project is [MIT licensed](../../LICENSE).


### PR DESCRIPTION
This PR updates incorrect relative links to the repository license file across
multiple crate READMEs. The previous paths resolved to non-existent locations
(404 on GitHub). Each link now points to the root-level `LICENSE`.

Affected files:
- crates/miden-block-prover/README.md
- crates/miden-lib/README.md
- crates/miden-testing/README.md
- crates/miden-tx-batch-prover/README.md
- crates/miden-tx/README.md