### PR TITLE
Move note dedicated procs from `tx` to corresponding note module

### DIFF
--- a/crates/miden-lib/asm/account_components/rpo_falcon_512_acl.masm
+++ b/crates/miden-lib/asm/account_components/rpo_falcon_512_acl.masm
@@ -3,7 +3,8 @@
 # See the `AuthRpoFalcon512Acl` Rust type's documentation for more details.
 
 use.miden::account
-use.miden::tx
+use.miden::input_note
+use.miden::output_note
 use.std::word
 
 # CONSTANTS
@@ -86,7 +87,7 @@ export.auth__tx_rpo_falcon512_acl.2
 
     # ------ Check if output notes were created ------
 
-    exec.tx::get_num_output_notes
+    exec.output_note::get_num_notes
     # => [num_output_notes, require_acl_auth, pad(16)]
 
     neq.0
@@ -103,7 +104,7 @@ export.auth__tx_rpo_falcon512_acl.2
 
     # ------ Check if input notes were consumed ------
 
-    exec.tx::get_num_input_notes
+    exec.input_note::get_num_notes
     # => [INPUT_NOTES_COMMITMENT, auth_required, pad(16)]
 
     neq.0

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1180,9 +1180,9 @@ end
 #! - num_input_notes is the total number of input notes consumed by this transaction.
 #!
 #! Invocation: dynexec
-export.tx_get_num_input_notes
+export.input_note_get_num_notes
     # get the number of input notes
-    exec.tx::get_num_input_notes
+    exec.input_note::get_num_notes
     # => [num_input_notes, pad(16)]
 
     # truncate the stack
@@ -1199,9 +1199,9 @@ end
 #! - num_output_notes is the number of output notes created in this transaction so far.
 #!
 #! Invocation: dynexec
-export.tx_get_num_output_notes
+export.output_note_get_num_notes
     # get the number of input notes
-    exec.tx::get_num_output_notes
+    exec.output_note::get_num_notes
     # => [num_output_notes, pad(16)]
 
     # truncate the stack

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1378,7 +1378,8 @@ export.tx_end_foreign_context
     # => [pad(16)]
 end
 
-#! Updates the transaction expiration time delta.
+#! Updates the transaction expiration block delta.
+#!
 #! Once set, the delta can be decreased but not increased.
 #!
 #! The input block height delta is added to the reference block in order to output an upper limit
@@ -1391,8 +1392,8 @@ end
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
 #!
 #! Invocation: dynexec
-export.tx_update_expiration_block_num
-    exec.tx::update_expiration_block_num
+export.tx_update_expiration_block_delta
+    exec.tx::update_expiration_block_delta
     # => [pad(16)]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1006,7 +1006,7 @@ export.output_note_add_asset
     movdn.4 dupw movup.8
     # => [note_idx, ASSET, ASSET, pad(11)]
 
-    exec.tx::add_asset_to_note
+    exec.output_note::add_asset_to_note
     # => [note_idx, ASSET, pad(11)]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -984,6 +984,29 @@ end
 
 ### OUTPUT NOTE #################################
 
+#! Creates a new note and returns its index.
+#!
+#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
+#! Outputs: [note_idx, pad(15)]
+#!
+#! Where:
+#! - tag is the tag to be included in the note.
+#! - aux is the auxiliary metadata to be included in the note.
+#! - note_type is the note storage type.
+#! - execution_hint is the note execution hint tag and payload.
+#! - RECIPIENT is the recipient of the note.
+#! - note_idx is the index of the created note.
+#!
+#! Invocation: dynexec
+export.output_note_create
+    # check that this procedure was executed against the native account
+    exec.memory::assert_native_account
+    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
+
+    exec.output_note::create
+    # => [note_idx, pad(15)]
+end
+
 #! Adds the ASSET to the note specified by the index.
 #!
 #! Inputs:  [note_idx, ASSET, pad(11)]
@@ -1103,29 +1126,6 @@ export.output_note_get_metadata
 end
 
 ### TRANSACTION #################################
-
-#! Creates a new note and returns the index of the note.
-#!
-#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
-#! Outputs: [note_idx, pad(15)]
-#!
-#! Where:
-#! - tag is the tag to be included in the note.
-#! - aux is the auxiliary metadata to be included in the note.
-#! - note_type is the note storage type.
-#! - execution_hint is the note execution hint tag and payload.
-#! - RECIPIENT is the recipient of the note.
-#! - note_idx is the index of the created note.
-#!
-#! Invocation: dynexec
-export.tx_create_note
-    # check that this procedure was executed against the native account
-    exec.memory::assert_native_account
-    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
-
-    exec.tx::create_note
-    # => [note_idx, pad(15)]
-end
 
 #! Returns the input notes commitment.
 #!

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -1029,7 +1029,7 @@ export.output_note_add_asset
     movdn.4 dupw movup.8
     # => [note_idx, ASSET, ASSET, pad(11)]
 
-    exec.output_note::add_asset_to_note
+    exec.output_note::add_asset
     # => [note_idx, ASSET, pad(11)]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/input_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/input_note.masm
@@ -8,6 +8,15 @@ const.ERR_INPUT_NOTE_INDEX_OUT_OF_BOUNDS="requested input note index should be l
 # INPUT NOTE PROCEDURES
 # =================================================================================================
 
+#! Returns the total number of input notes consumed by this transaction.
+#!
+#! Inputs:  []
+#! Outputs: [num_input_notes]
+#!
+#! Where:
+#! - num_input_notes is the total number of input notes consumed by this transaction.
+export.memory::get_num_input_notes->get_num_notes
+
 #! Returns the information about assets in the input note with the specified memory pointer.
 #!
 #! Inputs:  [input_note_ptr]

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -1589,7 +1589,7 @@ export.set_input_note_args
     mem_storew
 end
 
-#! Returns the number of inputs of the note currently being processed.
+#! Returns the number of inputs of the note located at the specified memory address.
 #!
 #! Inputs:  [note_ptr]
 #! Outputs: [num_inputs]

--- a/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
@@ -101,7 +101,7 @@ export.memory::get_num_output_notes->get_num_notes
 export.create
     emit.NOTE_BEFORE_CREATED_EVENT
 
-    exec.build_note_metadata
+    exec.build_metadata
     # => [NOTE_METADATA, RECIPIENT]
 
     # get the index for the next note to be created and increment counter
@@ -194,7 +194,7 @@ end
 #! - the max amount of fungible assets is exceeded.
 #! - the non-fungible asset already exists in the note.
 #! - the total number of ASSETs exceeds the maximum of 256.
-export.add_asset_to_note
+export.add_asset
     # check if the note exists, it must be within [0, num_of_notes]
     dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
     # => [note_idx, ASSET]
@@ -221,11 +221,11 @@ export.add_asset_to_note
 
     if.true
         # ASSET to add is fungible
-        exec.add_fungible_asset_to_note
+        exec.add_fungible_asset
         # => [note_ptr, note_idx]
     else
         # ASSET to add is non-fungible
-        exec.add_non_fungible_asset_to_note
+        exec.add_non_fungible_asset
         # => [note_ptr, note_idx]
     end
     # => [note_ptr, note_idx]
@@ -272,8 +272,7 @@ end
 #!   or off-chain).
 #! - execution_hint is the hint which specifies when a note is ready to be consumed.
 #! - NOTE_METADATA is the metadata associated with a note.
-export.build_note_metadata
-
+export.build_metadata
     # Validate the note type.
     # --------------------------------------------------------------------------------------------
 
@@ -400,7 +399,7 @@ end
 #!
 #! Panics if
 #! - the summed amounts exceed the maximum amount of fungible assets.
-proc.add_fungible_asset_to_note
+proc.add_fungible_asset
     dup.4 exec.memory::get_output_note_asset_data_ptr
     # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
 
@@ -490,7 +489,7 @@ end
 #!
 #! Panics if:
 #! - the non-fungible asset already exists in the note.
-proc.add_non_fungible_asset_to_note
+proc.add_non_fungible_asset
     dup.4 exec.memory::get_output_note_asset_data_ptr
     # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
@@ -1,9 +1,26 @@
+use.$kernel::account
 use.$kernel::memory
 use.$kernel::note
 use.$kernel::asset
+use.$kernel::constants
+
+# CONSTANTS
+# =================================================================================================
+
+# Constants for different note types
+const.PUBLIC_NOTE=1     # 0b01
+const.PRIVATE_NOTE=2    # 0b10
+const.ENCRYPTED_NOTE=3  # 0b11
+
+# The note type must be PUBLIC, unless the high bits are `0b11`. (See the table below.)
+const.LOCAL_ANY_PREFIX=3 # 0b11
 
 # ERRORS
 # =================================================================================================
+
+const.ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT="number of output notes in the transaction exceeds the maximum limit of 1024"
+
+const.ERR_NOTE_INVALID_TYPE="invalid note type"
 
 const.ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS="requested output note index should be less than the total number of created output notes"
 
@@ -13,8 +30,37 @@ const.ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED="adding a fungible asset to a note c
 
 const.ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS="non-fungible asset that already exists in the note cannot be added again"
 
+# The 2 highest bits in the u32 tag have the following meaning:
+#
+# | Prefix | Name                   | [`NoteExecutionMode`] | Target                   | Allowed [`NoteType`] |
+# | :----: | :--------------------: | :-------------------: | :----------------------: | :------------------: |
+# | `0b00` | `NetworkAccount`       | Network               | Network Account          | [`NoteType::Public`] |
+# | `0b01` | `NetworkUseCase`       | Network               | Use case                 | [`NoteType::Public`] |
+# | `0b10` | `LocalPublicAny`       | Local                 | Any                      | [`NoteType::Public`] |
+# | `0b11` | `LocalAny`             | Local                 | Any                      | Any                  |
+#
+# Execution: Is a hint for the network, to check if the note can be consumed by a network controlled
+#   account
+# Target: Is a hint for the type of target. Use case means the note may be consumed by anyone,
+#   specific means there is a specific target for the note (the target may be a public key, a user
+#   that knows some secret, or a specific account ID)
+#
+# Only the note type from the above list is enforced. The other values are only hints intended as a
+# best effort optimization strategy. A badly formatted note may 1. not be consumed because honest
+# users won't see the note 2. generate slightly more load as extra validation is performed for the
+# invalid tags. None of these scenarios have any significant impact.
+
+const.ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX="invalid note type for the given note tag prefix"
+
+const.ERR_NOTE_TAG_MUST_BE_U32="the note's tag must fit into a u32 so the 32 most significant bits must be zero"
+
 # EVENTS
 # =================================================================================================
+
+# Event emitted before a new note is created.
+const.NOTE_BEFORE_CREATED_EVENT=131083
+# Event emitted after a new note is created.
+const.NOTE_AFTER_CREATED_EVENT=131084
 
 # Event emitted before an ASSET is added to a note
 const.NOTE_BEFORE_ADD_ASSET_EVENT=131085
@@ -23,6 +69,54 @@ const.NOTE_AFTER_ADD_ASSET_EVENT=131086
 
 # OUTPUT NOTE PROCEDURES
 # =================================================================================================
+
+#! Creates a new note and returns the index of the note.
+#!
+#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
+#! Outputs: [note_idx]
+#!
+#! Where:
+#! - tag is the note tag which can be used by the recipient(s) to identify notes intended for them.
+#! - aux is the arbitrary user-defined value.
+#! - note_type is the type of the note, which defines how the note is to be stored (e.g., on-chain
+#!   or off-chain).
+#! - execution_hint is the hint which specifies when a note is ready to be consumed.
+#! - RECIPIENT defines spend conditions for the note.
+#! - note_idx is the index of the created note.
+#!
+#! Panics if:
+#! - the note_type is not valid.
+#! - the note_tag is not an u32.
+#! - the note_tag starts with anything but 0b11 and note_type is not public.
+#! - the number of output notes exceeds the maximum limit of 1024.
+export.create
+    emit.NOTE_BEFORE_CREATED_EVENT
+
+    exec.build_note_metadata
+    # => [NOTE_METADATA, RECIPIENT]
+
+    # get the index for the next note to be created and increment counter
+    exec.increment_num_output_notes dup movdn.9
+    # => [note_idx, NOTE_METADATA, RECIPIENT, note_idx]
+
+    # get a pointer to the memory address at which the note will be stored
+    exec.memory::get_output_note_ptr
+    # => [note_ptr, NOTE_METADATA, RECIPIENT, note_idx]
+
+    movdn.4
+    # => [NOTE_METADATA, note_ptr, RECIPIENT, note_idx]
+
+    # emit event to signal that a new note is created
+    emit.NOTE_AFTER_CREATED_EVENT
+
+    # set the metadata for the output note
+    dup.4 exec.memory::set_output_note_metadata dropw
+    # => [note_ptr, RECIPIENT, note_idx]
+
+    # set the RECIPIENT for the output note
+    exec.memory::set_output_note_recipient dropw
+    # => [note_idx]
+end
 
 #! Returns the information about assets in the output note with the specified index.
 #!
@@ -153,6 +247,133 @@ end
 
 # HELPER PROCEDURES
 # =================================================================================================
