### PR TITLE
Use "active note" terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [BREAKING] Moved `miden::asset::{create_fungible_asset, create_non_fungible_asset}` procedures to `miden::faucet` ([#1850](https://github.com/0xMiden/miden-base/pull/1850)).
 - [BREAKING] Moved `NetworkId` from account ID to address module ([#1851](https://github.com/0xMiden/miden-base/pull/1851)).
 - [BREAKING] Move `TransactionKernelError` to miden-tx ([#1859](https://github.com/0xMiden/miden-base/pull/1859)).
+- Change terminology of "current note" to "active note" ([#1863](https://github.com/0xMiden/miden-base/issues/1863)).
 
 ## 0.11.2 (2025-09-08)
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -29,17 +29,17 @@ const.ERR_FAUCET_IS_NF_ASSET_ISSUED_PROC_CAN_ONLY_BE_CALLED_ON_NON_FUNGIBLE_FAUC
 
 const.ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS="provided kernel procedure offset is out of bounds"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_ASSETS_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note assets of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_ASSETS_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note assets of active note because no note is currently being processed"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_RECIPIENT_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note recipient of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_RECIPIENT_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note recipient of active note because no note is currently being processed"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_METADATA_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note metadata of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_METADATA_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note metadata of active note because no note is currently being processed"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_INPUTS_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note inputs of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_INPUTS_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note inputs of active note because no note is currently being processed"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SCRIPT_ROOT_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note script root of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SCRIPT_ROOT_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note script root of active note because no note is currently being processed"
 
-const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SERIAL_NUMBER_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note serial number of current note because no note is currently being processed"
+const.ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SERIAL_NUMBER_WHILE_NO_NOTE_BEING_PROCESSED="failed to access note serial number of active note because no note is currently being processed"
 
 # AUTHENTICATION
 # =================================================================================================
@@ -744,20 +744,20 @@ end
 
 #! Returns the assets information of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(14)]
+#! Inputs:  [is_active_note, note_index, pad(14)]
 #! Outputs: [ASSETS_COMMITMENT, num_assets, pad(11)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the assets data from
-#!   the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the assets data from
+#!   the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose assets info should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - ASSETS_COMMITMENT is a sequential hash of the assets in the specified input note.
 #! - num_assets is the number of assets in the specified input note.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -783,19 +783,19 @@ end
 
 #! Returns the recipient of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(15)]
+#! Inputs:  [is_active_note, note_index, pad(15)]
 #! Outputs: [RECIPIENT, pad(12)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the assets data from
-#!   the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the assets data from
+#!   the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose assets info should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - RECIPIENT is the commitment to the input note's script, inputs, the serial number.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -821,19 +821,19 @@ end
 
 #! Returns the metadata of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(14)]
+#! Inputs:  [is_active_note, note_index, pad(14)]
 #! Outputs: [METADATA, pad(12)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the metadata from
-#!   the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the metadata from
+#!   the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose metadata should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - METADATA is the metadata of the specified input note.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -859,19 +859,19 @@ end
 
 #! Returns the serial number of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(14)]
+#! Inputs:  [is_active_note, note_index, pad(14)]
 #! Outputs: [SERIAL_NUMBER, pad(12)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the serial number
-#!   of the currently processing note or of the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the serial number
+#!   of the active note or of the note with the specified index.
 #! - note_index is the index of the input note whose serial number should be returned. Notice that 
-#!   if is_current_note is 1, note_index is ignored.
+#!   if is_active_note is 1, note_index is ignored.
 #! - SERIAL_NUMBER is the serial number of the specified input note.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -899,20 +899,20 @@ end
 
 #! Returns the inputs commitment and length of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(14)]
+#! Inputs:  [is_active_note, note_index, pad(14)]
 #! Outputs: [NOTE_INPUTS_COMMITMENT, num_inputs, pad(11)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the inputs commitment 
-#!   and length from the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the inputs commitment 
+#!   and length from the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose data should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - NOTE_INPUTS_COMMITMENT is the inputs commitment of the specified input note.
 #! - num_inputs is the number of inputs of the specified input note.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -944,19 +944,19 @@ end
 
 #! Returns the script root of the specified input note.
 #!
-#! Inputs:  [is_current_note, note_index, pad(14)]
+#! Inputs:  [is_active_note, note_index, pad(14)]
 #! Outputs: [SCRIPT_ROOT, pad(12)]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return the inputs commitment 
-#!   and length from the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return the inputs commitment 
+#!   and length from the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose data should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - SCRIPT_ROOT is the script root of the specified input note.
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-#! - is_current_note is 1 and no input note is not being processed (attempted to access note inputs
+#! - is_active_note is 1 and no input note is not being processed (attempted to access note inputs
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
@@ -1471,17 +1471,17 @@ end
 #! Returns the memory pointer to the input note, depending on whether the requested note is current
 #! or it was requested by index.
 #!
-#! If the pointer to the currently processing note was requested, but no note is being executed, 0 
+#! If the pointer to the active note was requested, but no note is being executed, 0 
 #! is returned.
 #!
-#! Inputs:  [is_current_note, note_index]
+#! Inputs:  [is_active_note, note_index]
 #! Outputs: [input_note_ptr]
 #!
 #! Where:
-#! - is_current_note is the boolean flag indicating whether we should return requested data from
-#!   the currently processing note or from the note with the specified index.
+#! - is_active_note is the boolean flag indicating whether we should return requested data from
+#!   the active note or from the note with the specified index.
 #! - note_index is the index of the input note whose data should be returned. Notice that if
-#!   is_current_note is 1, note_index is ignored.
+#!   is_active_note is 1, note_index is ignored.
 #! - input_note_ptr is the pointer to the correct input note. 
 #!
 #! Panics if:
@@ -1489,13 +1489,13 @@ end
 proc.get_requested_note_ptr
     # get the memory pointer to the note with the specified index and verify it is valid
     swap exec.input_note::get_input_note_ptr swap
-    # => [is_current_note, indexed_input_note_ptr]
+    # => [is_active_note, indexed_input_note_ptr]
 
     # get the memory pointer to the currently processed input note
     exec.memory::get_current_input_note_ptr swap
-    # => [is_current_note, current_input_note_ptr, indexed_input_note_ptr]
+    # => [is_active_note, current_input_note_ptr, indexed_input_note_ptr]
 
-    # If is_current_note flag is true (current note processing case), current_input_note_ptr remains
+    # If is_active_note flag is true (active note processing case), current_input_note_ptr remains
     # on the stack. If it is false, indexed_input_note_ptr remains instead.
     cdrop
     # => [input_note_ptr]

--- a/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/prologue.masm
@@ -995,7 +995,7 @@ proc.process_input_notes_data
     # - On the top of the stack is the hasher state containing the input notes commitment. The
     #   hasher state will be updated by `process_input_note`. After the loop the commitment is
     #   extracted.
-    # - Below the hasher state in the stack is the current note index. This number is used for two
+    # - Below the hasher state in the stack is the active note index. This number is used for two
     #   purposes:
     #   1. Compute the input note's memory addresses, the index works as an offset.
     #   2. Determine the loop condition. The loop below runs until all input notes have been

--- a/crates/miden-lib/asm/miden/input_note.masm
+++ b/crates/miden-lib/asm/miden/input_note.masm
@@ -28,10 +28,10 @@ export.get_assets_info
     # push the flag indicating that we want to request assets info from the note with the specified
     # index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_assets_info_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
@@ -102,10 +102,10 @@ export.get_recipient
     # push the flag indicating that we want to request assets info from the note with the specified
     # index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_recipient_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
@@ -140,14 +140,14 @@ export.get_metadata
     # push the flag indicating that we want to request metadata from the note with the specified
     # index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_metadata_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
-    # => [offset, is_current_note = 0, note_index, pad(13)]
+    # => [offset, is_active_note = 0, note_index, pad(13)]
 
     syscall.exec_kernel_proc
     # => [METADATA, pad(12)]
@@ -179,14 +179,14 @@ export.get_inputs_info
     # push the flag indicating that we want to request inputs info from the note with the specified
     # index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_inputs_info_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
-    # => [offset, is_current_note = 0, note_index, pad(13)]
+    # => [offset, is_active_note = 0, note_index, pad(13)]
 
     syscall.exec_kernel_proc
     # => [NOTE_INPUTS_COMMITMENT, num_inputs, pad(11)]
@@ -220,14 +220,14 @@ export.get_script_root
     # push the flag indicating that we want to request script root from the note with the specified
     # index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_script_root_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
-    # => [offset, is_current_note = 0, note_index, pad(13)]
+    # => [offset, is_active_note = 0, note_index, pad(13)]
 
     syscall.exec_kernel_proc
     # => [SCRIPT_ROOT, pad(12)]
@@ -258,14 +258,14 @@ export.get_serial_number
     # push the flag indicating that we want to request serial number from the note with the 
     # specified index
     push.0
-    # => [is_current_note = 0, note_index, 0]
+    # => [is_active_note = 0, note_index, 0]
 
     exec.kernel_proc_offsets::input_note_get_serial_number_offset
-    # => [offset, is_current_note = 0, note_index, 0]
+    # => [offset, is_active_note = 0, note_index, 0]
 
     # pad the stack
     padw swapw padw padw swapdw
-    # => [offset, is_current_note = 0, note_index, pad(13)]
+    # => [offset, is_active_note = 0, note_index, pad(13)]
 
     syscall.exec_kernel_proc
     # => [SERIAL_NUMBER, pad(12)]

--- a/crates/miden-lib/asm/miden/note.masm
+++ b/crates/miden-lib/asm/miden/note.masm
@@ -37,10 +37,10 @@ export.get_assets
     # push the flag indicating that we want to request assets info from the currently processing
     # note
     push.1
-    # => [is_current_note = 1, pad(14), dest_ptr]
+    # => [is_active_note = 1, pad(14), dest_ptr]
 
     exec.kernel_proc_offsets::input_note_get_assets_info_offset
-    # => [offset, is_current_note = 1, pad(14), dest_ptr]
+    # => [offset, is_active_note = 1, pad(14), dest_ptr]
 
     syscall.exec_kernel_proc
     # => [ASSETS_COMMITMENT, num_assets, pad(11), dest_ptr]
@@ -74,10 +74,10 @@ export.get_recipient
     # push the flag indicating that we want to request recipient from the currently processing
     # note
     push.1
-    # => [is_current_note = 1, pad(14)]
+    # => [is_active_note = 1, pad(14)]
 
     exec.kernel_proc_offsets::input_note_get_recipient_offset
-    # => [offset, is_current_note = 1, pad(14)]
+    # => [offset, is_active_note = 1, pad(14)]
 
     syscall.exec_kernel_proc
     # => [RECIPIENT, pad(12)]
@@ -112,10 +112,10 @@ export.get_inputs
     # push the flag indicating that we want to request inputs info from the currently processing 
     # note
     push.1
-    # => [is_current_note = 1, pad(14), dest_ptr]
+    # => [is_active_note = 1, pad(14), dest_ptr]
 
     exec.kernel_proc_offsets::input_note_get_inputs_info_offset
-    # => [offset, is_current_note = 1, pad(14), dest_ptr]
+    # => [offset, is_active_note = 1, pad(14), dest_ptr]
 
     syscall.exec_kernel_proc
     # => [NOTE_INPUTS_COMMITMENT, num_inputs, pad(11), dest_ptr]
@@ -148,12 +148,12 @@ export.get_sender
     padw padw padw push.0.0
     # => [pad(14)]
 
-    # push the flag indicating that we want to request metadata from the currently processing note
+    # push the flag indicating that we want to request metadata from the active note
     push.1
-    # => [is_current_note = 1, pad(14)]
+    # => [is_active_note = 1, pad(14)]
 
     exec.kernel_proc_offsets::input_note_get_metadata_offset
-    # => [offset, is_current_note = 1, pad(14)]
+    # => [offset, is_active_note = 1, pad(14)]
 
     syscall.exec_kernel_proc
     # => [METADATA, pad(12)]
@@ -187,10 +187,10 @@ export.get_serial_number
     # push the flag indicating that we want to request serial number from the currently processing
     # note
     push.1
-    # => [is_current_note = 1, pad(14)]
+    # => [is_active_note = 1, pad(14)]
 
     exec.kernel_proc_offsets::input_note_get_serial_number_offset
-    # => [offset, is_current_note = 1, pad(14)]
+    # => [offset, is_active_note = 1, pad(14)]
 
     syscall.exec_kernel_proc
     # => [SERIAL_NUMBER, pad(12)]
@@ -257,10 +257,10 @@ export.get_script_root
     # push the flag indicating that we want to request script root from the currently processing
     # note
     push.1
-    # => [is_current_note = 1, pad(14)]
+    # => [is_active_note = 1, pad(14)]
 
     exec.kernel_proc_offsets::input_note_get_script_root_offset
-    # => [offset, is_current_note = 1, pad(14)]
+    # => [offset, is_active_note = 1, pad(14)]
 
     syscall.exec_kernel_proc
     # => [SCRIPT_ROOT, pad(12)]

--- a/crates/miden-lib/asm/note_scripts/P2IDE.masm
+++ b/crates/miden-lib/asm/note_scripts/P2IDE.masm
@@ -41,11 +41,11 @@ end
 #! Outputs: []
 #!
 #! Panics if:
-#! - the reclaim of the current note is disabled.
+#! - the reclaim of the active note is disabled.
 #! - the reclaim block height is not reached yet.
 #! - the account attempting to reclaim the note is not the sender account.
 proc.reclaim_note
-    # check that the reclaim of the current note is enabled
+    # check that the reclaim of the active note is enabled
     movup.3 dup neq.0 assert.err=ERR_P2IDE_RECLAIM_DISABLED
     # => [reclaim_block_height, account_id_prefix, account_id_suffix, current_block_height]
 

--- a/crates/miden-lib/src/errors/tx_kernel_errors.rs
+++ b/crates/miden-lib/src/errors/tx_kernel_errors.rs
@@ -143,18 +143,18 @@ pub const ERR_NON_FUNGIBLE_ASSET_FORMAT_MOST_SIGNIFICANT_BIT_MUST_BE_ZERO: MasmE
 /// Error Message: "failed to build the non-fungible asset because the provided faucet id is not from a non-fungible faucet"
 pub const ERR_NON_FUNGIBLE_ASSET_PROVIDED_FAUCET_ID_IS_INVALID: MasmError = MasmError::from_static_str("failed to build the non-fungible asset because the provided faucet id is not from a non-fungible faucet");
 
-/// Error Message: "failed to access note assets of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_ASSETS_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note assets of current note because no note is currently being processed");
-/// Error Message: "failed to access note inputs of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_INPUTS_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note inputs of current note because no note is currently being processed");
-/// Error Message: "failed to access note metadata of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_METADATA_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note metadata of current note because no note is currently being processed");
-/// Error Message: "failed to access note recipient of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_RECIPIENT_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note recipient of current note because no note is currently being processed");
-/// Error Message: "failed to access note script root of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SCRIPT_ROOT_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note script root of current note because no note is currently being processed");
-/// Error Message: "failed to access note serial number of current note because no note is currently being processed"
-pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SERIAL_NUMBER_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note serial number of current note because no note is currently being processed");
+/// Error Message: "failed to access note assets of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_ASSETS_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note assets of active note because no note is currently being processed");
+/// Error Message: "failed to access note inputs of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_INPUTS_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note inputs of active note because no note is currently being processed");
+/// Error Message: "failed to access note metadata of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_METADATA_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note metadata of active note because no note is currently being processed");
+/// Error Message: "failed to access note recipient of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_RECIPIENT_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note recipient of active note because no note is currently being processed");
+/// Error Message: "failed to access note script root of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SCRIPT_ROOT_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note script root of active note because no note is currently being processed");
+/// Error Message: "failed to access note serial number of active note because no note is currently being processed"
+pub const ERR_NOTE_ATTEMPT_TO_ACCESS_NOTE_SERIAL_NUMBER_WHILE_NO_NOTE_BEING_PROCESSED: MasmError = MasmError::from_static_str("failed to access note serial number of active note because no note is currently being processed");
 /// Error Message: "note data does not match the commitment"
 pub const ERR_NOTE_DATA_DOES_NOT_MATCH_COMMITMENT: MasmError = MasmError::from_static_str("note data does not match the commitment");
 /// Error Message: "adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"

--- a/crates/miden-lib/src/note/well_known_note.rs
+++ b/crates/miden-lib/src/note/well_known_note.rs
@@ -108,7 +108,7 @@ impl WellKnownNote {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the expected inputs number of the current note.
+    /// Returns the expected inputs number of the active note.
     pub fn num_expected_inputs(&self) -> usize {
         match self {
             Self::P2ID => Self::P2ID_NUM_INPUTS,


### PR DESCRIPTION
This PR changes the terminology of "current note" to "active note" for clarity. Resolves #1863 