### PR TITLE
feat: load foreign accounts lazily on first access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `prove_dummy` APIs on `LocalBatchProver` and `LocalBlockProver` ([#1811](https://github.com/0xMiden/miden-base/pull/1811)).
 - Added `get_native_id` and `get_native_nonce` procedures to the `miden` library ([#1844](https://github.com/0xMiden/miden-base/pull/1844)).
 - Enabled lazy loading of assets during transaction execution ([#1848](https://github.com/0xMiden/miden-base/pull/1848)).
+- [BREAKING] Enabled lazy loading of foreign accounts during transaction execution ([#1873](https://github.com/0xMiden/miden-base/pull/1873)).
 - Added lazy loading of the native asset ([#1855](https://github.com/0xMiden/miden-base/pull/1855)).
 - Added `build_recipient` procedure to `miden::note` module ([#1807](https://github.com/0xMiden/miden-base/pull/1807)).
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1310,50 +1310,8 @@ export.tx_start_foreign_context
         exec.memory::push_ptr_to_account_stack
         # OS => [foreign_account_id_prefix, foreign_account_id_suffix, pad(14)]
 
-        # construct the word with account ID to load the core account data from the advice map
-        push.0.0
-        # OS => [0, 0, foreign_account_id_prefix, foreign_account_id_suffix, pad(14)]
-
-        # move the core account data to the advice stack
-        adv.push_mapval
-        # OS => [0, 0, foreign_account_id_prefix, foreign_account_id_suffix, pad(14)]
-        # AS => [[foreign_account_id_prefix, foreign_account_id_suffix, 0, account_nonce], VAULT_ROOT, STORAGE_ROOT, CODE_ROOT]
-
-        # store the id and nonce of the foreign account to the memory
-        dropw adv_loadw
-        exec.memory::set_account_id_and_nonce dropw
-        # OS => [pad(16)]
-        # AS => [VAULT_ROOT, STORAGE_ROOT, CODE_ROOT]
-
-        # store the vault root of the foreign account to the memory
-        adv_loadw exec.memory::set_account_vault_root dropw
-        # OS => [pad(16)]
-        # AS => [STORAGE_ROOT, CODE_ROOT]
-
-        # move the storage root and the code root to the operand stack
-        adv_loadw padw adv_loadw
-        # OS => [CODE_ROOT, STORAGE_ROOT, pad(16)]
-        # AS => []
-
-        # store the code root into the memory
-        exec.memory::set_account_code_commitment
-        # OS => [CODE_ROOT, STORAGE_ROOT, pad(16)]
-        # AS => []
-
-        # save the account procedure data into the memory
-        exec.account::save_account_procedure_data
-        # OS => [STORAGE_ROOT, pad(16)]
-        # AS => []
-
-        # store the storage root to the memory
-        exec.memory::set_account_storage_commitment
-        # OS => [STORAGE_ROOT, pad(16)]
-        # AS => []
-
-        # save the storage slots data into the memory
-        exec.account::save_account_storage_data
-        # OS => [pad(16)]
-        # AS => []
+        # load the advice data into the current account memory section
+        exec.account::load_from_advice
     end
 
     # make sure that the state of the loaded foreign account corresponds to this commitment in the

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1311,7 +1311,7 @@ export.tx_start_foreign_context
         # OS => [foreign_account_id_prefix, foreign_account_id_suffix, pad(14)]
 
         # load the advice data into the current account memory section
-        exec.account::load_from_advice
+        exec.account::load_foreign_account
     end
 
     # make sure that the state of the loaded foreign account corresponds to this commitment in the

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -929,10 +929,10 @@ end
 #! Inputs:
 #!   Operand stack: [account_id_prefix, account_id_suffix]
 #!   Advice map: {
-#!     ACCOUNT_ID: [[account_id_suffix, account_id_prefix, 0, account_nonce],
-#!                          VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT],
+#!     ACCOUNT_ID: [[account_id_suffix, account_id_prefix, 0, account_nonce]],
+#!                   VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT],
 #!     STORAGE_COMMITMENT: [[STORAGE_SLOT_DATA]],
-#!     CODE_COMMITMENT: [num_procs, [ACCOUNT_PROCEDURE_DATA]]
+#!     CODE_COMMITMENT: [[ACCOUNT_PROCEDURE_DATA]],
 #!   }
 #! Outputs:
 #!   Operand stack: []
@@ -969,13 +969,13 @@ export.load_foreign_account
     # AS => [[account_id_prefix, account_id_suffix, 0, account_nonce], VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
 
     # store the id and nonce of the foreign account to the memory
-    dropw adv_loadw
-    exec.memory::set_account_id_and_nonce dropw
+    adv_loadw
+    exec.memory::set_account_id_and_nonce
     # OS => []
     # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
 
     # store the vault root of the foreign account to the memory
-    adv_loadw exec.memory::set_account_vault_root dropw
+    adv_loadw exec.memory::set_account_vault_root
     # OS => []
     # AS => [STORAGE_COMMITMENT, CODE_COMMITMENT]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -5,7 +5,6 @@ use.std::mem
 
 use.$kernel::account_id
 use.$kernel::asset_vault
-use.$kernel::asset
 use.$kernel::account_delta
 use.$kernel::constants
 use.$kernel::memory
@@ -121,6 +120,9 @@ const.ACCOUNT_PROCEDURE_DATA_LENGTH=8
 
 # EVENTS
 # =================================================================================================
+
+# Event emitted before an account is loaded from the advice inputs.
+const.ACCOUNT_BEFORE_LOAD=131104
 
 # Event emitted before an asset is added to the account vault.
 const.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=131072
@@ -954,6 +956,9 @@ end
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
 export.load_from_advice
+    emit.ACCOUNT_BEFORE_LOAD
+    # => [account_id_prefix, account_id_suffix]
+
     # construct the word with account ID to load the core account data from the advice map
     push.0.0
     # OS => [0, 0, account_id_prefix, account_id_suffix]

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -121,8 +121,8 @@ const.ACCOUNT_PROCEDURE_DATA_LENGTH=8
 # EVENTS
 # =================================================================================================
 
-# Event emitted before an account is loaded from the advice inputs.
-const.ACCOUNT_BEFORE_LOAD=131104
+# Event emitted before a foreign account is loaded from the advice inputs.
+const.ACCOUNT_BEFORE_LOAD_FOREIGN=131104
 
 # Event emitted before an asset is added to the account vault.
 const.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=131072
@@ -955,8 +955,8 @@ end
 #! - the computed account code commitment does not match the provided account code commitment.
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
-export.load_from_advice
-    emit.ACCOUNT_BEFORE_LOAD
+export.load_foreign_account
+    emit.ACCOUNT_BEFORE_LOAD_FOREIGN
     # => [account_id_prefix, account_id_suffix]
 
     # construct the word with account ID to load the core account data from the advice map

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -922,6 +922,84 @@ end
 # DATA LOADERS
 # =================================================================================================
 
+#! Loads account data from the advice inputs into the _current_ account's memory section.
+#!
+#! Inputs:
+#!   Operand stack: [account_id_prefix, account_id_suffix]
+#!   Advice map: {
+#!     ACCOUNT_ID: [[account_id_suffix, account_id_prefix, 0, account_nonce],
+#!                          VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT],
+#!     STORAGE_COMMITMENT: [[STORAGE_SLOT_DATA]],
+#!     CODE_COMMITMENT: [num_procs, [ACCOUNT_PROCEDURE_DATA]]
+#!   }
+#! Outputs:
+#!   Operand stack: []
+#!
+#! Where:
+#! - account_id_{prefix,suffix} are the prefix and suffix felts of the ID of the account.
+#! - ACCOUNT_ID is the word constructed from the account_id as follows:
+#!   [account_id_suffix, account_id_prefix, 0, 0].
+#! - account_nonce is the nonce of the account.
+#! - VAULT_ROOT is the commitment of the account's vault.
+#! - STORAGE_COMMITMENT is the commitment to the account's storage.
+#! - STORAGE_SLOT_DATA is the data contained in the storage slot which is constructed as follows:
+#!   [SLOT_VALUE, slot_type, 0, 0, 0].
+#! - CODE_COMMITMENT is the commitment to the account's code.
+#! - ACCOUNT_PROCEDURE_DATA is the information about account procedures which is constructed as
+#!   follows: [PROCEDURE_MAST_ROOT, storage_offset, 0, 0, 0].
+#!
+#! Panics if:
+#! - the number of account procedures exceeded the maximum limit of 256.
+#! - the computed account code commitment does not match the provided account code commitment.
+#! - the number of account storage slots exceeded the maximum limit of 255.
+#! - the computed account storage commitment does not match the provided account storage commitment.
+export.load_from_advice
+    # construct the word with account ID to load the core account data from the advice map
+    push.0.0
+    # OS => [0, 0, account_id_prefix, account_id_suffix]
+
+    # move the core account data to the advice stack
+    adv.push_mapval
+    # OS => [0, 0, account_id_prefix, account_id_suffix]
+    # AS => [[account_id_prefix, account_id_suffix, 0, account_nonce], VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    # store the id and nonce of the foreign account to the memory
+    dropw adv_loadw
+    exec.memory::set_account_id_and_nonce dropw
+    # OS => []
+    # AS => [VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    # store the vault root of the foreign account to the memory
+    adv_loadw exec.memory::set_account_vault_root dropw
+    # OS => []
+    # AS => [STORAGE_COMMITMENT, CODE_COMMITMENT]
+
+    # move the storage root and the code root to the operand stack
+    adv_loadw padw adv_loadw
+    # OS => [CODE_COMMITMENT, STORAGE_COMMITMENT]
+    # AS => []
+
+    # store the code root into the memory
+    exec.memory::set_account_code_commitment
+    # OS => [CODE_COMMITMENT, STORAGE_COMMITMENT]
+    # AS => []
+
+    # save the account procedure data into the memory
+    exec.save_account_procedure_data
+    # OS => [STORAGE_COMMITMENT]
+    # AS => []
+
+    # store the storage root to the memory
+    exec.memory::set_account_storage_commitment
+    # OS => [STORAGE_COMMITMENT]
+    # AS => []
+
+    # save the storage slots data into the memory
+    exec.save_account_storage_data
+    # OS => []
+    # AS => []
+end
+
 #! Saves storage slots data into memory and validates that the storage commitment matches the
 #! sequential storage hash.
 #!
@@ -940,7 +1018,7 @@ end
 #!
 #! Panics if:
 #! - the number of account storage slots exceeded the maximum limit of 255.
-#! - the computed account storage commitment does not match the provided account storage commitment
+#! - the computed account storage commitment does not match the provided account storage commitment.
 export.save_account_storage_data
     # move storage slot data from the advice map to the advice stack
     adv.push_mapvaln
@@ -1013,8 +1091,8 @@ end
 #!   follows: [PROCEDURE_MAST_ROOT, storage_offset, storage_size, 0, 0]
 #!
 #! Panics if:
-#! - the number of account procedures exceeded the maximum limit of 256
-#! - the computed account code commitment does not match the provided account code commitment
+#! - the number of account procedures exceeded the maximum limit of 256.
+#! - the computed account code commitment does not match the provided account code commitment.
 export.save_account_procedure_data
     # move procedure data from the advice map to the advice stack
     adv.push_mapvaln

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -122,7 +122,7 @@ const.ACCOUNT_PROCEDURE_DATA_LENGTH=8
 # =================================================================================================
 
 # Event emitted before a foreign account is loaded from the advice inputs.
-const.ACCOUNT_BEFORE_LOAD_FOREIGN=131104
+const.ACCOUNT_BEFORE_FOREIGN_LOAD=131104
 
 # Event emitted before an asset is added to the account vault.
 const.ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT=131072
@@ -956,7 +956,7 @@ end
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
 export.load_foreign_account
-    emit.ACCOUNT_BEFORE_LOAD_FOREIGN
+    emit.ACCOUNT_BEFORE_FOREIGN_LOAD
     # => [account_id_prefix, account_id_suffix]
 
     # construct the word with account ID to load the core account data from the advice map

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -8,7 +8,7 @@ use super::TransactionEventError;
 // TRANSACTION EVENT
 // ================================================================================================
 
-const ACCOUNT_BEFORE_LOAD_FOREIGN: u32 = 0x2_0020; // 131104
+const ACCOUNT_BEFORE_FOREIGN_LOAD: u32 = 0x2_0020; // 131104
 
 const ACCOUNT_VAULT_BEFORE_ADD_ASSET: u32 = 0x2_0000; // 131072
 const ACCOUNT_VAULT_AFTER_ADD_ASSET: u32 = 0x2_0001; // 131073
@@ -69,7 +69,7 @@ const UNAUTHORIZED_EVENT: u32 = 0x2_001e; // 131102
 #[repr(u32)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionEvent {
-    AccountBeforeLoadForeign = ACCOUNT_BEFORE_LOAD_FOREIGN,
+    AccountBeforeForeignLoad = ACCOUNT_BEFORE_FOREIGN_LOAD,
 
     AccountVaultBeforeAddAsset = ACCOUNT_VAULT_BEFORE_ADD_ASSET,
     AccountVaultAfterAddAsset = ACCOUNT_VAULT_AFTER_ADD_ASSET,
@@ -148,7 +148,7 @@ impl TryFrom<u32> for TransactionEvent {
         }
 
         match value {
-            ACCOUNT_BEFORE_LOAD_FOREIGN => Ok(TransactionEvent::AccountBeforeLoadForeign),
+            ACCOUNT_BEFORE_FOREIGN_LOAD => Ok(TransactionEvent::AccountBeforeForeignLoad),
 
             ACCOUNT_VAULT_BEFORE_ADD_ASSET => Ok(TransactionEvent::AccountVaultBeforeAddAsset),
             ACCOUNT_VAULT_AFTER_ADD_ASSET => Ok(TransactionEvent::AccountVaultAfterAddAsset),

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -8,6 +8,8 @@ use super::TransactionEventError;
 // TRANSACTION EVENT
 // ================================================================================================
 
+const ACCOUNT_BEFORE_LOAD: u32 = 0x2_0020; // 131104
+
 const ACCOUNT_VAULT_BEFORE_ADD_ASSET: u32 = 0x2_0000; // 131072
 const ACCOUNT_VAULT_AFTER_ADD_ASSET: u32 = 0x2_0001; // 131073
 
@@ -67,6 +69,8 @@ const UNAUTHORIZED_EVENT: u32 = 0x2_001e; // 131102
 #[repr(u32)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionEvent {
+    AccountBeforeLoad = ACCOUNT_BEFORE_LOAD,
+
     AccountVaultBeforeAddAsset = ACCOUNT_VAULT_BEFORE_ADD_ASSET,
     AccountVaultAfterAddAsset = ACCOUNT_VAULT_AFTER_ADD_ASSET,
 
@@ -144,6 +148,8 @@ impl TryFrom<u32> for TransactionEvent {
         }
 
         match value {
+            ACCOUNT_BEFORE_LOAD => Ok(TransactionEvent::AccountBeforeLoad),
+
             ACCOUNT_VAULT_BEFORE_ADD_ASSET => Ok(TransactionEvent::AccountVaultBeforeAddAsset),
             ACCOUNT_VAULT_AFTER_ADD_ASSET => Ok(TransactionEvent::AccountVaultAfterAddAsset),
 

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -8,7 +8,7 @@ use super::TransactionEventError;
 // TRANSACTION EVENT
 // ================================================================================================
 
-const ACCOUNT_BEFORE_LOAD: u32 = 0x2_0020; // 131104
+const ACCOUNT_BEFORE_LOAD_FOREIGN: u32 = 0x2_0020; // 131104
 
 const ACCOUNT_VAULT_BEFORE_ADD_ASSET: u32 = 0x2_0000; // 131072
 const ACCOUNT_VAULT_AFTER_ADD_ASSET: u32 = 0x2_0001; // 131073
@@ -69,7 +69,7 @@ const UNAUTHORIZED_EVENT: u32 = 0x2_001e; // 131102
 #[repr(u32)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionEvent {
-    AccountBeforeLoad = ACCOUNT_BEFORE_LOAD,
+    AccountBeforeLoadForeign = ACCOUNT_BEFORE_LOAD_FOREIGN,
 
     AccountVaultBeforeAddAsset = ACCOUNT_VAULT_BEFORE_ADD_ASSET,
     AccountVaultAfterAddAsset = ACCOUNT_VAULT_AFTER_ADD_ASSET,
@@ -148,7 +148,7 @@ impl TryFrom<u32> for TransactionEvent {
         }
 
         match value {
-            ACCOUNT_BEFORE_LOAD => Ok(TransactionEvent::AccountBeforeLoad),
+            ACCOUNT_BEFORE_LOAD_FOREIGN => Ok(TransactionEvent::AccountBeforeLoadForeign),
 
             ACCOUNT_VAULT_BEFORE_ADD_ASSET => Ok(TransactionEvent::AccountVaultBeforeAddAsset),
             ACCOUNT_VAULT_AFTER_ADD_ASSET => Ok(TransactionEvent::AccountVaultAfterAddAsset),

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -87,7 +87,7 @@ impl TransactionAdviceInputs {
         self.0
     }
 
-    /// Consumes self and returns an iterator of [`AdviceMutation`]s.
+    /// Consumes self and returns an iterator of [`AdviceMutation`]s in arbitrary order.
     pub fn into_advice_mutations(self) -> impl Iterator<Item = AdviceMutation> {
         [
             AdviceMutation::ExtendMap { other: self.0.map },

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -64,7 +64,7 @@ impl TransactionAdviceInputs {
         // if a seed was provided, extend the map appropriately
         if let Some(seed) = tx_inputs.account_seed() {
             // ACCOUNT_ID |-> ACCOUNT_SEED
-            let account_id_key = build_account_id_key(partial_native_acc.id());
+            let account_id_key = Self::account_id_map_key(partial_native_acc.id());
             inputs.add_map_entry(account_id_key, seed.to_vec());
         }
 
@@ -118,7 +118,7 @@ impl TransactionAdviceInputs {
 
             // for foreign accounts, we need to insert the id to state mapping
             // NOTE: keep this in sync with the account::load_from_advice procedure
-            let account_id_key = build_account_id_key(foreign_acc.id());
+            let account_id_key = Self::account_id_map_key(foreign_acc.id());
             let header = AccountHeader::from(foreign_acc.account());
 
             // ACCOUNT_ID |-> [ID_AND_NONCE, VAULT_ROOT, STORAGE_COMMITMENT, CODE_COMMITMENT]
@@ -126,6 +126,13 @@ impl TransactionAdviceInputs {
         }
 
         Ok(())
+    }
+
+    /// Returns the advice map key where:
+    /// - the seed for native accounts is stored.
+    /// - the account header for foreign accounts is stored.
+    pub fn account_id_map_key(id: AccountId) -> Word {
+        Word::from([id.suffix(), id.prefix().as_felt(), ZERO, ZERO])
     }
 
     /// Extend the advice stack with the transaction inputs.
@@ -445,13 +452,6 @@ impl From<AdviceInputs> for TransactionAdviceInputs {
     fn from(inner: AdviceInputs) -> Self {
         Self(inner)
     }
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-fn build_account_id_key(id: AccountId) -> Word {
-    Word::from([id.suffix(), id.prefix().as_felt(), ZERO, ZERO])
 }
 
 // CONFLICT ERROR

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -96,7 +96,7 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     // tx_get_block_timestamp
     word!("0x7903185b847517debb6c2072364e3e757b99ee623e97c2bd0a4661316c5c5418"),
     // tx_start_foreign_context
-    word!("0x447889987e3a8b589b7852c32752df4e2a855e67076496195d40364c0b0730b0"),
+    word!("0x295f96bfdc011ed5b98e6a3850c3df034728798e433701b49895b1d1bed3927f"),
     // tx_end_foreign_context
     word!("0xaa0018aa8da890b73511879487f65553753fb7df22de380dd84c11e6f77eec6f"),
     // tx_get_expiration_delta

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -96,7 +96,7 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     // tx_get_block_timestamp
     word!("0x7903185b847517debb6c2072364e3e757b99ee623e97c2bd0a4661316c5c5418"),
     // tx_start_foreign_context
-    word!("0x295f96bfdc011ed5b98e6a3850c3df034728798e433701b49895b1d1bed3927f"),
+    word!("0x7fac8c3ab1af62226616bd157d01238ce3252f006bf4004e1b2ac6bc38f6c6f1"),
     // tx_end_foreign_context
     word!("0xaa0018aa8da890b73511879487f65553753fb7df22de380dd84c11e6f77eec6f"),
     // tx_get_expiration_delta

--- a/crates/miden-objects/src/transaction/executed_tx.rs
+++ b/crates/miden-objects/src/transaction/executed_tx.rs
@@ -16,7 +16,7 @@ use super::{
     TransactionOutputs,
     TransactionWitness,
 };
-use crate::account::PartialAccount;
+use crate::account::{AccountCode, PartialAccount};
 use crate::asset::FungibleAsset;
 use crate::block::BlockNumber;
 use crate::utils::serde::{
@@ -47,6 +47,7 @@ pub struct ExecutedTransaction {
     tx_outputs: TransactionOutputs,
     account_delta: AccountDelta,
     tx_args: TransactionArgs,
+    foreign_account_code: Vec<AccountCode>,
     advice_witness: AdviceInputs,
     tx_measurements: TransactionMeasurements,
 }
@@ -64,6 +65,7 @@ impl ExecutedTransaction {
         tx_outputs: TransactionOutputs,
         account_delta: AccountDelta,
         tx_args: TransactionArgs,
+        foreign_account_code: Vec<AccountCode>,
         advice_witness: AdviceInputs,
         tx_measurements: TransactionMeasurements,
     ) -> Self {
@@ -85,6 +87,7 @@ impl ExecutedTransaction {
             tx_outputs,
             account_delta,
             tx_args,
+            foreign_account_code,
             advice_witness,
             tx_measurements,
         }
@@ -175,6 +178,7 @@ impl ExecutedTransaction {
         let tx_witness = TransactionWitness {
             tx_inputs: self.tx_inputs,
             tx_args: self.tx_args,
+            foreign_account_code: self.foreign_account_code,
             advice_witness: self.advice_witness,
         };
 
@@ -202,6 +206,7 @@ impl Serializable for ExecutedTransaction {
         self.tx_outputs.write_into(target);
         self.account_delta.write_into(target);
         self.tx_args.write_into(target);
+        self.foreign_account_code.write_into(target);
         self.advice_witness.write_into(target);
         self.tx_measurements.write_into(target);
     }
@@ -213,6 +218,7 @@ impl Deserializable for ExecutedTransaction {
         let tx_outputs = TransactionOutputs::read_from(source)?;
         let account_delta = AccountDelta::read_from(source)?;
         let tx_args = TransactionArgs::read_from(source)?;
+        let foreign_account_code = <Vec<AccountCode>>::read_from(source)?;
         let advice_witness = AdviceInputs::read_from(source)?;
         let tx_measurements = TransactionMeasurements::read_from(source)?;
 
@@ -221,6 +227,7 @@ impl Deserializable for ExecutedTransaction {
             tx_outputs,
             account_delta,
             tx_args,
+            foreign_account_code,
             advice_witness,
             tx_measurements,
         ))

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -53,7 +53,7 @@ use crate::{Auth, MockChainBuilder, assert_execution_error, assert_transaction_e
 // ================================================================================================
 
 #[test]
-fn test_fpi_memory() -> anyhow::Result<()> {
+fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     // Prepare the test data
     let storage_slots =
         vec![AccountStorage::mock_item_0().slot, AccountStorage::mock_item_2().slot];
@@ -78,9 +78,10 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         end
     ";
 
+    let source_manager = Arc::new(DefaultSourceManager::default());
     let foreign_account_component = AccountComponent::compile(
         foreign_account_code_source,
-        TransactionKernel::with_kernel_library(Arc::new(DefaultSourceManager::default())),
+        TransactionKernel::with_kernel_library(source_manager.clone()),
         storage_slots.clone(),
     )?
     .with_supports_all_types();
@@ -100,6 +101,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         MockChainBuilder::with_accounts([native_account.clone(), foreign_account.clone()])?
             .build()?;
     mock_chain.prove_next_block()?;
+
     let fpi_inputs = mock_chain
         .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
@@ -108,6 +110,7 @@ fn test_fpi_memory() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![fpi_inputs])
+        .with_source_manager(source_manager)
         .build()?;
 
     // GET ITEM
@@ -531,9 +534,10 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         end
     ";
 
+    let source_manager = Arc::new(DefaultSourceManager::default());
     let foreign_account_component = AccountComponent::compile(
         NamedSource::new("foreign_account", foreign_account_code_source),
-        TransactionKernel::with_kernel_library(Arc::new(DefaultSourceManager::default())),
+        TransactionKernel::with_kernel_library(source_manager.clone()),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -618,7 +622,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         map_key = STORAGE_LEAVES_2[0].0,
     );
 
-    let tx_script = ScriptBuilder::default()
+    let tx_script = ScriptBuilder::with_source_manager(source_manager.clone())
         .with_dynamically_linked_library(foreign_account_component.library())?
         .compile_tx_script(code)?;
 
@@ -629,8 +633,10 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
     mock_chain
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
-        .foreign_accounts(vec![foreign_account_inputs])
+        .foreign_accounts([foreign_account_inputs])
+        .enable_partial_loading()
         .tx_script(tx_script)
+        .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;
 
@@ -691,9 +697,10 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         end
     "#;
 
+    let source_manager = Arc::new(DefaultSourceManager::default());
     let second_foreign_account_component = AccountComponent::compile(
         second_foreign_account_code_source,
-        TransactionKernel::with_kernel_library(Arc::new(DefaultSourceManager::default())),
+        TransactionKernel::with_kernel_library(source_manager.clone()),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -751,7 +758,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
 
     let first_foreign_account_component = AccountComponent::compile(
         NamedSource::new("first_foreign_account", first_foreign_account_code_source),
-        TransactionKernel::with_kernel_library(Arc::new(DefaultSourceManager::default())),
+        TransactionKernel::with_kernel_library(source_manager.clone()),
         storage_slots,
     )?
     .with_supports_all_types();
@@ -839,7 +846,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         foreign_suffix = first_foreign_account.id().suffix(),
     );
 
-    let tx_script = ScriptBuilder::default()
+    let tx_script = ScriptBuilder::with_source_manager(source_manager.clone())
         .with_dynamically_linked_library(first_foreign_account_component.library())?
         .compile_tx_script(code)?;
 
@@ -847,8 +854,10 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(foreign_account_inputs)
+        .enable_partial_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
+        .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;
 
@@ -1014,6 +1023,7 @@ fn test_nested_fpi_stack_overflow() {
                 .build_tx_context(native_account.id(), &[], &[])
                 .expect("failed to build tx context")
                 .foreign_accounts(foreign_accounts)
+                .enable_partial_loading()
                 .tx_script(tx_script)
                 .build().unwrap();
 
@@ -1127,6 +1137,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
+        .enable_partial_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
         .build()?
@@ -1352,6 +1363,7 @@ fn test_fpi_get_account_id() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
+        .enable_partial_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;
@@ -1462,6 +1474,7 @@ fn test_fpi_get_account_nonce() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
+        .enable_partial_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -634,7 +634,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts([foreign_account_inputs])
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .tx_script(tx_script)
         .with_source_manager(source_manager)
         .build()?
@@ -854,7 +854,7 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(foreign_account_inputs)
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
         .with_source_manager(source_manager)
@@ -1023,7 +1023,7 @@ fn test_nested_fpi_stack_overflow() {
                 .build_tx_context(native_account.id(), &[], &[])
                 .expect("failed to build tx context")
                 .foreign_accounts(foreign_accounts)
-                .enable_partial_loading()
+                .enable_lazy_loading()
                 .tx_script(tx_script)
                 .build().unwrap();
 
@@ -1137,7 +1137,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
         .build()?
@@ -1363,7 +1363,7 @@ fn test_fpi_get_account_id() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;
@@ -1474,7 +1474,7 @@ fn test_fpi_get_account_nonce() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -59,7 +59,7 @@ fn adding_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
         .extend_input_notes(vec![asset_note])
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?;
     let account = tx_context.account().clone();
@@ -125,7 +125,7 @@ fn removing_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
         .build()?
         .build_tx_context(account, &[], &[])?
         .tx_script(tx_script)
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?;
     let account = tx_context.account().clone();
@@ -159,7 +159,7 @@ fn loading_fee_asset_succeeds() -> anyhow::Result<()> {
     builder
         .build()?
         .build_tx_context(account, &[], &[])?
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .build()?
         .execute_blocking()?;
 
@@ -219,7 +219,7 @@ fn setting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
 
     let tx = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;
@@ -281,7 +281,7 @@ fn getting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
 
     TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
-        .enable_partial_loading()
+        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -35,7 +35,7 @@ pub struct MockHost {
 }
 
 impl MockHost {
-    /// Returns a new [`MockHost`] instance with the provided [`AdviceInputs`].
+    /// Returns a new [`MockHost`] instance with the provided inputs.
     pub fn new(
         native_account_code: &AccountCode,
         mast_store: Rc<TransactionMastStore>,

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -1,16 +1,15 @@
 use alloc::boxed::Box;
-use alloc::collections::BTreeSet;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use miden_lib::transaction::{TransactionEvent, TransactionEventError};
-use miden_objects::account::{AccountHeader, AccountVaultDelta};
+use miden_objects::account::{AccountCode, AccountVaultDelta};
 use miden_objects::assembly::debuginfo::SourceManagerSync;
 use miden_objects::assembly::{DefaultSourceManager, SourceManager};
+use miden_objects::transaction::AccountInputs;
 use miden_objects::{Felt, Word};
 use miden_processor::{
-    AdviceInputs,
     AdviceMutation,
     BaseHost,
     ContextId,
@@ -38,15 +37,17 @@ pub struct MockHost {
 impl MockHost {
     /// Returns a new [`MockHost`] instance with the provided [`AdviceInputs`].
     pub fn new(
-        account: AccountHeader,
-        advice_inputs: &AdviceInputs,
+        native_account_code: &AccountCode,
         mast_store: Rc<TransactionMastStore>,
-        mut foreign_code_commitments: BTreeSet<Word>,
+        foreign_account_inputs: &[AccountInputs],
     ) -> Self {
-        foreign_code_commitments.insert(account.code_commitment());
-        let account_procedure_index_map =
-            AccountProcedureIndexMap::new(foreign_code_commitments, advice_inputs)
-                .expect("account procedure index map should be valid");
+        let account_procedure_index_map = AccountProcedureIndexMap::new(
+            foreign_account_inputs
+                .iter()
+                .map(AccountInputs::code)
+                .chain([native_account_code]),
+        )
+        .expect("account procedure index map should be valid");
 
         Self {
             acct_procedure_index_map: account_procedure_index_map,

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -116,10 +116,9 @@ impl TransactionContext {
         let advice_inputs = advice_inputs.into_advice_inputs();
         CodeExecutor::new(
             MockHost::new(
-                self.tx_inputs.account().into(),
-                &advice_inputs,
+                self.tx_inputs().account().code(),
                 mast_store,
-                self.tx_args.to_foreign_account_code_commitments(),
+                self.tx_args.foreign_account_inputs(),
             )
             .with_source_manager(self.source_manager()),
         )

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::ToOwned;
-use alloc::collections::BTreeSet;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::rc::Rc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -12,6 +12,7 @@ use miden_objects::asset::AssetWitness;
 use miden_objects::block::{BlockHeader, BlockNumber};
 use miden_objects::note::Note;
 use miden_objects::transaction::{
+    AccountInputs,
     ExecutedTransaction,
     InputNote,
     InputNotes,
@@ -52,6 +53,7 @@ use crate::tx_context::builder::MockAuthenticator;
 pub struct TransactionContext {
     pub(super) account: Account,
     pub(super) expected_output_notes: Vec<Note>,
+    pub(super) foreign_account_inputs: BTreeMap<AccountId, AccountInputs>,
     pub(super) tx_args: TransactionArgs,
     pub(super) tx_inputs: TransactionInputs,
     pub(super) mast_store: TransactionMastStore,
@@ -203,6 +205,22 @@ impl DataStore for TransactionContext {
         let (partial_account, seed, header, mmr, _) = self.tx_inputs.clone().into_parts();
 
         async move { Ok((partial_account, seed, header, mmr)) }
+    }
+
+    fn get_partial_foreign_account(
+        &self,
+        foreign_account_id: AccountId,
+        _ref_block: BlockNumber,
+    ) -> impl FutureMaybeSend<Result<AccountInputs, DataStoreError>> {
+        // Note that we cannot validate that the foreign account inputs are valid for the
+        // transaction's reference block.
+        async move {
+            self.foreign_account_inputs.get(&foreign_account_id).cloned().ok_or_else(|| {
+                DataStoreError::other(format!(
+                    "failed to find foreign account {foreign_account_id}"
+                ))
+            })
+        }
     }
 
     fn get_vault_asset_witness(

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -207,7 +207,7 @@ impl DataStore for TransactionContext {
         async move { Ok((partial_account, seed, header, mmr)) }
     }
 
-    fn get_partial_foreign_account(
+    fn get_foreign_account_inputs(
         &self,
         foreign_account_id: AccountId,
         _ref_block: BlockNumber,

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -261,9 +261,9 @@ pub enum TransactionKernelError {
         "note input data in advice provider contains fewer elements ({actual}) than specified ({specified}) by its inputs length"
     )]
     TooFewElementsForNoteInputs { specified: u64, actual: u64 },
-    #[error("account procedure with procedure root {0} is not in the advice provider")]
+    #[error("account procedure with procedure root {0} is not in the account procedure index map")]
     UnknownAccountProcedure(Word),
-    #[error("code commitment {0} is not in the advice provider")]
+    #[error("code commitment {0} is not in the account procedure index map")]
     UnknownCodeCommitment(Word),
     #[error("account storage slots number is missing in memory at address {0}")]
     AccountStorageSlotsNumMissing(u32),

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -272,9 +272,9 @@ pub enum TransactionKernelError {
     #[error("failed to convert fee asset into fungible asset")]
     FailedToConvertFeeAsset(#[source] AssetError),
     #[error(
-        "failed to get partial data for foreign account {foreign_account_id} from data store at reference block {ref_block}"
+        "failed to get inputs for foreign account {foreign_account_id} from data store at reference block {ref_block}"
     )]
-    GetPartialForeignAccount {
+    GetForeignAccountInputs {
         foreign_account_id: AccountId,
         ref_block: BlockNumber,
         // thiserror will return this when calling Error::source on TransactionKernelError.

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -149,6 +149,8 @@ pub enum TransactionProverError {
     // case, the diagnostic is lost if the execution error is not explicitly unwrapped.
     #[error("failed to execute transaction kernel program:\n{}", PrintDiagnostic::new(.0))]
     TransactionProgramExecutionFailed(ExecutionError),
+    #[error("failed to create account procedure index map")]
+    CreateAccountProcedureIndexMap(#[source] TransactionHostError),
     #[error("failed to create transaction host")]
     TransactionHostCreationFailed(#[source] TransactionHostError),
     /// Custom error variant for errors not covered by the other variants.

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -272,6 +272,15 @@ pub enum TransactionKernelError {
     #[error("failed to convert fee asset into fungible asset")]
     FailedToConvertFeeAsset(#[source] AssetError),
     #[error(
+        "failed to get partial data for foreign account {foreign_account_id} from data store at reference block {ref_block}"
+    )]
+    GetPartialForeignAccount {
+        foreign_account_id: AccountId,
+        ref_block: BlockNumber,
+        // thiserror will return this when calling Error::source on TransactionKernelError.
+        source: DataStoreError,
+    },
+    #[error(
         "failed to get vault asset witness from data store for vault root {vault_root} and vault_key {vault_key}"
     )]
     GetVaultAssetWitness {

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -3,7 +3,7 @@ use alloc::collections::BTreeSet;
 use miden_objects::account::{AccountId, PartialAccount, StorageMapWitness};
 use miden_objects::asset::AssetWitness;
 use miden_objects::block::{BlockHeader, BlockNumber};
-use miden_objects::transaction::PartialBlockchain;
+use miden_objects::transaction::{AccountInputs, PartialBlockchain};
 use miden_processor::{FutureMaybeSend, MastForestStore, Word};
 
 use crate::DataStoreError;
@@ -34,6 +34,15 @@ pub trait DataStore: MastForestStore {
     ) -> impl FutureMaybeSend<
         Result<(PartialAccount, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
     >;
+
+    // TODO: Rename to get_foreign_account_inputs?
+    /// Returns a partial foreign account state together with a proof that it is a valid account
+    /// state as of the specified transaction reference block.
+    fn get_partial_foreign_account(
+        &self,
+        foreign_account_id: AccountId,
+        ref_block: BlockNumber,
+    ) -> impl FutureMaybeSend<Result<AccountInputs, DataStoreError>>;
 
     /// Returns a witness for an asset in the requested account's vault with the requested vault
     /// root.

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -35,10 +35,9 @@ pub trait DataStore: MastForestStore {
         Result<(PartialAccount, Option<Word>, BlockHeader, PartialBlockchain), DataStoreError>,
     >;
 
-    // TODO: Rename to get_foreign_account_inputs?
-    /// Returns a partial foreign account state together with a proof that it is a valid account
-    /// state as of the specified transaction reference block.
-    fn get_partial_foreign_account(
+    /// Returns a partial foreign account state together with a witness, proving its validity in the
+    /// specified transaction reference block.
+    fn get_foreign_account_inputs(
         &self,
         foreign_account_id: AccountId,
         ref_block: BlockNumber,

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -160,7 +160,7 @@ where
 
         self.base_host
             .account_procedure_index_map_mut()
-            .insert_procedures(foreign_account_inputs.code().commitment(), &tx_advice_inputs)
+            .insert_code(foreign_account_inputs.code())
             .map_err(|err| {
                 TransactionKernelError::other_with_source(
                     format!(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -129,8 +129,7 @@ where
     // EVENT HANDLERS
     // --------------------------------------------------------------------------------------------
 
-    /// Handles a request for a foreign account by querying the data store for its
-    /// [`PartialForeignAccount`] data.
+    /// Handles a request for a foreign account by querying the data store for its account inputs.
     async fn on_foreign_account_requested(
         &mut self,
         foreign_account_id: AccountId,
@@ -138,9 +137,9 @@ where
         let foreign_account_inputs = self
             .base_host
             .store()
-            .get_partial_foreign_account(foreign_account_id, self.ref_block)
+            .get_foreign_account_inputs(foreign_account_id, self.ref_block)
             .await
-            .map_err(|err| TransactionKernelError::GetPartialForeignAccount {
+            .map_err(|err| TransactionKernelError::GetForeignAccountInputs {
                 foreign_account_id,
                 ref_block: self.ref_block,
                 source: err,

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -159,8 +159,7 @@ where
             })?;
 
         self.base_host
-            .account_procedure_index_map_mut()
-            .insert_code(foreign_account_inputs.code())
+            .load_foreign_account_code(foreign_account_inputs.code())
             .map_err(|err| {
                 TransactionKernelError::other_with_source(
                     format!(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -400,12 +400,20 @@ where
         AccountDelta,
         InputNotes<InputNote>,
         Vec<OutputNote>,
+        Vec<AccountCode>,
         BTreeMap<Word, Vec<Felt>>,
         TransactionProgress,
     ) {
         let (account_delta, input_notes, output_notes, tx_progress) = self.base_host.into_parts();
 
-        (account_delta, input_notes, output_notes, self.generated_signatures, tx_progress)
+        (
+            account_delta,
+            input_notes,
+            output_notes,
+            self.accessed_foreign_account_code,
+            self.generated_signatures,
+            tx_progress,
+        )
     }
 }
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -300,18 +300,16 @@ where
 
         // To start executing the transaction, the procedure index map only needs to contain the
         // native account's procedures. Foreign accounts are inserted into the map on first access.
-        let acct_procedure_index_map = AccountProcedureIndexMap::new(
-            [tx_inputs.account().code().commitment()],
-            tx_advice_inputs.as_advice_inputs(),
-        )
-        .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
+        let account_procedure_index_map =
+            AccountProcedureIndexMap::new([tx_inputs.account().code()])
+                .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
 
         let host = TransactionExecutorHost::new(
             tx_inputs.account(),
             input_notes.clone(),
             self.data_store,
             script_mast_store,
-            acct_procedure_index_map,
+            account_procedure_index_map,
             self.authenticator,
             tx_inputs.block_header().block_num(),
             self.source_manager.clone(),

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -309,6 +309,7 @@ where
             script_mast_store,
             acct_procedure_index_map,
             self.authenticator,
+            tx_inputs.block_header().block_num(),
             self.source_manager.clone(),
         );
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -280,7 +280,7 @@ where
         let tx_inputs = TransactionInputs::new(account, seed, ref_block, mmr, notes)
             .map_err(TransactionExecutorError::InvalidTransactionInputs)?;
 
-        let (stack_inputs, advice_inputs) =
+        let (stack_inputs, tx_advice_inputs) =
             TransactionKernel::prepare_inputs(&tx_inputs, tx_args, init_advice_inputs)
                 .map_err(TransactionExecutorError::ConflictingAdviceMapEntry)?;
 
@@ -298,9 +298,13 @@ where
             input_notes.iter().map(|n| n.note().script()),
         );
 
-        let acct_procedure_index_map =
-            AccountProcedureIndexMap::from_transaction_params(&tx_inputs, tx_args, &advice_inputs)
-                .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
+        // To start executing the transaction, the procedure index map only needs to contain the
+        // native account's procedures. Foreign accounts are inserted into the map on first access.
+        let acct_procedure_index_map = AccountProcedureIndexMap::new(
+            [tx_inputs.account().code().commitment()],
+            tx_advice_inputs.as_advice_inputs(),
+        )
+        .map_err(TransactionExecutorError::TransactionHostCreationFailed)?;
 
         let host = TransactionExecutorHost::new(
             tx_inputs.account(),
@@ -313,7 +317,7 @@ where
             self.source_manager.clone(),
         );
 
-        let advice_inputs = advice_inputs.into_advice_inputs();
+        let advice_inputs = tx_advice_inputs.into_advice_inputs();
 
         Ok((host, tx_inputs, stack_inputs, advice_inputs))
     }
@@ -332,8 +336,14 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
 ) -> Result<ExecutedTransaction, TransactionExecutorError> {
     // Note that the account delta does not contain the removed transaction fee, so it is the
     // "pre-fee" delta of the transaction.
-    let (pre_fee_account_delta, _input_notes, output_notes, generated_signatures, tx_progress) =
-        host.into_parts();
+    let (
+        pre_fee_account_delta,
+        _input_notes,
+        output_notes,
+        accessed_foreign_account_code,
+        generated_signatures,
+        tx_progress,
+    ) = host.into_parts();
 
     let tx_outputs =
         TransactionKernel::from_transaction_parts(&stack_outputs, &advice_inputs, output_notes)
@@ -381,6 +391,7 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
         tx_outputs,
         post_fee_account_delta,
         tx_args,
+        accessed_foreign_account_code,
         advice_inputs,
         tx_progress.into(),
     ))

--- a/crates/miden-tx/src/host/account_procedures.rs
+++ b/crates/miden-tx/src/host/account_procedures.rs
@@ -31,12 +31,12 @@ impl AccountProcedureIndexMap {
         Ok(index_map)
     }
 
-    /// Inserts the account procedures at the provided `code_commitment` key in the advice inputs
-    /// into the account procedure index map.
+    /// Inserts the procedures from the provided [`AccountCode`] into the advice inputs, using
+    /// [`AccountCode::commitment`] as the key.
     ///
-    /// The resulting instance will map all account code commmitments to a mapping of
+    /// The resulting instance will map the account code commmitment to a mapping of
     /// `proc_root |-> proc_index` for any account that is expected to be involved in the
-    /// transaction, enabling easy procedure index lookups at runtime.
+    /// transaction, enabling fast procedure index lookups at runtime.
     pub fn insert_code(&mut self, code: &AccountCode) -> Result<(), TransactionHostError> {
         let mut procedure_map = BTreeMap::new();
         for (proc_idx, proc_info) in code.procedures().iter().enumerate() {

--- a/crates/miden-tx/src/host/account_procedures.rs
+++ b/crates/miden-tx/src/host/account_procedures.rs
@@ -34,7 +34,7 @@ impl AccountProcedureIndexMap {
     /// Inserts the procedures from the provided [`AccountCode`] into the advice inputs, using
     /// [`AccountCode::commitment`] as the key.
     ///
-    /// The resulting instance will map the account code commmitment to a mapping of
+    /// The resulting instance will map the account code commitment to a mapping of
     /// `proc_root |-> proc_index` for any account that is expected to be involved in the
     /// transaction, enabling fast procedure index lookups at runtime.
     pub fn insert_code(&mut self, code: &AccountCode) -> Result<(), TransactionHostError> {

--- a/crates/miden-tx/src/host/account_procedures.rs
+++ b/crates/miden-tx/src/host/account_procedures.rs
@@ -27,14 +27,14 @@ impl AccountProcedureIndexMap {
         account_code_commitments: impl IntoIterator<Item = Word>,
         adv_provider: &AdviceInputs,
     ) -> Result<Self, TransactionHostError> {
-        let mut result = BTreeMap::new();
+        let mut index_map = BTreeMap::new();
 
         for code_commitment in account_code_commitments {
             let account_procs_map = build_account_procedure_map(code_commitment, adv_provider)?;
-            result.insert(code_commitment, account_procs_map);
+            index_map.insert(code_commitment, account_procs_map);
         }
 
-        Ok(Self(result))
+        Ok(Self(index_map))
     }
 
     /// Builds an [`AccountProcedureIndexMap`] for the specified transaction inputs and arguments.
@@ -51,6 +51,20 @@ impl AccountProcedureIndexMap {
         account_code_commitments.insert(tx_inputs.account().code().commitment());
 
         Self::new(account_code_commitments, tx_advice_inputs.as_advice_inputs())
+    }
+
+    /// Inserts the account procedures at the provided `code_commitment` key in the advice inputs
+    /// into the account procedure index map.
+    pub fn insert_procedures(
+        &mut self,
+        code_commitment: Word,
+        tx_advice_inputs: &TransactionAdviceInputs,
+    ) -> Result<(), TransactionHostError> {
+        let procedure_map =
+            build_account_procedure_map(code_commitment, tx_advice_inputs.as_advice_inputs())?;
+        self.0.insert(code_commitment, procedure_map);
+
+        Ok(())
     }
 
     /// Returns index of the procedure whose root is currently at the top of the operand stack in

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -368,10 +368,10 @@ where
         let contains_account_id_key =
             process.advice_provider().contains_map_key(&account_id_map_key);
 
-        // The native account data is loaded before transaction execution begins, so there is
-        // nothing to do.
-        // Similarly, if a foreign account's key is already in the advice map, it doesn't need to be
-        // loaded again.
+        // If a foreign account's key is already in the advice map, it doesn't need to be loaded
+        // again.
+        // The native account's data is loaded before transaction execution begins, so it does not
+        // have to be loaded either.
         if contains_account_id_key || self.initial_account_header().id() == account_id {
             Ok(TransactionEventHandling::Handled(Vec::new()))
         } else {

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -29,6 +29,7 @@ use miden_lib::transaction::memory::{
 };
 use miden_lib::transaction::{TransactionAdviceInputs, TransactionEvent, TransactionEventError};
 use miden_objects::account::{
+    AccountCode,
     AccountDelta,
     AccountHeader,
     AccountId,
@@ -62,7 +63,7 @@ use miden_processor::{
 pub use tx_progress::TransactionProgress;
 
 use crate::auth::SigningInputs;
-use crate::errors::TransactionKernelError;
+use crate::errors::{TransactionHostError, TransactionKernelError};
 
 // TRANSACTION BASE HOST
 // ================================================================================================
@@ -204,8 +205,11 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Returns a mutable reference to the [`AccountProcedureIndexMap`].
-    pub fn account_procedure_index_map_mut(&mut self) -> &mut AccountProcedureIndexMap {
-        &mut self.acct_procedure_index_map
+    pub fn load_foreign_account_code(
+        &mut self,
+        account_code: &AccountCode,
+    ) -> Result<(), TransactionHostError> {
+        self.acct_procedure_index_map.insert_code(account_code)
     }
 
     // EVENT HANDLERS

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -224,7 +224,7 @@ where
         }
 
         let advice_mutations = match transaction_event {
-            TransactionEvent::AccountBeforeLoad => {
+            TransactionEvent::AccountBeforeLoadForeign => {
                 self.on_account_before_load(process)
             }
 

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -228,8 +228,8 @@ where
         }
 
         let advice_mutations = match transaction_event {
-            TransactionEvent::AccountBeforeLoadForeign => {
-                self.on_account_before_load_foreign(process)
+            TransactionEvent::AccountBeforeForeignLoad => {
+                self.on_account_before_foreign_load(process)
             }
 
             TransactionEvent::AccountVaultBeforeAddAsset => {
@@ -353,7 +353,7 @@ where
     /// being loaded.
     ///
     /// Expected stack state: `[account_id_prefix, account_id_suffix]`
-    pub fn on_account_before_load_foreign(
+    pub fn on_account_before_foreign_load(
         &self,
         process: &ProcessState,
     ) -> Result<TransactionEventHandling, TransactionKernelError> {

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -216,6 +216,10 @@ where
         }
 
         let advice_mutations = match transaction_event {
+            TransactionEvent::AccountBeforeLoad => {
+                self.on_account_before_load(process)
+            }
+
             TransactionEvent::AccountVaultBeforeAddAsset => {
                 Self::on_account_vault_before_add_or_remove_asset(process)
             },
@@ -331,6 +335,34 @@ where
         .map_err(EventError::from)?;
 
         Ok(advice_mutations)
+    }
+
+    /// Checks if the necessary data for accessing the account is already in the advice inputs,
+    /// and if not, extracts all necessary data for requesting it.
+    ///
+    /// Expected stack state: `[account_id_prefix, account_id_suffix]`
+    pub fn on_account_before_load(
+        &self,
+        process: &ProcessState,
+    ) -> Result<TransactionEventHandling, TransactionKernelError> {
+        let account_id_word = process.get_stack_word(0);
+        let account_id =
+            AccountId::try_from([account_id_word[3], account_id_word[2]]).map_err(|err| {
+                TransactionKernelError::other_with_source(
+                    "failed to convert account ID word into account ID",
+                    err,
+                )
+            })?;
+
+        // The native account data is loaded before transaction execution begins, so there is
+        // nothing to do.
+        if self.initial_account_header().id() == account_id {
+            Ok(TransactionEventHandling::Handled(Vec::new()))
+        } else {
+            Ok(TransactionEventHandling::Unhandled(TransactionEventData::ForeignAccount {
+                account_id,
+            }))
+        }
     }
 
     /// Pushes a signature to the advice stack as a response to the `AuthRequest` event.
@@ -988,6 +1020,11 @@ pub(super) enum TransactionEventData {
     TransactionFeeComputed {
         /// The fee asset extracted from the stack.
         fee_asset: FungibleAsset,
+    },
+    /// The data necessary to request a foreign account's data from the data store.
+    ForeignAccount {
+        /// The foreign account's ID.
+        account_id: AccountId,
     },
     /// The data necessary to request an asset witness from the data store.
     AccountVaultAssetWitness {

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -200,6 +200,14 @@ where
         )
     }
 
+    // MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a mutable reference to the [`AccountProcedureIndexMap`].
+    pub fn account_procedure_index_map_mut(&mut self) -> &mut AccountProcedureIndexMap {
+        &mut self.acct_procedure_index_map
+    }
+
     // EVENT HANDLERS
     // --------------------------------------------------------------------------------------------
 

--- a/crates/miden-tx/src/host/script_mast_forest_store.rs
+++ b/crates/miden-tx/src/host/script_mast_forest_store.rs
@@ -12,6 +12,7 @@ use miden_processor::MastForestStore;
 ///
 /// A [ScriptMastForestStore] is meant to exclusively store MAST forests related to both
 /// transaction and input note scripts.
+#[derive(Debug, Clone, Default)]
 pub struct ScriptMastForestStore {
     mast_forests: BTreeMap<Word, Arc<MastForest>>,
     advice_map: AdviceMap,

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -5,7 +5,6 @@ use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::delta::AccountUpdateDetails;
 use miden_objects::account::{
     Account,
-    AccountCode,
     AccountDelta,
     AccountStorage,
     PartialAccount,
@@ -142,12 +141,10 @@ impl LocalTransactionProver {
             tx_inputs.input_notes().iter().map(|n| n.note().script()),
         );
 
-        let account_procedure_index_map = AccountProcedureIndexMap::from_transaction_params(
-            &tx_inputs,
-            foreign_account_code.iter().map(AccountCode::commitment).collect(),
-            &advice_inputs,
+        let account_procedure_index_map = AccountProcedureIndexMap::new(
+            foreign_account_code.iter().chain([tx_inputs.account().code()]),
         )
-        .map_err(TransactionProverError::TransactionHostCreationFailed)?;
+        .map_err(TransactionProverError::CreateAccountProcedureIndexMap)?;
 
         let (partial_account, _, ref_block, _, input_notes) = tx_inputs.into_parts();
         let mut host = TransactionProverHost::new(

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -142,7 +142,7 @@ impl LocalTransactionProver {
             tx_inputs.input_notes().iter().map(|n| n.note().script()),
         );
 
-        let acct_procedure_index_map = AccountProcedureIndexMap::from_transaction_params(
+        let account_procedure_index_map = AccountProcedureIndexMap::from_transaction_params(
             &tx_inputs,
             foreign_account_code.iter().map(AccountCode::commitment).collect(),
             &advice_inputs,
@@ -155,7 +155,7 @@ impl LocalTransactionProver {
             input_notes,
             self.mast_store.as_ref(),
             script_mast_store,
-            acct_procedure_index_map,
+            account_procedure_index_map,
         );
 
         let advice_inputs = advice_inputs.into_advice_inputs();

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -123,8 +123,9 @@ where
                     TransactionEventData::AuthRequest { .. } => {
                         Err(EventError::from("base host should have handled auth request event"))
                     },
-                    // Witnesses should be in the advice provider at proving time, so there is
-                    // nothing to do.
+                    // Foreign account data and witnesses should be in the advice provider at
+                    // proving time, so there is nothing to do.
+                    TransactionEventData::ForeignAccount { .. } => Ok(Vec::new()),
                     TransactionEventData::AccountVaultAssetWitness { .. } => Ok(Vec::new()),
                     TransactionEventData::AccountStorageMapWitness { .. } => Ok(Vec::new()),
                     // We don't track enough information to handle this event. Since this just


### PR DESCRIPTION
This PR implements lazy loading for foreign accounts.

Essentially, foreign accounts do no longer have to be passed into the transaction ahead of time (via `TransactionArgs::new(..., foreign_account_inputs)`). Note that we cannot remove this parameter just yet due to https://github.com/0xMiden/miden-base/issues/1872. Instead, for those cases where lazy loading can be enabled, they are loaded on demand when the first `tx_start_foreign_context` call is made for a foreign account.

This resulted in the following changes:
- Introduced an event `ACCOUNT_BEFORE_LOAD` to signal that an account is being loaded.
- I moved account loading from `tx_start_foreign_context` to `account::load_from_advice`. The main motivation for this PR is to keep all account-related events defined in `account.masm` (i.e. `ACCOUNT_BEFORE_LOAD`). Longer-term, it would be really nice if we could use this procedure to also load the native account during the prologue to deduplicate some code. I believe this only requires changing how we provide the native account data in the advice provider. We'd have to insert it into the advice map rather than stack and handle the account seed differently. Though there may be other things I've glossed over.
	- The code was moved as is; only the variable names were updated.
- The `TransactionAdviceInputs` was previously used to prepare the _entire_ advice inputs for a transaction. I changed this type slightly to allow also constructing _partial_ transaction advice inputs, e.g. for foreign accounts. In general, keeping all advice inputs related to a transaction contained here seemed like a good idea.
- One of the things I wasn't sure about here was the code of foreign accounts. In particular, in #401 we discussed that account code could technically just be loaded via the `MastForestStore` and that does work for transaction execution. However, I think we need to pass all foreign account code as part of the `TransactionWitness` to a prover, because we cannot generally assume that the prover's `MastForestStore` implementation _already_ has the account code. For that reason, I've added tracking for the code of foreign accounts that we load and then pass it to the prover via `TransactionWitness`. This does allow us to get rid of the foreign account inputs in `TransactionArgs` long-term, but for now this wouldn't allow changing `PartialAccount` to only contain `AccountCodeHeader`. We still need to access the full account code somehow.
	- I wonder if one solution is to only track which foreign account code commitments were accessed and at the end of the transaction execution, load all account code from the `TransactionExecutor`'s `MastForestStore`. This would allow for the `AccountCodeHeader` change.
	- In any case, I think this is something for another PR.
- I did not add new tests, only enabled partial loading for existing FPI tests that execute a full transaction, not for those using `execute_code` due to https://github.com/0xMiden/miden-base/issues/1872.

## Follow-Ups

I wonder if we can essentially revert the changes from https://github.com/0xMiden/miden-base/pull/1461, since the `FastProcessor` and `Process` [load the advice data](https://github.com/0xMiden/miden-vm/blob/ba3c9644c64b7edf896bb4ce0b4ae43bdf28fa72/processor/src/lib.rs#L519-L526) from a mast forest into the advice provider when it is loaded through `get_mast_forest`. This should therefore be the case for both note script and account code MAST forests. That PR didn't introduce any tests, so it's a bit hard to say exactly if removing it works or not.

This PR does not yet enable lazy loading for assets and storage map items for foreign accounts, I'll look into this in another PR.

part of #401