+
+#! Builds the stack into the NOTE_METADATA word, encoding the note type and execution hint into a
+#! single element.
+#! Note that this procedure is only exported so it can be tested. It should not be called from
+#! non-test code.
+#!
+#! Inputs:  [tag, aux, note_type, execution_hint]
+#! Outputs: [NOTE_METADATA]
+#!
+#! Where:
+#! - tag is the note tag which can be used by the recipient(s) to identify notes intended for them.
+#! - aux is the arbitrary user-defined value.
+#! - note_type is the type of the note, which defines how the note is to be stored (e.g., on-chain
+#!   or off-chain).
+#! - execution_hint is the hint which specifies when a note is ready to be consumed.
+#! - NOTE_METADATA is the metadata associated with a note.
+export.build_note_metadata
+
+    # Validate the note type.
+    # --------------------------------------------------------------------------------------------
+
+    # NOTE: encrypted notes are currently unsupported
+    dup.2 eq.PRIVATE_NOTE dup.3 eq.PUBLIC_NOTE or assert.err=ERR_NOTE_INVALID_TYPE
+    # => [tag, aux, note_type, execution_hint]
+
+    # copy data to validate the tag
+    dup.2 push.PUBLIC_NOTE dup.1 dup.3
+    # => [tag, note_type, public_note, note_type, tag, aux, note_type, execution_hint]
+
+    u32assert.err=ERR_NOTE_TAG_MUST_BE_U32
+    # => [tag, note_type, public_note, note_type, tag, aux, note_type, execution_hint]
+
+    # enforce the note type depending on the tag' bits
+    u32shr.30 eq.LOCAL_ANY_PREFIX cdrop
+    assert_eq.err=ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX
+    # => [tag, aux, note_type, execution_hint]
+
+    # Split execution hint into its tag and payload parts as they are encoded in separate elements
+    # of the metadata.
+    # --------------------------------------------------------------------------------------------
+
+    # the execution_hint is laid out like this: [26 zero bits | payload (32 bits) | tag (6 bits)]
+    movup.3
+    # => [execution_hint, tag, aux, note_type]
+    dup u32split drop
+    # => [execution_hint_lo, execution_hint, tag, aux, note_type]
+
+    # mask out the lower 6 execution hint tag bits.
+    u32and.0x3f
+    # => [execution_hint_tag, execution_hint, tag, aux, note_type]
+
+    # compute the payload by subtracting the tag value so the lower 6 bits are zero
+    # note that this results in the following layout: [26 zero bits | payload (32 bits) | 6 zero bits]
+    swap
+    # => [execution_hint, execution_hint_tag, tag, aux, note_type]
+    dup.1
+    # => [execution_hint_tag, execution_hint, execution_hint_tag, tag, aux, note_type]
+    sub
+    # => [execution_hint_payload, execution_hint_tag, tag, aux, note_type]
+
+    # Merge execution hint payload and note tag.
+    # --------------------------------------------------------------------------------------------
+
+    # we need to move the payload to the upper 32 bits of the felt
+    # we only need to shift by 26 bits because the payload is already shifted left by 6 bits
+    # we shift the payload by multiplying with 2^26
+    # this results in the lower 32 bits being zero which is where the note tag will be added
+    mul.0x04000000
+    # => [execution_hint_payload, execution_hint_tag, tag, aux, note_type]
+
+    # add the tag to the payload to produce the merged value
+    movup.2 add
+    # => [note_tag_hint_payload, execution_hint_tag, aux, note_type]
+
+    # Merge sender_id_suffix, note_type and execution_hint_tag.
+    # --------------------------------------------------------------------------------------------
+
+    exec.account::get_id
+    # => [sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux, note_type]
+
+    movup.5
+    # => [note_type, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux]
+    # multiply by 2^6 to shift the two note_type bits left by 6 bits.
+    mul.0x40
+    # => [shifted_note_type, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux]
+
+    # merge execution_hint_tag into the note_type
+    # this produces an 8-bit value with the layout: [note_type (2 bits) | execution_hint_tag (6 bits)]
+    movup.4 add
+    # => [merged_note_type_execution_hint_tag, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, aux]
+
+    # merge sender_id_suffix into this value
+    movup.2 add
+    # => [sender_id_suffix_type_and_hint_tag, sender_id_prefix, note_tag_hint_payload, aux]
+
+    # Rearrange elements to produce the final note metadata layout.
+    # --------------------------------------------------------------------------------------------
+
+    swap movdn.3
+    # => [sender_id_suffix_type_and_hint_tag, note_tag_hint_payload, aux, sender_id_prefix]
+    swap
+    # => [note_tag_hint_payload, sender_id_suffix_type_and_hint_tag, aux, sender_id_prefix]
+    movup.2
+    # => [NOTE_METADATA = [aux, note_tag_hint_payload, sender_id_suffix_type_and_hint_tag, sender_id_prefix]]
+end
+
+#! Increments the number of output notes by one. Returns the index of the next note to be created.
+#!
+#! Inputs:  []
+#! Outputs: [note_idx]
+#!
+#! Where:
+#! - note_idx is the index of the next note to be created.
+proc.increment_num_output_notes
+    # get the current number of output notes
+    exec.memory::get_num_output_notes
+    # => [note_idx]
+
+    # assert that there is space for a new note
+    dup exec.constants::get_max_num_output_notes lt
+    assert.err=ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT
+    # => [note_idx]
+
+    # increment the number of output notes
+    dup add.1 exec.memory::set_num_output_notes
+    # => [note_idx]
+end
 
 #! Adds a fungible asset to a note. If the note already holds an asset issued by the same faucet id
 #! the two quantities are summed up and the new quantity is stored at the old position in the note.

--- a/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
@@ -1,10 +1,25 @@
 use.$kernel::memory
 use.$kernel::note
+use.$kernel::asset
 
 # ERRORS
 # =================================================================================================
 
 const.ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS="requested output note index should be less than the total number of created output notes"
+
+const.ERR_NOTE_INVALID_INDEX="failed to find note at the given index; index must be within [0, num_of_notes]"
+
+const.ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED="adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
+
+const.ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS="non-fungible asset that already exists in the note cannot be added again"
+
+# EVENTS
+# =================================================================================================
+
+# Event emitted before an ASSET is added to a note
+const.NOTE_BEFORE_ADD_ASSET_EVENT=131085
+# Event emitted after an ASSET is added to a note
+const.NOTE_AFTER_ADD_ASSET_EVENT=131086
 
 # OUTPUT NOTE PROCEDURES
 # =================================================================================================
@@ -62,6 +77,66 @@ export.get_assets_info
     # => [ASSETS_COMMITMENT, num_assets]
 end
 
+#! Adds the ASSET to the note specified by the index.
+#!
+#! Inputs:  [note_idx, ASSET]
+#! Outputs: [note_idx]
+#!
+#! Where:
+#! - note_idx is the index of the note to which the asset is added.
+#! - ASSET can be a fungible or non-fungible asset.
+#!
+#! Panics if:
+#! - the ASSET is malformed (e.g., invalid faucet ID).
+#! - the max amount of fungible assets is exceeded.
+#! - the non-fungible asset already exists in the note.
+#! - the total number of ASSETs exceeds the maximum of 256.
+export.add_asset_to_note
+    # check if the note exists, it must be within [0, num_of_notes]
+    dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
+    # => [note_idx, ASSET]
+
+    # get a pointer to the memory address of the note at which the asset will be stored
+    dup movdn.5 exec.memory::get_output_note_ptr
+    # => [note_ptr, ASSET, note_idx]
+
+    # get current num of assets
+    dup exec.memory::get_output_note_num_assets movdn.5
+    # => [note_ptr, ASSET, num_of_assets, note_idx]
+
+    # validate the ASSET
+    movdn.4 exec.asset::validate_asset
+    # => [ASSET, note_ptr, num_of_assets, note_idx]
+
+    # emit event to signal that a new asset is going to be added to the note.
+    emit.NOTE_BEFORE_ADD_ASSET_EVENT
+    # => [ASSET, note_ptr, num_of_assets, note_idx]
+
+    # Check if ASSET to add is fungible
+    exec.asset::is_fungible_asset
+    # => [is_fungible_asset?, ASSET, note_ptr, num_of_assets, note_idx]
+
+    if.true
+        # ASSET to add is fungible
+        exec.add_fungible_asset_to_note
+        # => [note_ptr, note_idx]
+    else
+        # ASSET to add is non-fungible
+        exec.add_non_fungible_asset_to_note
+        # => [note_ptr, note_idx]
+    end
+    # => [note_ptr, note_idx]
+
+    # update the assets commitment dirty flag to signal that the current assets commitment is not 
+    # valid anymore
+    push.1 swap exec.memory::set_output_note_dirty_flag
+    # => [note_idx]
+
+    # emit event to signal that a new asset was added to the note.
+    emit.NOTE_AFTER_ADD_ASSET_EVENT
+    # => [note_idx]
+end
+
 #! Assert that the provided note index is less than the total number of output notes.
 #!
 #! Inputs:  [note_index]
@@ -74,4 +149,158 @@ export.assert_note_index_in_bounds
     u32assert2.err=ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS
     u32lt assert.err=ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS
     # => [note_index]
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Adds a fungible asset to a note. If the note already holds an asset issued by the same faucet id
+#! the two quantities are summed up and the new quantity is stored at the old position in the note.
+#! In the other case, the asset is stored at the next available position.
+#! Returns the pointer to the note the asset was stored at.
+#!
+#! Inputs:  [ASSET, note_ptr, num_of_assets, note_idx]
+#! Outputs: [note_ptr]
+#!
+#! Where:
+#! - ASSET is the fungible asset to be added to the note.
+#! - note_ptr is the pointer to the note the asset will be added to.
+#! - num_of_assets is the current number of assets.
+#! - note_idx is the index of the note the asset will be added to.
+#!
+#! Panics if
+#! - the summed amounts exceed the maximum amount of fungible assets.
+proc.add_fungible_asset_to_note
+    dup.4 exec.memory::get_output_note_asset_data_ptr
+    # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
+
+    # compute the pointer at which we should stop iterating
+    dup dup.7 mul.4 add
+    # => [end_asset_ptr, asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
+
+    # reorganize and pad the stack, prepare for the loop
+    movdn.5 movdn.5 padw dup.9
+    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+    # compute the loop latch
+    dup dup.10 neq
+    # => [latch, asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
+    #     note_idx]
+
+    while.true
+        mem_loadw
+        # => [STORED_ASSET, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+        dup.4 eq
+        # => [are_equal, 0, 0, stored_amount, ASSET, end_asset_ptr, asset_ptr, note_ptr,
+        #     num_of_assets, note_idx]
+
+        if.true
+            # add the asset quantity, we don't overflow here, bc both ASSETs are valid.
+            movup.2 movup.6 add
+            # => [updated_amount, 0, 0, faucet_id, 0, 0, end_asset_ptr, asset_ptr, note_ptr,
+            #     num_of_assets, note_idx]
+
+            # check that we don't overflow bc we use lte
+            dup exec.asset::get_fungible_asset_max_amount lte
+            assert.err=ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED
+            # => [updated_amount, 0, 0, faucet_id, 0, 0, end_asset_ptr, asset_ptr, note_ptr,
+            #     num_of_assets, note_idx]
+
+            # prepare stack to store the "updated" ASSET'' with the new quantity
+            movdn.5
+            # => [0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+            # decrease num_of_assets by 1 to offset incrementing it later
+            movup.9 sub.1 movdn.9
+            # => [0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr, num_of_assets - 1, note_idx]
+
+            # end the loop we add 0's to the stack to have the correct number of elements
+            push.0.0 dup.9 push.0
+            # => [0, asset_ptr, 0, 0, 0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr,
+            #     num_of_assets - 1, note_idx]
+        else
+            # => [0, 0, stored_amount, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
+            #     note_idx]
+
+            # drop ASSETs and increment the asset pointer
+            movup.2 drop push.0.0 movup.9 add.4 dup movdn.10
+            # => [asset_ptr + 4, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr + 4, note_ptr,
+            #     num_of_assets, note_idx]
+
+            # check if we reached the end of the loop
+            dup dup.10 neq
+        end
+    end
+    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+    # prepare stack for storing the ASSET
+    movdn.4 dropw
+    # => [asset_ptr, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+    # Store the fungible asset, either the combined ASSET or the new ASSET
+    mem_storew dropw drop drop
+    # => [note_ptr, num_of_assets, note_idx]
+
+    # increase the number of assets in the note
+    swap add.1 dup.1 exec.memory::set_output_note_num_assets
+    # => [note_ptr, note_idx]
+end
+
+#! Adds a non-fungible asset to a note at the next available position.
+#! Returns the pointer to the note the asset was stored at.
+#!
+#! Inputs:  [ASSET, note_ptr, num_of_assets, note_idx]
+#! Outputs: [note_ptr, note_idx]
+#!
+#! Where:
+#! - ASSET is the non-fungible asset to be added to the note.
+#! - note_ptr is the pointer to the note the asset will be added to.
+#! - num_of_assets is the current number of assets.
+#! - note_idx is the index of the note the asset will be added to.
+#!
+#! Panics if:
+#! - the non-fungible asset already exists in the note.
+proc.add_non_fungible_asset_to_note
+    dup.4 exec.memory::get_output_note_asset_data_ptr
+    # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
+
+    # compute the pointer at which we should stop iterating
+    dup dup.7 mul.4 add
+    # => [end_asset_ptr, asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
+
+    # reorganize and pad the stack, prepare for the loop
+    movdn.5 movdn.5 padw dup.9
+    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+    # compute the loop latch
+    dup dup.10 neq
+    # => [latch, asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
+    #     note_idx]
+
+    while.true
+        # load the asset and compare
+        mem_loadw eqw assertz.err=ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS
+        # => [ASSET', ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+        # drop ASSET' and increment the asset pointer
+        dropw movup.5 add.4 dup movdn.6 padw movup.4
+        # => [asset_ptr + 4, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr + 4, note_ptr,
+        #     num_of_assets, note_idx]
+
+        # check if we reached the end of the loop
+        dup dup.10 neq
+    end
+    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+    # prepare stack for storing the ASSET
+    movdn.4 dropw
+    # => [asset_ptr, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
+
+    # end of the loop reached, no error so we can store the non-fungible asset
+    mem_storew dropw drop drop
+    # => [note_ptr, num_of_assets, note_idx]
+
+    # increase the number of assets in the note
+    swap add.1 dup.1 exec.memory::set_output_note_num_assets
+    # => [note_ptr, note_idx]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
@@ -70,6 +70,15 @@ const.NOTE_AFTER_ADD_ASSET_EVENT=131086
 # OUTPUT NOTE PROCEDURES
 # =================================================================================================
 
