### PR TITLE
chore: apply changes from 1866 to next

### DIFF
--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -127,6 +127,9 @@ impl LocalTransactionProver {
                 .map_err(TransactionProverError::ConflictingAdviceMapEntry)?;
 
         self.mast_store.load_account_code(tx_inputs.account().code());
+        for account_inputs in tx_args.foreign_account_inputs() {
+            self.mast_store.load_account_code(account_inputs.code());
+        }
 
         let script_mast_store = ScriptMastForestStore::new(
             tx_args.tx_script(),


### PR DESCRIPTION
Apply changes from #1866 to `next` where the `test_nested_fpi_cyclic_invocation` is currently failing.