### PR TITLE
feat: load the initial fee asset lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `add_signature` helper to simplify loading signatures into advice map ([#1725](https://github.com/0xMiden/miden-base/pull/1725)).
 - Enable lazy loading of assets during transaction execution ([#1848](https://github.com/0xMiden/miden-base/pull/1848)).
 - Added `get_native_id` and `get_native_nonce` procedures to the `miden` library ([#1844](https://github.com/0xMiden/miden-base/pull/1844)).
+- Lazy load the native asset ([#1855](https://github.com/0xMiden/miden-base/pull/1855)).
 - Added `prove_dummy` APIs on `LocalBatchProver` and `LocalBlockProver` ([#1811](https://github.com/0xMiden/miden-base/pull/1811)).
 
 ### Changes

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -25,7 +25,7 @@ const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been call
 const.EPILOGUE_AFTER_TX_CYCLES_OBTAINED=131097
 
 # Event emitted to signal that the fee was computed.
-const.EPILOGUE_TX_FEE_COMPUTED=131098
+const.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT=131098
 
 # An additional number of cyclces to account for the number of cycles that smt::set will take when
 # removing the computed fee from the asset vault.
@@ -307,7 +307,7 @@ proc.compute_and_remove_fee
     exec.build_native_fee_asset
     # => [FEE_ASSET]
 
-    emit.EPILOGUE_TX_FEE_COMPUTED
+    emit.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT
     # => [FEE_ASSET]
 
     # remove the fee from the native account's vault

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -47,7 +47,7 @@ const TX_SCRIPT_PROCESSING_END: u32 = 0x2_0017; // 131095
 
 const EPILOGUE_START: u32 = 0x2_0018; // 131096
 const EPILOGUE_TX_CYCLES_OBTAINED: u32 = 0x2_0019; // 131097
-const EPILOGUE_TX_FEE_COMPUTED: u32 = 0x2_001a; // 131098
+const EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT: u32 = 0x2_001a; // 131098
 const EPILOGUE_END: u32 = 0x2_001b; // 131099
 
 const LINK_MAP_SET_EVENT: u32 = 0x2_001c; // 131100
@@ -104,7 +104,7 @@ pub enum TransactionEvent {
 
     EpilogueStart = EPILOGUE_START,
     EpilogueTxCyclesObtained = EPILOGUE_TX_CYCLES_OBTAINED,
-    EpilogueTxFeeComputed = EPILOGUE_TX_FEE_COMPUTED,
+    EpilogueBeforeTxFeeRemovedFromAccount = EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT,
     EpilogueEnd = EPILOGUE_END,
 
     LinkMapSetEvent = LINK_MAP_SET_EVENT,
@@ -185,7 +185,9 @@ impl TryFrom<u32> for TransactionEvent {
 
             EPILOGUE_START => Ok(TransactionEvent::EpilogueStart),
             EPILOGUE_TX_CYCLES_OBTAINED => Ok(TransactionEvent::EpilogueTxCyclesObtained),
-            EPILOGUE_TX_FEE_COMPUTED => Ok(TransactionEvent::EpilogueTxFeeComputed),
+            EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT => {
+                Ok(TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount)
+            },
             EPILOGUE_END => Ok(TransactionEvent::EpilogueEnd),
 
             LINK_MAP_SET_EVENT => Ok(TransactionEvent::LinkMapSetEvent),

--- a/crates/miden-objects/src/asset/vault/asset_witness.rs
+++ b/crates/miden-objects/src/asset/vault/asset_witness.rs
@@ -39,6 +39,14 @@ impl AssetWitness {
         Self(smt_proof)
     }
 
+    /// Returns the assets in this witness.
+    pub fn assets(&self) -> impl Iterator<Item = Asset> {
+        // Check if we can avoid cloning the vector.
+        self.0.leaf().entries().to_vec().into_iter().map(|(_key, value)| {
+            Asset::try_from(value).expect("asset witness should track valid assets")
+        })
+    }
+
     /// Returns an iterator over every inner node of this witness' merkle path.
     pub fn authenticated_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
         self.0

--- a/crates/miden-objects/src/asset/vault/asset_witness.rs
+++ b/crates/miden-objects/src/asset/vault/asset_witness.rs
@@ -10,6 +10,9 @@ use crate::{AssetError, Word};
 pub struct AssetWitness(SmtProof);
 
 impl AssetWitness {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
     /// Creates a new [`AssetWitness`] from an SMT proof.
     ///
     /// # Errors
@@ -38,6 +41,9 @@ impl AssetWitness {
     pub fn new_unchecked(smt_proof: SmtProof) -> Self {
         Self(smt_proof)
     }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
 
     /// Searches for an [`Asset`] in the witness with the given `vault_key`.
     pub fn find(&self, vault_key: Word) -> Option<Asset> {

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -138,6 +138,9 @@ fn removing_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
 
 /// Tests that a transaction against an account with a non-empty vault successfully loads the fee
 /// asset during the epilogue.
+///
+/// The non-empty vault is important for the test because the advice provider's merkle store has all
+/// merkle paths for an empty vault by default, and so there would be nothing to load.
 #[test]
 fn loading_fee_asset_succeeds() -> anyhow::Result<()> {
     let mut builder =

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -7,13 +7,14 @@ use miden_lib::utils::ScriptBuilder;
 use miden_objects::account::AccountId;
 use miden_objects::asset::{Asset, FungibleAsset};
 use miden_objects::testing::account_id::{
+    ACCOUNT_ID_NATIVE_ASSET_FAUCET,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
 };
 use miden_objects::testing::constants::FUNGIBLE_ASSET_AMOUNT;
 
 use super::Word;
-use crate::{MockChain, TransactionContextBuilder};
+use crate::{Auth, MockChain, TransactionContextBuilder};
 
 /// Tests that adding two different assets to the account vault succeeds when lazy loading is
 /// enabled.
@@ -131,6 +132,29 @@ fn removing_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
     account_vault.remove_asset(fungible_asset2.into())?;
 
     assert_eq!(tx.final_account().vault_root(), account_vault.root());
+
+    Ok(())
+}
+
+/// Tests that a transaction against an account with a non-empty vault successfully loads the fee
+/// asset during the epilogue.
+#[test]
+fn loading_fee_asset_succeeds() -> anyhow::Result<()> {
+    let mut builder =
+        MockChain::builder().native_asset_id(ACCOUNT_ID_NATIVE_ASSET_FAUCET.try_into()?);
+    let account = builder.add_existing_mock_account_with_assets(
+        Auth::IncrNonce,
+        [
+            FungibleAsset::mock(23),
+            FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?, 50)?.into(),
+        ],
+    )?;
+    builder
+        .build()?
+        .build_tx_context(account, &[], &[])?
+        .enable_partial_loading()
+        .build()?
+        .execute_blocking()?;
 
     Ok(())
 }

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -309,7 +309,6 @@ where
             script_mast_store,
             acct_procedure_index_map,
             self.authenticator,
-            tx_inputs.block_header().fee_parameters(),
             self.source_manager.clone(),
         );
 

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -288,7 +288,7 @@ where
                 self.tx_progress.epilogue_after_tx_cycles_obtained(process.clk());
                 Ok(TransactionEventHandling::Handled(vec![]))
             }
-            TransactionEvent::EpilogueTxFeeComputed => self.on_tx_fee_computed(process),
+            TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount => self.on_before_tx_fee_removed_from_account(process),
             TransactionEvent::EpilogueEnd => {
                 self.tx_progress.end_epilogue(process.clk());
                 Ok(TransactionEventHandling::Handled(Vec::new()))
@@ -385,14 +385,15 @@ where
         TransactionKernelError::Unauthorized(Box::new(tx_summary))
     }
 
-    /// Extracts all necessary data to handle [`TransactionEvent::EpilogueTxFeeComputed`].
+    /// Extracts all necessary data to handle
+    /// [`TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount`].
     ///
     /// Expected stack state:
     ///
     /// ```text
     /// [FEE_ASSET]
     /// ```
-    fn on_tx_fee_computed(
+    fn on_before_tx_fee_removed_from_account(
         &self,
         process: &ProcessState,
     ) -> Result<TransactionEventHandling, TransactionKernelError> {


### PR DESCRIPTION
Loads the initial native asset of the native account lazily and removes the assumption that the partial vault tracks all assets of the account.

While working on lazy storage map item loading, tests were failing under certain conditions when lazy loading was enabled, so it had to be done now.

This currently always goes to the data store to fetch the initial state of the asset. Ideally, there would be a way to check the advice provider first and only go to the store if it's not present, but I'm not sure how to do it.

closes https://github.com/0xMiden/miden-base/issues/1754