+#! Returns the current number of output notes created in this transaction.
+#!
+#! Inputs:  []
+#! Outputs: [num_output_notes]
+#!
+#! Where:
+#! - num_output_notes is the number of output notes created in this transaction so far.
+export.memory::get_num_output_notes->get_num_notes
+
 #! Creates a new note and returns the index of the note.
 #!
 #! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -1,25 +1,11 @@
-use.$kernel::account
-use.$kernel::asset
-use.$kernel::constants
 use.$kernel::memory
 use.$kernel::note
 
 # CONSTANTS
 # =================================================================================================
 
-# Constants for different note types
-const.PUBLIC_NOTE=1     # 0b01
-const.PRIVATE_NOTE=2    # 0b10
-const.ENCRYPTED_NOTE=3  # 0b11
-
-# Two raised to the power of 38 (2^38), used for shifting the note type value
-const.TWO_POW_38=274877906944
-
 # Max value for U16, used as the upper limit for expiration block delta
 const.EXPIRY_UPPER_LIMIT=0xFFFF+1
-
-# The note type must be PUBLIC, unless the high bits are `0b11`. (See the table below.)
-const.LOCAL_ANY_PREFIX=3 # 0b11
 
 # Max U32 value, used for initializing the expiration block number
 const.MAX_BLOCK_NUM=0xFFFFFFFF
@@ -27,45 +13,7 @@ const.MAX_BLOCK_NUM=0xFFFFFFFF
 # ERRORS
 # =================================================================================================
 
-const.ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT="number of output notes in the transaction exceeds the maximum limit of 1024"
-
-const.ERR_NOTE_INVALID_TYPE="invalid note type"
-
-# The 2 highest bits in the u32 tag have the following meaning:
-#
-# | Prefix | Name                   | [`NoteExecutionMode`] | Target                   | Allowed [`NoteType`] |
-# | :----: | :--------------------: | :-------------------: | :----------------------: | :------------------: |
-# | `0b00` | `NetworkAccount`       | Network               | Network Account          | [`NoteType::Public`] |
-# | `0b01` | `NetworkUseCase`       | Network               | Use case                 | [`NoteType::Public`] |
-# | `0b10` | `LocalPublicAny`       | Local                 | Any                      | [`NoteType::Public`] |
-# | `0b11` | `LocalAny`             | Local                 | Any                      | Any                  |
-#
-# Execution: Is a hint for the network, to check if the note can be consumed by a network controlled
-#   account
-# Target: Is a hint for the type of target. Use case means the note may be consumed by anyone,
-#   specific means there is a specific target for the note (the target may be a public key, a user
-#   that knows some secret, or a specific account ID)
-#
-# Only the note type from the above list is enforced. The other values are only hints intended as a
-# best effort optimization strategy. A badly formatted note may 1. not be consumed because honest
-# users won't see the note 2. generate slightly more load as extra validation is performed for the
-# invalid tags. None of these scenarios have any significant impact.
-
-const.ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX="invalid note type for the given note tag prefix"
-
-const.ERR_NOTE_TAG_MUST_BE_U32="the note's tag must fit into a u32 so the 32 most significant bits must be zero"
-
-const.ERR_NOTE_NETWORK_EXECUTION_DOES_NOT_TARGET_NETWORK_ACCOUNT="network execution mode with a specific target can only target network accounts"
-
 const.ERR_TX_INVALID_EXPIRATION_DELTA="transaction expiration block delta must be within 0x1 and 0xFFFF"
-
-# EVENTS
-# =================================================================================================
-
-# Event emitted before a new note is created.
-const.NOTE_BEFORE_CREATED_EVENT=131083
-# Event emitted after a new note is created.
-const.NOTE_AFTER_CREATED_EVENT=131084
 
 # PROCEDURES
 # =================================================================================================
@@ -136,28 +84,6 @@ export.memory::get_num_input_notes
 #! - num_output_notes is the number of output notes created in this transaction so far.
 export.memory::get_num_output_notes
 
-#! Increments the number of output notes by one. Returns the index of the next note to be created.
-#!
-#! Inputs:  []
-#! Outputs: [note_idx]
-#!
-#! Where:
-#! - note_idx is the index of the next note to be created.
-proc.increment_num_output_notes
-    # get the current number of output notes
-    exec.memory::get_num_output_notes
-    # => [note_idx]
-
-    # assert that there is space for a new note
-    dup exec.constants::get_max_num_output_notes lt
-    assert.err=ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT
-    # => [note_idx]
-
-    # increment the number of output notes
-    dup add.1 exec.memory::set_num_output_notes
-    # => [note_idx]
-end
-
 #! Updates the transaction expiration block number.
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper
@@ -216,157 +142,4 @@ export.get_expiration_delta
         # Calculate the delta
         exec.get_block_number sub
     end
-end
-
-#! Builds the stack into the NOTE_METADATA word, encoding the note type and execution hint into a
-#! single element.
-#! Note that this procedure is only exported so it can be tested. It should not be called from
-#! non-test code.
-#!
-#! Inputs:  [tag, aux, note_type, execution_hint]
-#! Outputs: [NOTE_METADATA]
-#!
-#! Where:
-#! - tag is the note tag which can be used by the recipient(s) to identify notes intended for them.
-#! - aux is the arbitrary user-defined value.
-#! - note_type is the type of the note, which defines how the note is to be stored (e.g., on-chain
-#!   or off-chain).
-#! - execution_hint is the hint which specifies when a note is ready to be consumed.
-#! - NOTE_METADATA is the metadata associated with a note.
-export.build_note_metadata
-
-    # Validate the note type.
-    # --------------------------------------------------------------------------------------------
-
-    # NOTE: encrypted notes are currently unsupported
-    dup.2 eq.PRIVATE_NOTE dup.3 eq.PUBLIC_NOTE or assert.err=ERR_NOTE_INVALID_TYPE
-    # => [tag, aux, note_type, execution_hint]
-
-    # copy data to validate the tag
-    dup.2 push.PUBLIC_NOTE dup.1 dup.3
-    # => [tag, note_type, public_note, note_type, tag, aux, note_type, execution_hint]
-
-    u32assert.err=ERR_NOTE_TAG_MUST_BE_U32
-    # => [tag, note_type, public_note, note_type, tag, aux, note_type, execution_hint]
-
-    # enforce the note type depending on the tag' bits
-    u32shr.30 eq.LOCAL_ANY_PREFIX cdrop
-    assert_eq.err=ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX
-    # => [tag, aux, note_type, execution_hint]
-
-    # Split execution hint into its tag and payload parts as they are encoded in separate elements
-    # of the metadata.
-    # --------------------------------------------------------------------------------------------
-
-    # the execution_hint is laid out like this: [26 zero bits | payload (32 bits) | tag (6 bits)]
-    movup.3
-    # => [execution_hint, tag, aux, note_type]
-    dup u32split drop
-    # => [execution_hint_lo, execution_hint, tag, aux, note_type]
-
-    # mask out the lower 6 execution hint tag bits.
-    u32and.0x3f
-    # => [execution_hint_tag, execution_hint, tag, aux, note_type]
-
-    # compute the payload by subtracting the tag value so the lower 6 bits are zero
-    # note that this results in the following layout: [26 zero bits | payload (32 bits) | 6 zero bits]
-    swap
-    # => [execution_hint, execution_hint_tag, tag, aux, note_type]
-    dup.1
-    # => [execution_hint_tag, execution_hint, execution_hint_tag, tag, aux, note_type]
-    sub
-    # => [execution_hint_payload, execution_hint_tag, tag, aux, note_type]
-
-    # Merge execution hint payload and note tag.
-    # --------------------------------------------------------------------------------------------
-
-    # we need to move the payload to the upper 32 bits of the felt
-    # we only need to shift by 26 bits because the payload is already shifted left by 6 bits
-    # we shift the payload by multiplying with 2^26
-    # this results in the lower 32 bits being zero which is where the note tag will be added
-    mul.0x04000000
-    # => [execution_hint_payload, execution_hint_tag, tag, aux, note_type]
-
-    # add the tag to the payload to produce the merged value
-    movup.2 add
-    # => [note_tag_hint_payload, execution_hint_tag, aux, note_type]
-
-    # Merge sender_id_suffix, note_type and execution_hint_tag.
-    # --------------------------------------------------------------------------------------------
-
-    exec.account::get_id
-    # => [sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux, note_type]
-
-    movup.5
-    # => [note_type, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux]
-    # multiply by 2^6 to shift the two note_type bits left by 6 bits.
-    mul.0x40
-    # => [shifted_note_type, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, execution_hint_tag, aux]
-
-    # merge execution_hint_tag into the note_type
-    # this produces an 8-bit value with the layout: [note_type (2 bits) | execution_hint_tag (6 bits)]
-    movup.4 add
-    # => [merged_note_type_execution_hint_tag, sender_id_prefix, sender_id_suffix, note_tag_hint_payload, aux]
-
-    # merge sender_id_suffix into this value
-    movup.2 add
-    # => [sender_id_suffix_type_and_hint_tag, sender_id_prefix, note_tag_hint_payload, aux]
-
-    # Rearrange elements to produce the final note metadata layout.
-    # --------------------------------------------------------------------------------------------
-
-    swap movdn.3
-    # => [sender_id_suffix_type_and_hint_tag, note_tag_hint_payload, aux, sender_id_prefix]
-    swap
-    # => [note_tag_hint_payload, sender_id_suffix_type_and_hint_tag, aux, sender_id_prefix]
-    movup.2
-    # => [NOTE_METADATA = [aux, note_tag_hint_payload, sender_id_suffix_type_and_hint_tag, sender_id_prefix]]
-end
-
-#! Creates a new note and returns the index of the note.
-#!
-#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
-#! Outputs: [note_idx]
-#!
-#! Where:
-#! - tag is the note tag which can be used by the recipient(s) to identify notes intended for them.
-#! - aux is the arbitrary user-defined value.
-#! - note_type is the type of the note, which defines how the note is to be stored (e.g., on-chain
-#!   or off-chain).
-#! - execution_hint is the hint which specifies when a note is ready to be consumed.
-#! - RECIPIENT defines spend conditions for the note.
-#! - note_idx is the index of the created note.
-#!
-#! Panics if:
-#! - the note_type is not valid.
-#! - the note_tag is not an u32.
-#! - the note_tag starts with anything but 0b11 and note_type is not public.
-#! - the number of output notes exceeds the maximum limit of 1024.
-export.create_note
-    emit.NOTE_BEFORE_CREATED_EVENT
-
-    exec.build_note_metadata
-    # => [NOTE_METADATA, RECIPIENT]
-
-    # get the index for the next note to be created and increment counter
-    exec.increment_num_output_notes dup movdn.9
-    # => [note_idx, NOTE_METADATA, RECIPIENT, note_idx]
-
-    # get a pointer to the memory address at which the note will be stored
-    exec.memory::get_output_note_ptr
-    # => [note_ptr, NOTE_METADATA, RECIPIENT, note_idx]
-
-    movdn.4
-    # => [NOTE_METADATA, note_ptr, RECIPIENT, note_idx]
-
-    # emit event to signal that a new note is created
-    emit.NOTE_AFTER_CREATED_EVENT
-
-    # set the metadata for the output note
-    dup.4 exec.memory::set_output_note_metadata dropw
-    # => [note_ptr, RECIPIENT, note_idx]
-
-    # set the RECIPIENT for the output note
-    exec.memory::set_output_note_recipient dropw
-    # => [note_idx]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -84,7 +84,7 @@ export.memory::get_num_input_notes
 #! - num_output_notes is the number of output notes created in this transaction so far.
 export.memory::get_num_output_notes
 
