### PR TITLE
Move `miden::asset::{create_fungible_asset, create_non_fungible_asset}` to `miden::faucet`

### DIFF
--- a/crates/miden-lib/asm/miden/asset.masm
+++ b/crates/miden-lib/asm/miden/asset.masm
@@ -40,26 +40,6 @@ export.build_fungible_asset
     # => [ASSET]
 end
 
-#! Creates a fungible asset for the faucet the transaction is being executed against.
-#!
-#! Inputs:  [amount]
-#! Outputs: [ASSET]
-#!
-#! Where:
-#! - amount is the amount of the asset to create.
-#! - ASSET is the created fungible asset.
-#!
-#! Invocation: exec
-export.create_fungible_asset
-    # fetch the id of the faucet the transaction is being executed against.
-    exec.account::get_id
-    # => [id_prefix, id_suffix, amount]
-
-    # build the fungible asset
-    exec.build_fungible_asset
-    # => [ASSET]
-end
-
 #! Builds a non fungible asset for the specified non-fungible faucet and amount.
 #!
 #! Inputs:  [faucet_id_prefix, DATA_HASH]
@@ -81,26 +61,6 @@ export.build_non_fungible_asset
     # build the asset
     swap drop
     # => [faucet_id_prefix, hash2, hash1, hash0]
-    # => [ASSET]
-end
-
-#! Creates a non-fungible asset for the faucet the transaction is being executed against.
-#!
-#! Inputs:  [DATA_HASH]
-#! Outputs: [ASSET]
-#!
-#! Where:
-#! - DATA_HASH is the data hash of the non-fungible asset to create.
-#! - ASSET is the created non-fungible asset.
-#!
-#! Invocation: exec
-export.create_non_fungible_asset
-    # get the id of the faucet the transaction is being executed against
-    exec.account::get_id swap drop
-    # => [faucet_id_prefix, DATA_HASH]
-
-    # build the non-fungible asset
-    exec.build_non_fungible_asset
     # => [ASSET]
 end
 

--- a/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
+++ b/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
@@ -8,7 +8,6 @@
 # - decimals are the decimals of the token.
 # - token_symbol as three chars encoded in a Felt.
 use.miden::account
-use.miden::asset
 use.miden::faucet
 use.miden::tx
 use.miden::contracts::auth::basic
@@ -69,7 +68,7 @@ export.distribute.4
     # => [amount, tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
 
     # creating the asset
-    exec.asset::create_fungible_asset
+    exec.faucet::create_fungible_asset
     # => [ASSET, tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
 
     # mint the asset; this is needed to satisfy asset preservation logic.

--- a/crates/miden-lib/asm/miden/faucet.masm
+++ b/crates/miden-lib/asm/miden/faucet.masm
@@ -1,4 +1,46 @@
+use.miden::asset
+use.miden::account
 use.miden::kernel_proc_offsets
+
+#! Creates a fungible asset for the faucet the transaction is being executed against.
+#!
+#! Inputs:  [amount]
+#! Outputs: [ASSET]
+#!
+#! Where:
+#! - amount is the amount of the asset to create.
+#! - ASSET is the created fungible asset.
+#!
+#! Invocation: exec
+export.create_fungible_asset
+    # fetch the id of the faucet the transaction is being executed against.
+    exec.account::get_id
+    # => [id_prefix, id_suffix, amount]
+
+    # build the fungible asset
+    exec.asset::build_fungible_asset
+    # => [ASSET]
+end
+
+#! Creates a non-fungible asset for the faucet the transaction is being executed against.
+#!
+#! Inputs:  [DATA_HASH]
+#! Outputs: [ASSET]
+#!
+#! Where:
+#! - DATA_HASH is the data hash of the non-fungible asset to create.
+#! - ASSET is the created non-fungible asset.
+#!
+#! Invocation: exec
+export.create_non_fungible_asset
+    # get the id of the faucet the transaction is being executed against
+    exec.account::get_id swap drop
+    # => [faucet_id_prefix, DATA_HASH]
+
+    # build the non-fungible asset
+    exec.asset::build_non_fungible_asset
+    # => [ASSET]
+end
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -21,14 +21,14 @@ fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {
     let code = format!(
         "
         use.$kernel::prologue
-        use.miden::asset
+        use.miden::faucet
 
         begin
             exec.prologue::prepare_transaction
 
             # create fungible asset
             push.{FUNGIBLE_ASSET_AMOUNT}
-            exec.asset::create_fungible_asset
+            exec.faucet::create_fungible_asset
 
             # truncate the stack
             swapw dropw
@@ -62,14 +62,14 @@ fn test_create_non_fungible_asset_succeeds() -> anyhow::Result<()> {
     let code = format!(
         "
         use.$kernel::prologue
-        use.miden::asset
+        use.miden::faucet
 
         begin
             exec.prologue::prepare_transaction
 
             # push non-fungible asset data hash onto the stack
             push.{non_fungible_asset_data_hash}
-            exec.asset::create_non_fungible_asset
+            exec.faucet::create_non_fungible_asset
 
             # truncate the stack
             swapw dropw


### PR DESCRIPTION
This tiny PR moves two `miden::asset::create_fungible_asset` and `miden::asset::create_non_fungible_asset` procedures to the `miden::faucet` module.

TODO:
- [ ] Update the kernel procedures table.

Closes: #1830.