### PR TITLE
chore: rename `is_onchain` to `has_public_state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [BREAKING] Incremented MSRV to 1.89.
 - [BREAKING] Remove versioning of the transaction kernel, leaving only one latest version ([#1793](https://github.com/0xMiden/miden-base/pull/1793)).
+- [BREAKING] Rename the `is_onchain` method to `has_public_state` for `AccountId`, `AccountIdPrefix`, `Account`, `AccountInterface` and `AccountStorageMode` ([#1846](https://github.com/0xMiden/miden-base/pull/1846)).
 
 ## 0.11.1 (2025-08-28)
 

--- a/crates/miden-lib/src/account/interface/mod.rs
+++ b/crates/miden-lib/src/account/interface/mod.rs
@@ -79,12 +79,12 @@ impl AccountInterface {
         self.account_id.is_regular_account()
     }
 
-    /// Returns `true` if the full state of the account is on chain, i.e. if the modes are
+    /// Returns `true` if the full state of the account is public on chain, i.e. if the modes are
     /// [`AccountStorageMode::Public`](miden_objects::account::AccountStorageMode::Public) or
     /// [`AccountStorageMode::Network`](miden_objects::account::AccountStorageMode::Network),
     /// `false` otherwise.
-    pub fn is_onchain(&self) -> bool {
-        self.account_id.is_onchain()
+    pub fn has_public_state(&self) -> bool {
+        self.account_id.has_public_state()
     }
 
     /// Returns `true` if the reference account is a private account, `false` otherwise.

--- a/crates/miden-objects/src/account/account_id/id_prefix.rs
+++ b/crates/miden-objects/src/account/account_id/id_prefix.rs
@@ -119,10 +119,10 @@ impl AccountIdPrefix {
         }
     }
 
-    /// Returns `true` if the full state of the account is on chain, i.e. if the modes are
+    /// Returns `true` if the full state of the account is public on chain, i.e. if the modes are
     /// [`AccountStorageMode::Public`] or [`AccountStorageMode::Network`], `false` otherwise.
-    pub fn is_onchain(&self) -> bool {
-        self.storage_mode().is_onchain()
+    pub fn has_public_state(&self) -> bool {
+        self.storage_mode().has_public_state()
     }
 
     /// Returns `true` if the storage mode is [`AccountStorageMode::Public`], `false` otherwise.

--- a/crates/miden-objects/src/account/account_id/mod.rs
+++ b/crates/miden-objects/src/account/account_id/mod.rs
@@ -231,10 +231,10 @@ impl AccountId {
         }
     }
 
-    /// Returns `true` if the full state of the account is on chain, i.e. if the modes are
+    /// Returns `true` if the full state of the account is public on chain, i.e. if the modes are
     /// [`AccountStorageMode::Public`] or [`AccountStorageMode::Network`], `false` otherwise.
-    pub fn is_onchain(&self) -> bool {
-        self.storage_mode().is_onchain()
+    pub fn has_public_state(&self) -> bool {
+        self.storage_mode().has_public_state()
     }
 
     /// Returns `true` if the storage mode is [`AccountStorageMode::Public`], `false` otherwise.

--- a/crates/miden-objects/src/account/account_id/storage_mode.rs
+++ b/crates/miden-objects/src/account/account_id/storage_mode.rs
@@ -28,9 +28,9 @@ pub enum AccountStorageMode {
 }
 
 impl AccountStorageMode {
-    /// Returns `true` if the full state of the account is on chain, i.e. if the modes are
+    /// Returns `true` if the full state of the account is public on chain, i.e. if the modes are
     /// [`Self::Public`] or [`Self::Network`], `false` otherwise.
-    pub fn is_onchain(&self) -> bool {
+    pub fn has_public_state(&self) -> bool {
         matches!(self, Self::Public | Self::Network)
     }
 

--- a/crates/miden-objects/src/account/mod.rs
+++ b/crates/miden-objects/src/account/mod.rs
@@ -262,10 +262,10 @@ impl Account {
         self.id.is_regular_account()
     }
 
-    /// Returns `true` if the full state of the account is on chain, i.e. if the storage modes are
+    /// Returns `true` if the full state of the account is public on chain, i.e. if the modes are
     /// [`AccountStorageMode::Public`] or [`AccountStorageMode::Network`], `false` otherwise.
-    pub fn is_onchain(&self) -> bool {
-        self.id().is_onchain()
+    pub fn has_public_state(&self) -> bool {
+        self.id().has_public_state()
     }
 
     /// Returns `true` if the storage mode is [`AccountStorageMode::Public`], `false` otherwise.

--- a/crates/miden-objects/src/block/block_account_update.rs
+++ b/crates/miden-objects/src/block/block_account_update.rs
@@ -46,7 +46,7 @@ impl BlockAccountUpdate {
         self.final_state_commitment
     }
 
-    /// Returns the description of the updates for on-chain accounts.
+    /// Returns the description of the updates for accounts whose state is public on chain.
     ///
     /// These descriptions can be used to build the new account state from the previous account
     /// state.

--- a/crates/miden-objects/src/block/block_account_update.rs
+++ b/crates/miden-objects/src/block/block_account_update.rs
@@ -46,10 +46,9 @@ impl BlockAccountUpdate {
         self.final_state_commitment
     }
 
-    /// Returns the description of the updates for accounts whose state is public on chain.
+    /// Returns the account update details for this account update.
     ///
-    /// These descriptions can be used to build the new account state from the previous account
-    /// state.
+    /// These details can be used to build the new account state from the previous account state.
     pub fn details(&self) -> &AccountUpdateDetails {
         &self.details
     }

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -662,7 +662,7 @@ pub enum ProvenTransactionError {
     #[error(
         "existing account {0} with public state should only provide delta updates instead of full details"
     )]
-    ExistingPublicStateccountRequiresDeltaDetails(AccountId),
+    ExistingPublicStateAccountRequiresDeltaDetails(AccountId),
     #[error("failed to construct output notes for proven transaction")]
     OutputNotesError(TransactionOutputError),
     #[error(

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -655,14 +655,14 @@ pub enum ProvenTransactionError {
     InputNotesError(TransactionInputError),
     #[error("private account {0} should not have account details")]
     PrivateAccountWithDetails(AccountId),
-    #[error("on-chain account {0} is missing its account details")]
-    OnChainAccountMissingDetails(AccountId),
-    #[error("new on-chain account {0} is missing its account details")]
-    NewOnChainAccountRequiresFullDetails(AccountId),
+    #[error("account {0} with public state is missing its account details")]
+    PublicStateAccountMissingDetails(AccountId),
+    #[error("new account {0} with public state is missing its account details")]
+    NewPublicStateAccountRequiresFullDetails(AccountId),
     #[error(
-        "existing on-chain account {0} should only provide delta updates instead of full details"
+        "existing account {0} with public state should only provide delta updates instead of full details"
     )]
-    ExistingOnChainAccountRequiresDeltaDetails(AccountId),
+    ExistingPublicStateccountRequiresDeltaDetails(AccountId),
     #[error("failed to construct output notes for proven transaction")]
     OutputNotesError(TransactionOutputError),
     #[error(

--- a/crates/miden-objects/src/note/note_tag.rs
+++ b/crates/miden-objects/src/note/note_tag.rs
@@ -32,7 +32,7 @@ const LOCAL_ANY: u32 = 0xc000_0000;
 ///
 /// The execution hints are _not_ enforced, therefore function only as hints. For example, if a
 /// note's tag is created with the [NoteExecutionMode::Network], further validation is necessary to
-/// check the account_id is known, that the account's state is on-chain, and the account is
+/// check the account_id is known, that the account's state is public on chain, and the account is
 /// controlled by the network.
 ///
 /// The goal of the hint is to allow for a network node to quickly filter notes that are not

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -177,7 +177,7 @@ impl ProvenTransaction {
                 AccountUpdateDetails::New(account) => {
                     if !is_new_account {
                         return Err(
-                            ProvenTransactionError::ExistingPublicStateccountRequiresDeltaDetails(
+                            ProvenTransactionError::ExistingPublicStateAccountRequiresDeltaDetails(
                                 self.account_id(),
                             ),
                         );

--- a/crates/miden-objects/src/transaction/proven_tx.rs
+++ b/crates/miden-objects/src/transaction/proven_tx.rs
@@ -141,21 +141,21 @@ impl ProvenTransaction {
     /// - The size of the serialized account update exceeds [`ACCOUNT_UPDATE_MAX_SIZE`].
     /// - The transaction is empty, which is the case if the account state is unchanged or the
     ///   number of input notes is zero.
-    /// - The transaction was executed against a _new_ on-chain account and its account ID does not
-    ///   match the ID in the account update.
-    /// - The transaction was executed against a _new_ on-chain account and its commitment does not
-    ///   match the final state commitment of the account update.
+    /// - The transaction was executed against a _new_ account with public state and its account ID
+    ///   does not match the ID in the account update.
+    /// - The transaction was executed against a _new_ account with public state and its commitment
+    ///   does not match the final state commitment of the account update.
     /// - The transaction was executed against a private account and the account update is _not_ of
     ///   type [`AccountUpdateDetails::Private`].
-    /// - The transaction was executed against an on-chain account and the update is of type
-    ///   [`AccountUpdateDetails::Private`].
-    /// - The transaction was executed against an _existing_ on-chain account and the update is of
-    ///   type [`AccountUpdateDetails::New`].
-    /// - The transaction creates a _new_ on-chain account and the update is of type
+    /// - The transaction was executed against an account with public state and the update is of
+    ///   type [`AccountUpdateDetails::Private`].
+    /// - The transaction was executed against an _existing_ account with public state and the
+    ///   update is of type [`AccountUpdateDetails::New`].
+    /// - The transaction creates a _new_ account with public state and the update is of type
     ///   [`AccountUpdateDetails::Delta`].
     fn validate(self) -> Result<Self, ProvenTransactionError> {
-        // If the account is on-chain, then the account update details must be present.
-        if self.account_id().is_onchain() {
+        // If the account's state is public, then the account update details must be present.
+        if self.account_id().has_public_state() {
             self.account_update.validate()?;
 
             // check that either the account state was changed or at least one note was consumed,
@@ -170,14 +170,14 @@ impl ProvenTransaction {
             let is_new_account = self.account_update.initial_state_commitment() == Word::empty();
             match self.account_update.details() {
                 AccountUpdateDetails::Private => {
-                    return Err(ProvenTransactionError::OnChainAccountMissingDetails(
+                    return Err(ProvenTransactionError::PublicStateAccountMissingDetails(
                         self.account_id(),
                     ));
                 },
                 AccountUpdateDetails::New(account) => {
                     if !is_new_account {
                         return Err(
-                            ProvenTransactionError::ExistingOnChainAccountRequiresDeltaDetails(
+                            ProvenTransactionError::ExistingPublicStateccountRequiresDeltaDetails(
                                 self.account_id(),
                             ),
                         );
@@ -197,9 +197,11 @@ impl ProvenTransaction {
                 },
                 AccountUpdateDetails::Delta(_) => {
                     if is_new_account {
-                        return Err(ProvenTransactionError::NewOnChainAccountRequiresFullDetails(
-                            self.account_id(),
-                        ));
+                        return Err(
+                            ProvenTransactionError::NewPublicStateAccountRequiresFullDetails(
+                                self.account_id(),
+                            ),
+                        );
                     }
                 },
             }
@@ -380,17 +382,17 @@ impl ProvenTransactionBuilder {
     /// - The size of the serialized account update exceeds [`ACCOUNT_UPDATE_MAX_SIZE`].
     /// - The transaction is empty, which is the case if the account state is unchanged or the
     ///   number of input notes is zero.
-    /// - The transaction was executed against a _new_ on-chain account and its account ID does not
-    ///   match the ID in the account update.
-    /// - The transaction was executed against a _new_ on-chain account and its commitment does not
-    ///   match the final state commitment of the account update.
+    /// - The transaction was executed against a _new_ account with public state and its account ID
+    ///   does not match the ID in the account update.
+    /// - The transaction was executed against a _new_ account with public state and its commitment
+    ///   does not match the final state commitment of the account update.
     /// - The transaction was executed against a private account and the account update is _not_ of
     ///   type [`AccountUpdateDetails::Private`].
-    /// - The transaction was executed against an on-chain account and the update is of type
-    ///   [`AccountUpdateDetails::Private`].
-    /// - The transaction was executed against an _existing_ on-chain account and the update is of
-    ///   type [`AccountUpdateDetails::New`].
-    /// - The transaction creates a _new_ on-chain account and the update is of type
+    /// - The transaction was executed against an account with public state and the update is of
+    ///   type [`AccountUpdateDetails::Private`].
+    /// - The transaction was executed against an _existing_ account with public state and the
+    ///   update is of type [`AccountUpdateDetails::New`].
+    /// - The transaction creates a _new_ account with public state and the update is of type
     ///   [`AccountUpdateDetails::Delta`].
     pub fn build(self) -> Result<ProvenTransaction, ProvenTransactionError> {
         let input_notes =

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -84,8 +84,8 @@ impl LocalTransactionProver {
             .remove_asset(Asset::from(tx_outputs.fee))
             .map_err(TransactionProverError::RemoveFeeAssetFromDelta)?;
 
-        // If the account is on-chain, add the update details.
-        let builder = match account.is_onchain() {
+        // If the account's state is public, add the update details.
+        let builder = match account.has_public_state() {
             true => {
                 let account_update_details = if account.is_new() {
                     let mut account = account.clone();


### PR DESCRIPTION
Rename the `is_onchain` method to `has_public_state` for `AccountId`, `AccountIdPrefix`, `Account`, `AccountInterface` and `AccountStorageMode`, as discussed here: https://github.com/0xMiden/miden-base/pull/1840#discussion_r2317925648.

Note that we use on-chain fairly pervasively in docs, but I think the remaining occurrences are clear enough.