-#! Updates the transaction expiration block number.
+#! Updates the transaction expiration block delta.
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper
 #! limit at which the transaction will be considered valid (not expired).
@@ -95,7 +95,7 @@ export.memory::get_num_output_notes
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-export.update_expiration_block_num
+export.update_expiration_block_delta
     # Ensure block_height_delta is between 1 and 0xFFFF (inclusive)
     dup neq.0 assert.err=ERR_TX_INVALID_EXPIRATION_DELTA
     # => [block_height_delta]

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -55,12 +55,6 @@ const.ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX="invalid note type for the 
 
 const.ERR_NOTE_TAG_MUST_BE_U32="the note's tag must fit into a u32 so the 32 most significant bits must be zero"
 
-const.ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED="adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
-
-const.ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS="non-fungible asset that already exists in the note cannot be added again"
-
-const.ERR_NOTE_INVALID_INDEX="failed to find note at the given index; index must be within [0, num_of_notes]"
-
 const.ERR_NOTE_NETWORK_EXECUTION_DOES_NOT_TARGET_NETWORK_ACCOUNT="network execution mode with a specific target can only target network accounts"
 
 const.ERR_TX_INVALID_EXPIRATION_DELTA="transaction expiration block delta must be within 0x1 and 0xFFFF"
@@ -72,11 +66,6 @@ const.ERR_TX_INVALID_EXPIRATION_DELTA="transaction expiration block delta must b
 const.NOTE_BEFORE_CREATED_EVENT=131083
 # Event emitted after a new note is created.
 const.NOTE_AFTER_CREATED_EVENT=131084
-
-# Event emitted before an ASSET is added to a note
-const.NOTE_BEFORE_ADD_ASSET_EVENT=131085
-# Event emitted after an ASSET is added to a note
-const.NOTE_AFTER_ADD_ASSET_EVENT=131086
 
 # PROCEDURES
 # =================================================================================================
@@ -169,65 +158,6 @@ proc.increment_num_output_notes
     # => [note_idx]
 end
 
-#! Adds a non-fungible asset to a note at the next available position.
-#! Returns the pointer to the note the asset was stored at.
-#!
-#! Inputs:  [ASSET, note_ptr, num_of_assets, note_idx]
-#! Outputs: [note_ptr, note_idx]
-#!
-#! Where:
-#! - ASSET is the non-fungible asset to be added to the note.
-#! - note_ptr is the pointer to the note the asset will be added to.
-#! - num_of_assets is the current number of assets.
-#! - note_idx is the index of the note the asset will be added to.
-#!
-#! Panics if:
-#! - the non-fungible asset already exists in the note.
-proc.add_non_fungible_asset_to_note
-    dup.4 exec.memory::get_output_note_asset_data_ptr
-    # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
-
-    # compute the pointer at which we should stop iterating
-    dup dup.7 mul.4 add
-    # => [end_asset_ptr, asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
-
-    # reorganize and pad the stack, prepare for the loop
-    movdn.5 movdn.5 padw dup.9
-    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-    # compute the loop latch
-    dup dup.10 neq
-    # => [latch, asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
-    #     note_idx]
-
-    while.true
-        # load the asset and compare
-        mem_loadw eqw assertz.err=ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS
-        # => [ASSET', ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-        # drop ASSET' and increment the asset pointer
-        dropw movup.5 add.4 dup movdn.6 padw movup.4
-        # => [asset_ptr + 4, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr + 4, note_ptr,
-        #     num_of_assets, note_idx]
-
-        # check if we reached the end of the loop
-        dup dup.10 neq
-    end
-    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-    # prepare stack for storing the ASSET
-    movdn.4 dropw
-    # => [asset_ptr, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-    # end of the loop reached, no error so we can store the non-fungible asset
-    mem_storew dropw drop drop
-    # => [note_ptr, num_of_assets, note_idx]
-
-    # increase the number of assets in the note
-    swap add.1 dup.1 exec.memory::set_output_note_num_assets
-    # => [note_ptr, note_idx]
-end
-
 #! Updates the transaction expiration block number.
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper
@@ -286,98 +216,6 @@ export.get_expiration_delta
         # Calculate the delta
         exec.get_block_number sub
     end
-end
-
-#! Adds a fungible asset to a note. If the note already holds an asset issued by the same faucet id
-#! the two quantities are summed up and the new quantity is stored at the old position in the note.
-#! In the other case, the asset is stored at the next available position.
-#! Returns the pointer to the note the asset was stored at.
-#!
-#! Inputs:  [ASSET, note_ptr, num_of_assets, note_idx]
-#! Outputs: [note_ptr]
-#!
-#! Where:
-#! - ASSET is the fungible asset to be added to the note.
-#! - note_ptr is the pointer to the note the asset will be added to.
-#! - num_of_assets is the current number of assets.
-#! - note_idx is the index of the note the asset will be added to.
-#!
-#! Panics if
-#! - the summed amounts exceed the maximum amount of fungible assets.
-proc.add_fungible_asset_to_note
-    dup.4 exec.memory::get_output_note_asset_data_ptr
-    # => [asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
-
-    # compute the pointer at which we should stop iterating
-    dup dup.7 mul.4 add
-    # => [end_asset_ptr, asset_ptr, ASSET, note_ptr, num_of_assets, note_idx]
-
-    # reorganize and pad the stack, prepare for the loop
-    movdn.5 movdn.5 padw dup.9
-    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-    # compute the loop latch
-    dup dup.10 neq
-    # => [latch, asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
-    #     note_idx]
-
-    while.true
-        mem_loadw
-        # => [STORED_ASSET, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-        dup.4 eq
-        # => [are_equal, 0, 0, stored_amount, ASSET, end_asset_ptr, asset_ptr, note_ptr,
-        #     num_of_assets, note_idx]
-
-        if.true
-            # add the asset quantity, we don't overflow here, bc both ASSETs are valid.
-            movup.2 movup.6 add
-            # => [updated_amount, 0, 0, faucet_id, 0, 0, end_asset_ptr, asset_ptr, note_ptr,
-            #     num_of_assets, note_idx]
-
-            # check that we don't overflow bc we use lte
-            dup exec.asset::get_fungible_asset_max_amount lte
-            assert.err=ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED
-            # => [updated_amount, 0, 0, faucet_id, 0, 0, end_asset_ptr, asset_ptr, note_ptr,
-            #     num_of_assets, note_idx]
-
-            # prepare stack to store the "updated" ASSET'' with the new quantity
-            movdn.5
-            # => [0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-            # decrease num_of_assets by 1 to offset incrementing it later
-            movup.9 sub.1 movdn.9
-            # => [0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr, num_of_assets - 1, note_idx]
-
-            # end the loop we add 0's to the stack to have the correct number of elements
-            push.0.0 dup.9 push.0
-            # => [0, asset_ptr, 0, 0, 0, 0, ASSET'', end_asset_ptr, asset_ptr, note_ptr,
-            #     num_of_assets - 1, note_idx]
-        else
-            # => [0, 0, stored_amount, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets,
-            #     note_idx]
-
-            # drop ASSETs and increment the asset pointer
-            movup.2 drop push.0.0 movup.9 add.4 dup movdn.10
-            # => [asset_ptr + 4, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr + 4, note_ptr,
-            #     num_of_assets, note_idx]
-
-            # check if we reached the end of the loop
-            dup dup.10 neq
-        end
-    end
-    # => [asset_ptr, 0, 0, 0, 0, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-    # prepare stack for storing the ASSET
-    movdn.4 dropw
-    # => [asset_ptr, ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
-
-    # Store the fungible asset, either the combined ASSET or the new ASSET
-    mem_storew dropw drop drop
-    # => [note_ptr, num_of_assets, note_idx]
-
-    # increase the number of assets in the note
-    swap add.1 dup.1 exec.memory::set_output_note_num_assets
-    # => [note_ptr, note_idx]
 end
 
 #! Builds the stack into the NOTE_METADATA word, encoding the note type and execution hint into a
@@ -530,65 +368,5 @@ export.create_note
 
     # set the RECIPIENT for the output note
     exec.memory::set_output_note_recipient dropw
-    # => [note_idx]
-end
-
-#! Adds the ASSET to the note specified by the index.
-#!
-#! Inputs:  [note_idx, ASSET]
-#! Outputs: [note_idx]
-#!
-#! Where:
-#! - note_idx is the index of the note to which the asset is added.
-#! - ASSET can be a fungible or non-fungible asset.
-#!
-#! Panics if:
-#! - the ASSET is malformed (e.g., invalid faucet ID).
-#! - the max amount of fungible assets is exceeded.
-#! - the non-fungible asset already exists in the note.
-#! - the total number of ASSETs exceeds the maximum of 256.
-export.add_asset_to_note
-    # check if the note exists, it must be within [0, num_of_notes]
-    dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
-    # => [note_idx, ASSET]
-
-    # get a pointer to the memory address of the note at which the asset will be stored
-    dup movdn.5 exec.memory::get_output_note_ptr
-    # => [note_ptr, ASSET, note_idx]
-
-    # get current num of assets
-    dup exec.memory::get_output_note_num_assets movdn.5
-    # => [note_ptr, ASSET, num_of_assets, note_idx]
-
-    # validate the ASSET
-    movdn.4 exec.asset::validate_asset
-    # => [ASSET, note_ptr, num_of_assets, note_idx]
-
-    # emit event to signal that a new asset is going to be added to the note.
-    emit.NOTE_BEFORE_ADD_ASSET_EVENT
-    # => [ASSET, note_ptr, num_of_assets, note_idx]
-
-    # Check if ASSET to add is fungible
-    exec.asset::is_fungible_asset
-    # => [is_fungible_asset?, ASSET, note_ptr, num_of_assets, note_idx]
-
-    if.true
-        # ASSET to add is fungible
-        exec.add_fungible_asset_to_note
-        # => [note_ptr, note_idx]
-    else
-        # ASSET to add is non-fungible
-        exec.add_non_fungible_asset_to_note
-        # => [note_ptr, note_idx]
-    end
-    # => [note_ptr, note_idx]
-
-    # update the assets commitment dirty flag to signal that the current assets commitment is not 
-    # valid anymore
-    push.1 swap exec.memory::set_output_note_dirty_flag
-    # => [note_idx]
-
-    # emit event to signal that a new asset was added to the note.
-    emit.NOTE_AFTER_ADD_ASSET_EVENT
     # => [note_idx]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/tx.masm
@@ -66,24 +66,6 @@ export.memory::get_input_notes_commitment
 #! - OUTPUT_NOTES_COMMITMENT is the output notes commitment.
 export.note::compute_output_notes_commitment->get_output_notes_commitment
 
-#! Returns the total number of input notes consumed by this transaction.
-#!
-#! Inputs:  []
-#! Outputs: [num_input_notes]
-#!
-#! Where:
-#! - num_input_notes is the total number of input notes consumed by this transaction.
-export.memory::get_num_input_notes
-
-#! Returns the current number of output notes created in this transaction.
-#!
-#! Inputs:  []
-#! Outputs: [num_output_notes]
-#!
-#! Where:
-#! - num_output_notes is the number of output notes created in this transaction so far.
-export.memory::get_num_output_notes
-
 #! Updates the transaction expiration block delta.
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper

--- a/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
+++ b/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
@@ -82,7 +82,7 @@ export.distribute.4
     # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
 
     # create a note
-    exec.tx::create_note
+    exec.output_note::create
     # => [note_idx, pad(15)]
 
     # load the ASSET and add it to the note

--- a/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
+++ b/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
@@ -7,9 +7,11 @@
 # - max_supply is the maximum supply of the token.
 # - decimals are the decimals of the token.
 # - token_symbol as three chars encoded in a Felt.
+
 use.miden::account
 use.miden::faucet
 use.miden::tx
+use.miden::output_note
 use.miden::contracts::auth::basic
 
 # CONSTANTS
@@ -84,7 +86,7 @@ export.distribute.4
     # => [note_idx, pad(15)]
 
     # load the ASSET and add it to the note
-    movdn.4 loc_loadw.0 exec.tx::add_asset_to_note movup.4
+    movdn.4 loc_loadw.0 exec.output_note::add_asset movup.4
     # => [note_idx, ASSET, pad(11)]
 end
 

--- a/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
+++ b/crates/miden-lib/asm/miden/contracts/faucets/basic_fungible.masm
@@ -10,9 +10,7 @@
 
 use.miden::account
 use.miden::faucet
-use.miden::tx
 use.miden::output_note
-use.miden::contracts::auth::basic
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-lib/asm/miden/contracts/wallets/basic.masm
+++ b/crates/miden-lib/asm/miden/contracts/wallets/basic.masm
@@ -1,5 +1,5 @@
 use.miden::account
-use.miden::tx
+use.miden::output_note
 
 # CONSTANTS
 # =================================================================================================
@@ -53,6 +53,6 @@ export.move_asset_to_note
     exec.account::remove_asset
     # => [ASSET, note_idx, pad(11)]
 
-    exec.tx::add_asset_to_note
+    exec.output_note::add_asset
     # => [ASSET, note_idx, pad(11) ...]
 end

--- a/crates/miden-lib/asm/miden/input_note.masm
+++ b/crates/miden-lib/asm/miden/input_note.masm
@@ -4,6 +4,31 @@ use.miden::note
 # PROCEDURES
 # =================================================================================================
 
+#! Returns the total number of input notes consumed by this transaction.
+#!
+#! Inputs:  []
+#! Outputs: [num_input_notes]
+#!
+#! Where:
+#! - num_input_notes is the total number of input notes consumed by this transaction.
+#!
+#! Invocation: exec
+export.get_num_notes
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [pad(15)]
+
+    exec.kernel_proc_offsets::input_note_get_num_notes_offset
+    # => [offset, pad(15)]
+
+    syscall.exec_kernel_proc
+    # => [num_input_notes, pad(15)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
+    # => [num_input_notes]
+end
+
 #! Returns the information about assets in the input note with the specified index.
 #!
 #! This information can then be used to retrieve the actual assets from the advice map.

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -57,20 +57,18 @@ const.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET=30
 const.INPUT_NOTE_GET_RECIPIENT_OFFSET=31
 
 # output notes
-const.OUTPUT_NOTE_GET_METADATA_OFFSET=32
-const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=33
-const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=34
-const.OUTPUT_NOTE_ADD_ASSET_OFFSET=35
+const.OUTPUT_NOTE_CREATE_OFFSET=32
+const.OUTPUT_NOTE_GET_METADATA_OFFSET=33
+const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=34
+const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=35
+const.OUTPUT_NOTE_ADD_ASSET_OFFSET=36
 
 ### Tx ##########################################
-# creation
-const.TX_CREATE_NOTE_OFFSET=36
-
-# input/output notes
-
+# input notes
 const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=37
 const.TX_GET_NUM_INPUT_NOTES_OFFSET=38
 
+# output notes
 const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=39
 const.TX_GET_NUM_OUTPUT_NOTES_OFFSET=40
 
@@ -406,7 +404,19 @@ export.faucet_is_non_fungible_asset_issued_offset
     push.FAUCET_IS_NON_FUNGIBLE_ASSET_ISSUED_OFFSET
 end
 
-### NOTE ########################################
+### OUTPUT NOTE ########################################
+
+#! Returns the offset of the `output_note_create` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `output_note_create` kernel procedure required to get the
+#!   address where this procedure is stored.
+export.output_note_create_offset
+    push.OUTPUT_NOTE_CREATE_OFFSET
+end
 
 #! Returns the offset of the `output_note_add_asset` kernel procedure.
 #!
@@ -418,18 +428,6 @@ end
 #!   address where this procedure is stored.
 export.output_note_add_asset_offset
     push.OUTPUT_NOTE_ADD_ASSET_OFFSET
-end
-
-#! Returns the offset of the `input_note_get_assets_info` kernel procedure.
-#!
-#! Inputs:  []
-#! Outputs: [proc_offset]
-#!
-#! Where:
-#! - proc_offset is the offset of the `input_note_get_assets_info` kernel procedure required to get
-#! the address where this procedure is stored.
-export.input_note_get_assets_info_offset
-    push.INPUT_NOTE_GET_ASSETS_INFO_OFFSET
 end
 
 #! Returns the offset of the `output_note_get_assets_info` kernel procedure.
@@ -444,18 +442,6 @@ export.output_note_get_assets_info_offset
     push.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET
 end
 
-#! Returns the offset of the `input_note_get_recipient` kernel procedure.
-#!
-#! Inputs:  []
-#! Outputs: [proc_offset]
-#!
-#! Where:
-#! - proc_offset is the offset of the `input_note_get_recipient` kernel procedure required to get
-#!  the address where this procedure is stored.
-export.input_note_get_recipient_offset
-    push.INPUT_NOTE_GET_RECIPIENT_OFFSET
-end
-
 #! Returns the offset of the `output_note_get_recipient` kernel procedure.
 #!
 #! Inputs:  []
@@ -468,18 +454,6 @@ export.output_note_get_recipient_offset
     push.OUTPUT_NOTE_GET_RECIPIENT_OFFSET
 end
 
-#! Returns the offset of the `input_note_get_metadata` kernel procedure.
-#!
-#! Inputs:  []
-#! Outputs: [proc_offset]
-#!
-#! Where:
-#! - proc_offset is the offset of the `input_note_get_metadata` kernel procedure required to get
-#!  the address where this procedure is stored.
-export.input_note_get_metadata_offset
-    push.INPUT_NOTE_GET_METADATA_OFFSET
-end
-
 #! Returns the offset of the `output_note_get_metadata` kernel procedure.
 #!
 #! Inputs:  []
@@ -490,6 +464,44 @@ end
 #!  the address where this procedure is stored.
 export.output_note_get_metadata_offset
     push.OUTPUT_NOTE_GET_METADATA_OFFSET
+end
+
+### INPUT NOTE ########################################
+
+#! Returns the offset of the `input_note_get_assets_info` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `input_note_get_assets_info` kernel procedure required to get
+#! the address where this procedure is stored.
+export.input_note_get_assets_info_offset
+    push.INPUT_NOTE_GET_ASSETS_INFO_OFFSET
+end
+
+#! Returns the offset of the `input_note_get_recipient` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `input_note_get_recipient` kernel procedure required to get
+#!  the address where this procedure is stored.
+export.input_note_get_recipient_offset
+    push.INPUT_NOTE_GET_RECIPIENT_OFFSET
+end
+
+#! Returns the offset of the `input_note_get_metadata` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `input_note_get_metadata` kernel procedure required to get
+#!  the address where this procedure is stored.
+export.input_note_get_metadata_offset
+    push.INPUT_NOTE_GET_METADATA_OFFSET
 end
 
 #! Returns the offset of the `input_note_get_serial_number` kernel procedure.
@@ -529,18 +541,6 @@ export.input_note_get_script_root_offset
 end
 
 ### TRANSACTION #################################
-
-#! Returns the offset of the `tx_create_note` kernel procedure.
-#!
-#! Inputs:  []
-#! Outputs: [proc_offset]
-#!
-#! Where:
-#! - proc_offset is the offset of the `tx_create_note` kernel procedure required to get the address
-#!   where this procedure is stored.
-export.tx_create_note_offset
-    push.TX_CREATE_NOTE_OFFSET
-end
 
 #! Returns the offset of the `tx_get_input_notes_commitment` kernel procedure.
 #!

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -83,7 +83,7 @@ const.TX_END_FOREIGN_CONTEXT_OFFSET=45
 
 # expiration data
 const.TX_GET_EXPIRATION_DELTA_OFFSET=46               # accessor
-const.TX_UPDATE_EXPIRATION_BLOCK_NUM_OFFSET=47        # mutator
+const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=47        # mutator
 
 # ACCESSORS
 # -------------------------------------------------------------------------------------------------
@@ -650,16 +650,16 @@ export.tx_end_foreign_context_offset
     push.TX_END_FOREIGN_CONTEXT_OFFSET
 end
 
-#! Returns the offset of the `tx_update_expiration_block_num` kernel procedure.
+#! Returns the offset of the `tx_update_expiration_block_delta` kernel procedure.
 #!
 #! Inputs:  []
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `tx_update_expiration_block_num` kernel procedure required to
-#!   get the address where this procedure is stored.
-export.tx_update_expiration_block_num_offset
-    push.TX_UPDATE_EXPIRATION_BLOCK_NUM_OFFSET
+#! - proc_offset is the offset of the `tx_update_expiration_block_delta` kernel procedure required
+#!   to get the address where this procedure is stored.
+export.tx_update_expiration_block_delta_offset
+    push.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET
 end
 
 #! Returns the offset of the `tx_get_expiration_delta` kernel procedure.

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -2,6 +2,7 @@
 # -------------------------------------------------------------------------------------------------
 
 ### Account #####################################
+
 # Entire account commitment
 const.ACCOUNT_GET_INITIAL_COMMITMENT_OFFSET=0
 const.ACCOUNT_COMPUTE_CURRENT_COMMITMENT_OFFSET=1
@@ -41,6 +42,7 @@ const.ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET=20
 const.ACCOUNT_WAS_PROCEDURE_CALLED_OFFSET=21
 
 ### Faucet ######################################
+
 const.FAUCET_MINT_ASSET_OFFSET=22
 const.FAUCET_BURN_ASSET_OFFSET=23
 const.FAUCET_GET_TOTAL_FUNGIBLE_ASSET_ISSUANCE_OFFSET=24
@@ -66,6 +68,7 @@ const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=37
 const.OUTPUT_NOTE_ADD_ASSET_OFFSET=38
 
 ### Tx ##########################################
+
 # notes commitment
 const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=39
 const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=40

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -49,28 +49,26 @@ const.FAUCET_IS_NON_FUNGIBLE_ASSET_ISSUED_OFFSET=25
 ### Note ########################################
 
 # input notes
-const.INPUT_NOTE_GET_METADATA_OFFSET=26
-const.INPUT_NOTE_GET_ASSETS_INFO_OFFSET=27
-const.INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET=28
-const.INPUT_NOTE_GET_INPUTS_INFO_OFFSET=29
-const.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET=30
-const.INPUT_NOTE_GET_RECIPIENT_OFFSET=31
+const.INPUT_NOTE_GET_NUM_NOTES_OFFSET=26
+const.INPUT_NOTE_GET_METADATA_OFFSET=27
+const.INPUT_NOTE_GET_ASSETS_INFO_OFFSET=28
+const.INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET=29
+const.INPUT_NOTE_GET_INPUTS_INFO_OFFSET=30
+const.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET=31
+const.INPUT_NOTE_GET_RECIPIENT_OFFSET=32
 
 # output notes
-const.OUTPUT_NOTE_CREATE_OFFSET=32
-const.OUTPUT_NOTE_GET_METADATA_OFFSET=33
-const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=34
-const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=35
-const.OUTPUT_NOTE_ADD_ASSET_OFFSET=36
+const.OUTPUT_NOTE_CREATE_OFFSET=33
+const.OUTPUT_NOTE_GET_NUM_NOTES_OFFSET=34
+const.OUTPUT_NOTE_GET_METADATA_OFFSET=35
+const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=36
+const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=37
+const.OUTPUT_NOTE_ADD_ASSET_OFFSET=38
 
 ### Tx ##########################################
-# input notes
-const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=37
-const.TX_GET_NUM_INPUT_NOTES_OFFSET=38
-
-# output notes
-const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=39
-const.TX_GET_NUM_OUTPUT_NOTES_OFFSET=40
+# notes commitment
+const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=39
+const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=40
 
 # block info
 const.TX_GET_BLOCK_COMMITMENT_OFFSET=41
@@ -83,7 +81,7 @@ const.TX_END_FOREIGN_CONTEXT_OFFSET=45
 
 # expiration data
 const.TX_GET_EXPIRATION_DELTA_OFFSET=46               # accessor
-const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=47        # mutator
+const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=47      # mutator
 
 # ACCESSORS
 # -------------------------------------------------------------------------------------------------
@@ -566,28 +564,28 @@ export.tx_get_output_notes_commitment_offset
     push.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET
 end
 
-#! Returns the offset of the `tx_get_num_input_notes` kernel procedure.
+#! Returns the offset of the `input_note_get_num_notes` kernel procedure.
 #!
 #! Inputs:  []
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `tx_get_num_input_notes` kernel procedure required to get the 
-#!   address where this procedure is stored.
-export.tx_get_num_input_notes_offset
-    push.TX_GET_NUM_INPUT_NOTES_OFFSET
+#! - proc_offset is the offset of the `input_note_get_num_notes` kernel procedure required to get
+#!   the address where this procedure is stored.
+export.input_note_get_num_notes_offset
+    push.INPUT_NOTE_GET_NUM_NOTES_OFFSET
 end
 
-#! Returns the offset of the `tx_get_num_output_notes` kernel procedure.
+#! Returns the offset of the `output_note_get_num_notes` kernel procedure.
 #!
 #! Inputs:  []
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `tx_get_num_output_notes` kernel procedure required to get the 
-#!   address where this procedure is stored.
-export.tx_get_num_output_notes_offset
-    push.TX_GET_NUM_OUTPUT_NOTES_OFFSET
+#! - proc_offset is the offset of the `output_note_get_num_notes` kernel procedure required to get
+#!   the address where this procedure is stored.
+export.output_note_get_num_notes_offset
+    push.OUTPUT_NOTE_GET_NUM_NOTES_OFFSET
 end
 
 #! Returns the offset of the `tx_get_block_commitment` kernel procedure.

--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -87,7 +87,7 @@ export.get_recipient
     # => [RECIPIENT]
 end
 
-#! Writes the active note's inputs to memory starting at dest_ptr
+#! Writes the active note's inputs to memory starting at the specified address.
 #!
 #! Inputs:
 #!   Stack: [dest_ptr]

--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -87,7 +87,7 @@ export.get_recipient
     # => [RECIPIENT]
 end
 
-#! Writes the note's inputs to `dest_ptr`.
+#! Writes the active note's inputs to memory starting at dest_ptr
 #!
 #! Inputs:
 #!   Stack: [dest_ptr]

--- a/crates/miden-lib/asm/miden/output_note.masm
+++ b/crates/miden-lib/asm/miden/output_note.masm
@@ -5,6 +5,37 @@ use.std::mem
 # PROCEDURES
 # =================================================================================================
 
+#! Creates a new note and returns the index of the note.
+#!
+#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
+#! Outputs: [note_idx]
+#!
+#! Where:
+#! - tag is the tag to be included in the note.
+#! - aux is the auxiliary metadata to be included in the note.
+#! - note_type is the storage type of the note.
+#! - execution_hint is the note's execution hint.
+#! - RECIPIENT is the recipient of the note.
+#! - note_idx is the index of the created note.
+#!
+#! Invocation: exec
+export.create
+    # pad the stack before the syscall to prevent accidental modification of the deeper stack
+    # elements
+    padw padw swapdw movup.8 drop
+    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
+
+    exec.kernel_proc_offsets::output_note_create_offset
+    # => [offset, tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
+
+    syscall.exec_kernel_proc
+    # => [note_idx, pad(15)]
+
+    # remove excess PADs from the stack
+    swapdw dropw dropw movdn.7 dropw drop drop drop
+    # => [note_idx]
+end
+
 #! Returns the information about assets in the output note with the specified index.
 #!
 #! This information can then be used to retrieve the actual assets from the advice map.

--- a/crates/miden-lib/asm/miden/output_note.masm
+++ b/crates/miden-lib/asm/miden/output_note.masm
@@ -36,6 +36,34 @@ export.create
     # => [note_idx]
 end
 
+#! Returns the current number of output notes created in this transaction.
+#!
+#! The number of output notes can changes during transaction execution. This will happen any time
+#! as new output notes is created.
+#!
+#! Inputs:  []
+#! Outputs: [num_output_notes]
+#!
+#! Where:
+#! - num_output_notes is the number of output notes created in this transaction so far.
+#!
+#! Invocation: exec
+export.get_num_notes
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [pad(15)]
+
+    exec.kernel_proc_offsets::output_note_get_num_notes_offset
+    # => [offset, pad(15)]
+
+    syscall.exec_kernel_proc
+    # => [num_output_notes, pad(15)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
+    # => [num_output_notes]
+end
+
 #! Returns the information about assets in the output note with the specified index.
 #!
 #! This information can then be used to retrieve the actual assets from the advice map.

--- a/crates/miden-lib/asm/miden/output_note.masm
+++ b/crates/miden-lib/asm/miden/output_note.masm
@@ -77,6 +77,33 @@ export.get_assets
     # => [num_assets, dest_ptr, note_index]
 end
 
+#! Adds the ASSET to the note specified by the index.
+#!
+#! Inputs:  [ASSET, note_idx]
+#! Outputs: [ASSET, note_idx]
+#!
+#! Where:
+#! - note_idx is the index of the note to which the asset is added.
+#! - ASSET can be a fungible or non-fungible asset.
+#!
+#! Invocation: exec
+export.add_asset
+    movup.4 exec.kernel_proc_offsets::output_note_add_asset_offset
+    # => [offset, note_idx, ASSET]
+
+    # pad the stack before the syscall to prevent accidental modification of the deeper stack
+    # elements
+    push.0.0 movdn.7 movdn.7 padw padw swapdw
+    # => [offset, note_idx, ASSET, pad(10)]
+
+    syscall.exec_kernel_proc
+    # => [note_idx, ASSET, pad(11)]
+
+    # remove excess PADs from the stack
+    swapdw dropw dropw swapw movdn.7 drop drop drop movdn.4
+    # => [ASSET, note_idx]
+end
+
 #! Returns the recipient of the output note with the specified index.
 #!
 #! Inputs:  [note_index]

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -199,37 +199,6 @@ export.get_num_output_notes
     # => [num_output_notes]
 end
 
-#! Creates a new note and returns the index of the note.
-#!
-#! Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
-#! Outputs: [note_idx]
-#!
-#! Where:
-#! - tag is the tag to be included in the note.
-#! - aux is the auxiliary metadata to be included in the note.
-#! - note_type is the storage type of the note.
-#! - execution_hint is the note's execution hint.
-#! - RECIPIENT is the recipient of the note.
-#! - note_idx is the index of the created note.
-#!
-#! Invocation: exec
-export.create_note
-    # pad the stack before the syscall to prevent accidental modification of the deeper stack
-    # elements
-    padw padw swapdw movup.8 drop
-    # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
-
-    exec.kernel_proc_offsets::tx_create_note_offset
-    # => [offset, tag, aux, note_type, execution_hint, RECIPIENT, pad(7)]
-
-    syscall.exec_kernel_proc
-    # => [note_idx, pad(15)]
-
-    # remove excess PADs from the stack
-    swapdw dropw dropw movdn.7 dropw drop drop drop
-    # => [note_idx]
-end
-
 #! Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.
 #!
 #! Inputs:  [SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -146,59 +146,6 @@ export.get_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT]
 end
 
-#! Returns the total number of input notes consumed by this transaction.
-#!
-#! Inputs:  []
-#! Outputs: [num_input_notes]
-#!
-#! Where:
-#! - num_input_notes is the total number of input notes consumed by this transaction.
-#!
-#! Invocation: exec
-export.get_num_input_notes
-    # pad the stack
-    padw padw padw push.0.0.0
-    # => [pad(15)]
-
-    exec.kernel_proc_offsets::tx_get_num_input_notes_offset
-    # => [offset, pad(15)]
-
-    syscall.exec_kernel_proc
-    # => [num_input_notes, pad(15)]
-
-    # clean the stack
-    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
-    # => [num_input_notes]
-end
-
-#! Returns the current number of output notes created in this transaction.
-#!
-#! The number of output notes can changes during transaction execution. This will happen any time
-#! as new output notes is created.
-#!
-#! Inputs:  []
-#! Outputs: [num_output_notes]
-#!
-#! Where:
-#! - num_output_notes is the number of output notes created in this transaction so far.
-#!
-#! Invocation: exec
-export.get_num_output_notes
-    # pad the stack
-    padw padw padw push.0.0.0
-    # => [pad(15)]
-
-    exec.kernel_proc_offsets::tx_get_num_output_notes_offset
-    # => [offset, pad(15)]
-
-    syscall.exec_kernel_proc
-    # => [num_output_notes, pad(15)]
-
-    # clean the stack
-    swapdw dropw dropw swapw dropw movdn.3 drop drop drop
-    # => [num_output_notes]
-end
-
 #! Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.
 #!
 #! Inputs:  [SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -230,33 +230,6 @@ export.create_note
     # => [note_idx]
 end
 
-#! Adds the ASSET to the note specified by the index.
-#!
-#! Inputs:  [ASSET, note_idx]
-#! Outputs: [ASSET, note_idx]
-#!
-#! Where:
-#! - note_idx is the index of the note to which the asset is added.
-#! - ASSET can be a fungible or non-fungible asset.
-#!
-#! Invocation: exec
-export.add_asset_to_note
-    movup.4 exec.kernel_proc_offsets::output_note_add_asset_offset
-    # => [offset, note_idx, ASSET]
-
-    # pad the stack before the syscall to prevent accidental modification of the deeper stack
-    # elements
-    push.0.0 movdn.7 movdn.7 padw padw swapdw
-    # => [offset, note_idx, ASSET, pad(10)]
-
-    syscall.exec_kernel_proc
-    # => [note_idx, ASSET, pad(11)]
-
-    # remove excess PADs from the stack
-    swapdw dropw dropw swapw movdn.7 drop drop drop movdn.4
-    # => [ASSET, note_idx]
-end
-
 #! Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.
 #!
 #! Inputs:  [SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]

--- a/crates/miden-lib/asm/miden/tx.masm
+++ b/crates/miden-lib/asm/miden/tx.masm
@@ -292,7 +292,7 @@ end
 #!
 #! Annotation hint: is not used anywhere
 export.update_expiration_block_delta
-    exec.kernel_proc_offsets::tx_update_expiration_block_num_offset
+    exec.kernel_proc_offsets::tx_update_expiration_block_delta_offset
     # => [offset, expiration_delta, ...]
 
     # pad the stack

--- a/crates/miden-lib/asm/note_scripts/P2IDE.masm
+++ b/crates/miden-lib/asm/note_scripts/P2IDE.masm
@@ -2,7 +2,6 @@ use.miden::account
 use.miden::account_id
 use.miden::note
 use.miden::tx
-use.note_scripts::utils
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-lib/asm/note_scripts/SWAP.masm
+++ b/crates/miden-lib/asm/note_scripts/SWAP.masm
@@ -1,5 +1,5 @@
 use.miden::note
-use.miden::tx
+use.miden::output_note
 use.miden::contracts::wallets::basic->wallet
 
 # CONSTANTS
@@ -66,7 +66,7 @@ begin
     # => [tag, aux, note_type, execution_hint, PAYBACK_NOTE_RECIPIENT, REQUESTED_ASSET]
 
     # create payback P2ID note
-    exec.tx::create_note
+    exec.output_note::create
     # => [note_idx, REQUESTED_ASSET]
 
     movdn.4

--- a/crates/miden-lib/src/account/interface/component.rs
+++ b/crates/miden-lib/src/account/interface/component.rs
@@ -174,7 +174,7 @@ impl AccountComponentInterface {
     ///
     /// ```masm
     ///     push.{note_information}
-    ///     call.::miden::tx::create_note
+    ///     call.::miden::output_note::create
     ///
     ///     push.{note asset}
     ///     call.::miden::contracts::wallets::basic::move_asset_to_note dropw
@@ -248,7 +248,7 @@ impl AccountComponentInterface {
                     // stack => []
                 },
                 AccountComponentInterface::BasicWallet => {
-                    body.push_str("call.::miden::tx::create_note\n");
+                    body.push_str("call.::miden::output_note::create\n");
                     // stack => [note_idx]
 
                     for asset in partial_note.assets().iter() {

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -167,8 +167,6 @@ pub const ERR_NOTE_INVALID_NOTE_TYPE_FOR_NOTE_TAG_PREFIX: MasmError = MasmError:
 pub const ERR_NOTE_INVALID_NUMBER_OF_INPUTS: MasmError = MasmError::from_static_str("the specified number of note inputs does not match the actual number");
 /// Error Message: "invalid note type"
 pub const ERR_NOTE_INVALID_TYPE: MasmError = MasmError::from_static_str("invalid note type");
-/// Error Message: "network execution mode with a specific target can only target network accounts"
-pub const ERR_NOTE_NETWORK_EXECUTION_DOES_NOT_TARGET_NETWORK_ACCOUNT: MasmError = MasmError::from_static_str("network execution mode with a specific target can only target network accounts");
 /// Error Message: "number of assets in a note exceed 255"
 pub const ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT: MasmError = MasmError::from_static_str("number of assets in a note exceed 255");
 /// Error Message: "the note's tag must fit into a u32 so the 32 most significant bits must be zero"

--- a/crates/miden-lib/src/testing/mock_util_lib.rs
+++ b/crates/miden-lib/src/testing/mock_util_lib.rs
@@ -5,7 +5,6 @@ use miden_objects::utils::sync::LazyLock;
 use crate::transaction::TransactionKernel;
 
 const MOCK_UTIL_LIBRARY_CODE: &str = "
-    use.miden::tx
     use.miden::output_note
 
     # Inputs:  []
@@ -18,7 +17,7 @@ const MOCK_UTIL_LIBRARY_CODE: &str = "
         push.0xc0000000        # = NoteTag::LocalAny
         # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
-        exec.tx::create_note
+        exec.output_note::create
         # => [note_idx]
     end
 

--- a/crates/miden-lib/src/testing/mock_util_lib.rs
+++ b/crates/miden-lib/src/testing/mock_util_lib.rs
@@ -6,6 +6,7 @@ use crate::transaction::TransactionKernel;
 
 const MOCK_UTIL_LIBRARY_CODE: &str = "
     use.miden::tx
+    use.miden::output_note
 
     # Inputs:  []
     # Outputs: [note_idx]
@@ -30,7 +31,7 @@ const MOCK_UTIL_LIBRARY_CODE: &str = "
         movdn.4
         # => [ASSET, note_idx]
 
-        exec.tx::add_asset_to_note dropw
+        exec.output_note::add_asset dropw
         # => [note_idx]
     end
 ";

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -101,6 +101,6 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0xaa0018aa8da890b73511879487f65553753fb7df22de380dd84c11e6f77eec6f"),
     // tx_get_expiration_delta
     word!("0xa60286e820a755128b2269db5057b0e2d9b79fef6f813bf3fe3337553a8fbb53"),
-    // tx_update_expiration_block_num
+    // tx_update_expiration_block_delta
     word!("0xa16440a9a8cd2a6d0ff7f5c3bcce2958976e5d3e6e8a6935ff40ae1863c324f0"),
 ];

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -59,6 +59,8 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0x7d32952d4dc0edd0311e3424b8128df2d48cf949f800c28218fbc851a8db42b5"),
     // faucet_is_non_fungible_asset_issued
     word!("0xc827d2430763c70880216804d3523c14e70e5cf926d5d8a72844c6476add5ef7"),
+    // input_note_get_num_notes
+    word!("0xfcc186d4b65c584f3126dda1460b01eef977efd76f9e36f972554af28e33c685"),
     // input_note_get_metadata
     word!("0x7ad3e94585e7a397ee27443c98b376ed8d4ba762122af6413fde9314c00a6219"),
     // input_note_get_assets_info
@@ -73,6 +75,8 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0xd3c255177f9243bb1a523a87615bbe76dd5a3605fcae87eb9d3a626d4ecce33c"),
     // output_note_create
     word!("0x52b37f8b25e26517f22f1f600acae7fbfffa84094595ba961af2af807a484736"),
+    // output_note_get_num_notes
+    word!("0x2511fca9c078cd96e526fd488d1362cbfd597eb3db8452aedb00beffee9782b4"),
     // output_note_get_metadata
     word!("0xde4a5b57f9d53692459383e6cf6302ef3602a348896ed6ab6fdf67e07fa483ff"),
     // output_note_get_assets_info
@@ -83,12 +87,8 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0x47673b932aac8c186cb0979bbc3c4c2afa00fa1b80c0afb5e5efb4924bba48d9"),
     // tx_get_input_notes_commitment
     word!("0xc3a334434daa7d4ea15e1b2cb1a8000ad757f9348560a7246336662b77b0d89a"),
-    // tx_get_num_input_notes
-    word!("0xfcc186d4b65c584f3126dda1460b01eef977efd76f9e36f972554af28e33c685"),
     // tx_get_output_notes_commitment
     word!("0xd5b22dae48ec4b20ed479f2c43573d34930720886371ef6b484310a3bea4e818"),
-    // tx_get_num_output_notes
-    word!("0x2511fca9c078cd96e526fd488d1362cbfd597eb3db8452aedb00beffee9782b4"),
     // tx_get_block_commitment
     word!("0xe474b491a64d222397fcf83ee5db7b048061988e5e83ce99b91bae6fd75a3522"),
     // tx_get_block_number

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -71,6 +71,8 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0x25815e02b7976d8e5c297dde60d372cc142c81f702f424ac0920190528c547ee"),
     // input_note_get_recipient
     word!("0xd3c255177f9243bb1a523a87615bbe76dd5a3605fcae87eb9d3a626d4ecce33c"),
+    // output_note_create
+    word!("0x52b37f8b25e26517f22f1f600acae7fbfffa84094595ba961af2af807a484736"),
     // output_note_get_metadata
     word!("0xde4a5b57f9d53692459383e6cf6302ef3602a348896ed6ab6fdf67e07fa483ff"),
     // output_note_get_assets_info
@@ -79,8 +81,6 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0xc824115ed79a2e1670daed8c18fba1bc15f54c5ec0ec6699de69a00b21d9df92"),
     // output_note_add_asset
     word!("0x47673b932aac8c186cb0979bbc3c4c2afa00fa1b80c0afb5e5efb4924bba48d9"),
-    // tx_create_note
-    word!("0x52b37f8b25e26517f22f1f600acae7fbfffa84094595ba961af2af807a484736"),
     // tx_get_input_notes_commitment
     word!("0xc3a334434daa7d4ea15e1b2cb1a8000ad757f9348560a7246336662b77b0d89a"),
     // tx_get_num_input_notes

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -415,7 +415,7 @@ pub const INPUT_NOTE_ASSETS_OFFSET: MemoryOffset = 40;
 //
 // Dirty flag is set to 0 after every recomputation of the assets commitment in the
 // `kernel::note::compute_output_note_assets_commitment` procedure. It is set to 1 in the
-// `kernel::output_note::add_asset_to_note` procedure after any change was made to the assets data .
+// `kernel::output_note::add_asset` procedure after any change was made to the assets data.
 
 /// The memory address at which the output notes section begins.
 pub const OUTPUT_NOTE_SECTION_OFFSET: MemoryOffset = 16_777_216;

--- a/crates/miden-lib/src/transaction/memory.rs
+++ b/crates/miden-lib/src/transaction/memory.rs
@@ -415,7 +415,7 @@ pub const INPUT_NOTE_ASSETS_OFFSET: MemoryOffset = 40;
 //
 // Dirty flag is set to 0 after every recomputation of the assets commitment in the
 // `kernel::note::compute_output_note_assets_commitment` procedure. It is set to 1 in the
-// `kernel::tx::add_asset_to_note` procedure after any change was made to the assets data .
+// `kernel::output_note::add_asset_to_note` procedure after any change was made to the assets data .
 
 /// The memory address at which the output notes section begins.
 pub const OUTPUT_NOTE_SECTION_OFFSET: MemoryOffset = 16_777_216;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -615,7 +615,7 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
             # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
             # create the note
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx, pad(15)]
 
             # move an asset to the created note to partially deplete fungible asset balance
@@ -637,7 +637,7 @@ fn asset_and_storage_delta() -> anyhow::Result<()> {
     let tx_script_src = format!(
         "\
         use.mock::account
-        use.miden::tx
+        use.miden::output_note
 
         ## TRANSACTION SCRIPT
         ## ========================================================================================
@@ -832,7 +832,7 @@ fn compile_tx_script(code: impl AsRef<str>) -> anyhow::Result<TransactionScript>
 
 const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
       use.mock::account
-      use.miden::tx
+      use.miden::output_note
 
       #! Inputs:  [index, VALUE]
       #! Outputs: []
@@ -885,7 +885,7 @@ const TEST_ACCOUNT_CONVENIENCE_WRAPPERS: &str = "
           repeat.8 push.0 movdn.8 end
           # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(8)]
 
-          call.tx::create_note
+          call.output_note::create
           # => [note_idx, pad(15)]
 
           repeat.15 swap drop end

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -364,9 +364,9 @@ fn test_block_expiration_height_monotonically_decreases() -> anyhow::Result<()> 
         begin
             exec.prologue::prepare_transaction
             push.{value_1}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_block_delta
             push.{value_2}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_block_delta
 
             push.{min_value} exec.tx::get_expiration_delta assert_eq
 
@@ -405,7 +405,7 @@ fn test_invalid_expiration_deltas() -> anyhow::Result<()> {
 
         begin
             push.{value_1}
-            exec.tx::update_expiration_block_num
+            exec.tx::update_expiration_block_delta
         end
         ";
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -538,7 +538,7 @@ fn test_epilogue_empty_transaction_with_empty_output_note() -> anyhow::Result<()
     // create an empty output note in the transaction script
     let tx_script_source = format!(
         r#"
-        use.miden::tx
+        use.miden::output_note
         use.$kernel::prologue
         use.$kernel::epilogue
         use.$kernel::note
@@ -559,7 +559,7 @@ fn test_epilogue_empty_transaction_with_empty_output_note() -> anyhow::Result<()
             # => [tag, aux, execution_hint, note_type, RECIPIENT, pad(8)]
 
             # create the note
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx, GARBAGE(15)]
 
             # make sure that output note was created: compare the output note hash with an empty

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -753,7 +753,7 @@ fn test_get_current_script_root() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_build_note_metadata() -> miette::Result<()> {
+fn test_build_metadata() -> miette::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
 
     let sender = tx_context.account().id();
@@ -789,7 +789,7 @@ fn test_build_note_metadata() -> miette::Result<()> {
         begin
           exec.prologue::prepare_transaction
           push.{execution_hint}.{note_type}.{aux}.{tag}
-          exec.output_note::build_note_metadata
+          exec.output_note::build_metadata
 
           # truncate the stack
           swapw dropw

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -784,12 +784,12 @@ fn test_build_note_metadata() -> miette::Result<()> {
         let code = format!(
             "
         use.$kernel::prologue
-        use.$kernel::tx
+        use.$kernel::output_note
 
         begin
           exec.prologue::prepare_transaction
           push.{execution_hint}.{note_type}.{aux}.{tag}
-          exec.tx::build_note_metadata
+          exec.output_note::build_note_metadata
 
           # truncate the stack
           swapw dropw

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -72,7 +72,6 @@ fn test_get_asset_info() -> anyhow::Result<()> {
 
     let tx_script_src = &format!(
         r#"
-        use.miden::tx
         use.miden::output_note
         use.std::sys
 
@@ -83,7 +82,7 @@ fn test_get_asset_info() -> anyhow::Result<()> {
             push.{note_type}
             push.0              # aux
             push.{tag}
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx]
 
             # move the asset 0 to the note
@@ -189,7 +188,6 @@ fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
 
     let tx_script_src = &format!(
         r#"
-        use.miden::tx
         use.miden::output_note
         use.std::sys
 
@@ -304,7 +302,6 @@ fn test_get_assets() -> anyhow::Result<()> {
 
     let tx_script_src = &format!(
         "
-        use.miden::tx
         use.miden::output_note
         use.std::sys
 
@@ -362,7 +359,7 @@ fn create_output_note(note: &Note) -> String {
         push.{note_type}
         push.0              # aux
         push.{tag}
-        call.tx::create_note
+        call.output_note::create
         # => [note_idx]
     ",
         RECIPIENT = note.recipient().digest(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -190,7 +190,7 @@ fn test_create_note() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.miden::tx
+        use.miden::output_note
 
         use.$kernel::prologue
 
@@ -203,7 +203,7 @@ fn test_create_note() -> anyhow::Result<()> {
             push.{aux}
             push.{tag}
 
-            call.tx::create_note
+            call.output_note::create
 
             # truncate the stack
             swapdw dropw dropw
@@ -271,7 +271,7 @@ fn test_create_note_with_invalid_tag() -> anyhow::Result<()> {
 fn note_creation_script(tag: Felt) -> String {
     format!(
         "
-            use.miden::tx
+            use.miden::output_note
             use.$kernel::prologue
 
             begin
@@ -283,7 +283,7 @@ fn note_creation_script(tag: Felt) -> String {
                 push.{aux}
                 push.{tag}
 
-                call.tx::create_note
+                call.output_note::create
 
                 # clean the stack
                 dropw dropw
@@ -302,7 +302,7 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.miden::tx
+        use.miden::output_note
         use.$kernel::constants
         use.$kernel::memory
         use.$kernel::prologue
@@ -318,7 +318,7 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
             push.{aux}
             push.{tag}
 
-            call.tx::create_note
+            call.output_note::create
         end
         ",
         tag = NoteTag::for_local_use_case(1234, 5678).unwrap(),
@@ -434,7 +434,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
             push.{PUBLIC_NOTE}
             push.{aux_1}
             push.{tag_1}
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx]
 
             push.{asset_1}
@@ -450,7 +450,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
             push.{PUBLIC_NOTE}
             push.{aux_2}
             push.{tag_2}
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx]
 
             push.{asset_2}
@@ -526,7 +526,6 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.miden::tx
         use.miden::output_note
 
         use.$kernel::prologue
@@ -541,7 +540,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
             push.{aux}
             push.{tag}
 
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx]
 
             push.{asset}
@@ -599,7 +598,6 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
 
     let code = format!(
         "
-        use.miden::tx
         use.miden::output_note
 
         use.$kernel::prologue
@@ -613,7 +611,7 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
             push.{aux}
             push.{tag}
 
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx]
 
             push.{asset}
@@ -685,7 +683,6 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
     let code = format!(
         "
         use.$kernel::prologue
-        use.miden::tx
         use.miden::output_note
 
         begin
@@ -699,7 +696,7 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
             push.{aux}
             push.{tag}
 
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx, pad(15)]
 
             push.{nft}
@@ -776,6 +773,7 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::tx
+        use.miden::output_note
         use.$kernel::prologue
 
         proc.build_recipient_hash
@@ -805,7 +803,7 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
             push.{tag}
             # => [tag, aux, note_type, execution_hint, RECIPIENT, pad(12)]
 
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx, pad(19)]
 
             # clean the stack
@@ -959,7 +957,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
     let tx_script_src = format!(
         "\
         use.miden::contracts::wallets::basic->wallet
-        use.miden::tx
+        use.miden::output_note
         use.mock::account
 
         # Inputs:  [tag, aux, note_type, execution_hint, RECIPIENT]
@@ -970,7 +968,7 @@ fn executed_transaction_output_notes() -> anyhow::Result<()> {
             padw padw swapdw
             # => [tag, aux, execution_hint, note_type, RECIPIENT, pad(8)]
 
-            call.tx::create_note
+            call.output_note::create
             # => [note_idx, pad(15)]
 
             # remove excess PADs from the stack

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -419,9 +419,9 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
         use.std::sys
 
         use.miden::tx
+        use.miden::output_note
 
         use.$kernel::prologue
-        use.mock::account
 
         begin
             # => [BH, acct_id, IAH, NC]
@@ -438,7 +438,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
             # => [note_idx]
 
             push.{asset_1}
-            call.tx::add_asset_to_note
+            call.output_note::add_asset
             # => [ASSET, note_idx]
 
             dropw drop
@@ -454,7 +454,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
             # => [note_idx]
 
             push.{asset_2}
-            call.tx::add_asset_to_note
+            call.output_note::add_asset
             # => [ASSET, note_idx]
 
             dropw drop
@@ -527,6 +527,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::tx
+        use.miden::output_note
 
         use.$kernel::prologue
         use.mock::account
@@ -544,7 +545,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
             # => [note_idx]
 
             push.{asset}
-            call.tx::add_asset_to_note
+            call.output_note::add_asset
             # => [ASSET, note_idx]
 
             dropw
@@ -599,6 +600,7 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
     let code = format!(
         "
         use.miden::tx
+        use.miden::output_note
 
         use.$kernel::prologue
         use.mock::account
@@ -615,19 +617,19 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
             # => [note_idx]
 
             push.{asset}
-            call.tx::add_asset_to_note dropw
+            call.output_note::add_asset dropw
             # => [note_idx]
 
             push.{asset_2}
-            call.tx::add_asset_to_note dropw
+            call.output_note::add_asset dropw
             # => [note_idx]
 
             push.{asset_3}
-            call.tx::add_asset_to_note dropw
+            call.output_note::add_asset dropw
             # => [note_idx]
 
             push.{nft}
-            call.tx::add_asset_to_note dropw
+            call.output_note::add_asset dropw
             # => [note_idx]
 
             # truncate the stack
@@ -683,8 +685,8 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
     let code = format!(
         "
         use.$kernel::prologue
-        use.mock::account
         use.miden::tx
+        use.miden::output_note
 
         begin
             exec.prologue::prepare_transaction
@@ -701,12 +703,12 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
             # => [note_idx, pad(15)]
 
             push.{nft}
-            call.tx::add_asset_to_note
+            call.output_note::add_asset
             # => [NFT, note_idx, pad(15)]
             dropw
 
             push.{nft}
-            call.tx::add_asset_to_note
+            call.output_note::add_asset
             # => [NFT, note_idx, pad(15)]
 
             repeat.5 dropw end

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -155,7 +155,7 @@ pub fn create_spawn_note(sender_id: AccountId, output_notes: Vec<&Note>) -> anyh
 
 /// Returns the code for a note that creates all notes in `output_notes`
 fn note_script_that_creates_notes(output_notes: Vec<&Note>) -> String {
-    let mut out = String::from("use.miden::tx\nuse.mock::account\n\nbegin\n");
+    let mut out = String::from("use.miden::tx\nuse.miden::output_note\n\nbegin\n");
 
     for (idx, note) in output_notes.iter().enumerate() {
         if idx == 0 {
@@ -181,7 +181,7 @@ fn note_script_that_creates_notes(output_notes: Vec<&Note>) -> String {
         for asset in assets_str {
             out.push_str(&format!(
                 " push.{asset}
-                  call.tx::add_asset_to_note\n",
+                  call.output_note::add_asset\n",
             ));
         }
     }

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -155,7 +155,7 @@ pub fn create_spawn_note(sender_id: AccountId, output_notes: Vec<&Note>) -> anyh
 
 /// Returns the code for a note that creates all notes in `output_notes`
 fn note_script_that_creates_notes(output_notes: Vec<&Note>) -> String {
-    let mut out = String::from("use.miden::tx\nuse.miden::output_note\n\nbegin\n");
+    let mut out = String::from("use.miden::output_note\n\nbegin\n");
 
     for (idx, note) in output_notes.iter().enumerate() {
         if idx == 0 {
@@ -170,7 +170,7 @@ fn note_script_that_creates_notes(output_notes: Vec<&Note>) -> String {
               push.{note_type}
               push.{aux}
               push.{tag}
-              call.tx::create_note\n",
+              call.output_note::create\n",
             recipient = note.recipient().digest(),
             hint = Felt::from(note.metadata().execution_hint()),
             note_type = note.metadata().note_type() as u8,

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -219,14 +219,14 @@ fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
 
     let tx_script_src = &format!(
         "
-            use.miden::tx
+            use.miden::output_note
             begin
                 push.{recipient_1}
                 push.{note_execution_hint_1}
                 push.{note_type_1}
                 push.0              # aux
                 push.{tag_1}
-                call.tx::create_note
+                call.output_note::create
 
                 push.{asset_1}
                 call.::miden::contracts::wallets::basic::move_asset_to_note
@@ -237,7 +237,7 @@ fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
                 push.{note_type_2}
                 push.0              # aux
                 push.{tag_2}
-                call.tx::create_note
+                call.output_note::create
 
                 push.{asset_2}
                 call.::miden::contracts::wallets::basic::move_asset_to_note

--- a/crates/miden-testing/tests/scripts/swap.rs
+++ b/crates/miden-testing/tests/scripts/swap.rs
@@ -40,14 +40,14 @@ pub fn prove_send_swap_note() -> anyhow::Result<()> {
 
     let tx_script_src = &format!(
         "
-        use.miden::tx
+        use.miden::output_note
         begin
             push.{recipient}
             push.{note_execution_hint}
             push.{note_type}
             push.0              # aux
             push.{tag}
-            call.tx::create_note
+            call.output_note::create
 
             push.{asset}
             call.::miden::contracts::wallets::basic::move_asset_to_note

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -85,6 +85,7 @@ Output note procedures can be used to fetch data on output notes created by the 
 
 | Procedure | Description | Context |
 | --- | --- | --- |
+| `create` | Creates a new note and returns the index of the note.<br><br>Inputs: `[tag, aux, note_type, execution_hint, RECIPIENT]`<br>Outputs: `[note_idx]` | Native & Account |
 | `get_assets_info` | Returns the information about assets in the output note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[ASSETS_COMMITMENT, num_assets]` | Any |
 | `get_assets` | Writes the assets of the output note with the specified index into memory starting at the specified address.<br><br>Inputs: `[dest_ptr, note_index]`<br>Outputs: `[num_assets, dest_ptr, note_index]` | Any |
 | `add_asset` | Adds the ASSET to the note specified by the index.<br><br>Inputs: `[ASSET, note_idx]`<br>Outputs: `[ASSET, note_idx]` | Native |
@@ -104,7 +105,6 @@ Transaction procedures manage transaction-level operations including note creati
 | `get_output_notes_commitment` | Returns the output notes commitment hash.<br><br>Inputs: `[]`<br>Outputs: `[OUTPUT_NOTES_COMMITMENT]` | Any |
 | `get_num_input_notes` | Returns the total number of input notes consumed by this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_input_notes]` | Any |
 | `get_num_output_notes` | Returns the current number of output notes created in this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_output_notes]` | Any |
-| `create_note` | Creates a new note and returns the index of the note.<br><br>Inputs: `[tag, aux, note_type, execution_hint, RECIPIENT]`<br>Outputs: `[note_idx]` | Native & Account |
 | `build_recipient_hash` | Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.<br><br>Inputs: `[SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]`<br>Outputs: `[RECIPIENT]` | Any |
 | `execute_foreign_procedure` | Executes the provided procedure against the foreign account.<br><br>Inputs: `[foreign_account_id_prefix, foreign_account_id_suffix, FOREIGN_PROC_ROOT, <inputs>, pad(n)]`<br>Outputs: `[<outputs>]` | Any |
 | `get_expiration_block_delta` | Returns the transaction expiration delta, or 0 if not set.<br><br>Inputs: `[]`<br>Outputs: `[block_height_delta]` | Any |

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -87,6 +87,7 @@ Output note procedures can be used to fetch data on output notes created by the 
 | --- | --- | --- |
 | `get_assets_info` | Returns the information about assets in the output note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[ASSETS_COMMITMENT, num_assets]` | Any |
 | `get_assets` | Writes the assets of the output note with the specified index into memory starting at the specified address.<br><br>Inputs: `[dest_ptr, note_index]`<br>Outputs: `[num_assets, dest_ptr, note_index]` | Any |
+| `add_asset` | Adds the ASSET to the note specified by the index.<br><br>Inputs: `[ASSET, note_idx]`<br>Outputs: `[ASSET, note_idx]` | Native |
 | `get_recipient` | Returns the [recipient](note.md#note-recipient-restricting-consumption) of the output note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[RECIPIENT]` | Any |
 | `get_metadata` | Returns the [metadata](note.md#metadata) of the output note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[METADATA]` | Any |
 
@@ -104,7 +105,6 @@ Transaction procedures manage transaction-level operations including note creati
 | `get_num_input_notes` | Returns the total number of input notes consumed by this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_input_notes]` | Any |
 | `get_num_output_notes` | Returns the current number of output notes created in this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_output_notes]` | Any |
 | `create_note` | Creates a new note and returns the index of the note.<br><br>Inputs: `[tag, aux, note_type, execution_hint, RECIPIENT]`<br>Outputs: `[note_idx]` | Native & Account |
-| `add_asset_to_note` | Adds the ASSET to the note specified by the index.<br><br>Inputs: `[ASSET, note_idx]`<br>Outputs: `[ASSET, note_idx]` | Native |
 | `build_recipient_hash` | Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.<br><br>Inputs: `[SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]`<br>Outputs: `[RECIPIENT]` | Any |
 | `execute_foreign_procedure` | Executes the provided procedure against the foreign account.<br><br>Inputs: `[foreign_account_id_prefix, foreign_account_id_suffix, FOREIGN_PROC_ROOT, <inputs>, pad(n)]`<br>Outputs: `[<outputs>]` | Any |
 | `get_expiration_block_delta` | Returns the transaction expiration delta, or 0 if not set.<br><br>Inputs: `[]`<br>Outputs: `[block_height_delta]` | Any |

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -71,6 +71,7 @@ Input note procedures can be used to fetch data on input notes consumed by the t
 
 | Procedure | Description | Context |
 | --- | --- | --- |
+| `get_num_notes` | Returns the total number of input notes consumed by this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_input_notes]` | Any |
 | `get_assets_info` | Returns the information about [assets](note.md#assets) in the input note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[ASSETS_COMMITMENT, num_assets]` | Any |
 | `get_assets` | Writes the [assets](note.md#assets) of the input note with the specified index into memory starting at the specified address.<br><br>Inputs: `[dest_ptr, note_index]`<br>Outputs: `[num_assets, dest_ptr, note_index]` | Any |
 | `get_recipient` | Returns the [recipient](note.md#note-recipient-restricting-consumption) of the input note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[RECIPIENT]` | Any |
@@ -86,6 +87,7 @@ Output note procedures can be used to fetch data on output notes created by the 
 | Procedure | Description | Context |
 | --- | --- | --- |
 | `create` | Creates a new note and returns the index of the note.<br><br>Inputs: `[tag, aux, note_type, execution_hint, RECIPIENT]`<br>Outputs: `[note_idx]` | Native & Account |
+| `get_num_notes` | Returns the current number of output notes created in this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_output_notes]` | Any |
 | `get_assets_info` | Returns the information about assets in the output note with the specified index.<br><br>Inputs: `[note_index]`<br>Outputs: `[ASSETS_COMMITMENT, num_assets]` | Any |
 | `get_assets` | Writes the assets of the output note with the specified index into memory starting at the specified address.<br><br>Inputs: `[dest_ptr, note_index]`<br>Outputs: `[num_assets, dest_ptr, note_index]` | Any |
 | `add_asset` | Adds the ASSET to the note specified by the index.<br><br>Inputs: `[ASSET, note_idx]`<br>Outputs: `[ASSET, note_idx]` | Native |
@@ -103,8 +105,6 @@ Transaction procedures manage transaction-level operations including note creati
 | `get_block_timestamp` | Returns the timestamp of the reference block for this transaction.<br><br>Inputs: `[]`<br>Outputs: `[timestamp]` | Any |
 | `get_input_notes_commitment` | Returns the input notes commitment hash.<br><br>Inputs: `[]`<br>Outputs: `[INPUT_NOTES_COMMITMENT]` | Any |
 | `get_output_notes_commitment` | Returns the output notes commitment hash.<br><br>Inputs: `[]`<br>Outputs: `[OUTPUT_NOTES_COMMITMENT]` | Any |
-| `get_num_input_notes` | Returns the total number of input notes consumed by this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_input_notes]` | Any |
-| `get_num_output_notes` | Returns the current number of output notes created in this transaction.<br><br>Inputs: `[]`<br>Outputs: `[num_output_notes]` | Any |
 | `build_recipient_hash` | Returns the RECIPIENT for a specified SERIAL_NUM, SCRIPT_ROOT, and inputs commitment.<br><br>Inputs: `[SERIAL_NUM, SCRIPT_ROOT, INPUT_COMMITMENT]`<br>Outputs: `[RECIPIENT]` | Any |
 | `execute_foreign_procedure` | Executes the provided procedure against the foreign account.<br><br>Inputs: `[foreign_account_id_prefix, foreign_account_id_suffix, FOREIGN_PROC_ROOT, <inputs>, pad(n)]`<br>Outputs: `[<outputs>]` | Any |
 | `get_expiration_block_delta` | Returns the transaction expiration delta, or 0 if not set.<br><br>Inputs: `[]`<br>Outputs: `[block_height_delta]` | Any |


### PR DESCRIPTION
This PR moves a bunch of note procedures from `tx` module (both `kernel` and `miden`) to the corresponding `input_note` or `output_note` module, namely: 
- `tx::add_asset_to_note` -> `output_note::add_asset`
- `tx::create_note` -> `output_note::create`
- `tx::get_num_input_notes` -> `input_note::get_num_notes`
- `tx::get_num_output_notes` -> `output_note::get_num_notes`

Also the `tx_update_expiration_block_num` kernel procedure was renamed to `tx_update_expiration_block_delta`.

Closes: #1835.