### PR TITLE
Add initial slot & map storage kernel procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added lazy loading of the native asset ([#1855](https://github.com/0xMiden/miden-base/pull/1855)).
 - Added `build_recipient` procedure to `miden::note` module ([#1807](https://github.com/0xMiden/miden-base/pull/1807)).
 - Added Serialize and Deserialize Traits on `SigningInputs` ([#1858](https://github.com/0xMiden/miden-base/pull/1858))
+- Added `get_item_init` and `get_map_item_init` procedures to `miden::account` module for accessing initial storage state ([#1883](https://github.com/0xMiden/miden-base/pull/1883)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,8 @@
 - [BREAKING] Enabled lazy loading of foreign accounts during transaction execution ([#1873](https://github.com/0xMiden/miden-base/pull/1873)).
 - Added lazy loading of the native asset ([#1855](https://github.com/0xMiden/miden-base/pull/1855)).
 - Added `build_recipient` procedure to `miden::note` module ([#1807](https://github.com/0xMiden/miden-base/pull/1807)).
-- Added Serialize and Deserialize Traits on `SigningInputs` ([#1858](https://github.com/0xMiden/miden-base/pull/1858))
-- Added `get_item_init` and `get_map_item_init` procedures to `miden::account` module for accessing initial storage state ([#1883](https://github.com/0xMiden/miden-base/pull/1883)).
 - [BREAKING] Move account seed into `PartialAccount` ([#1875](https://github.com/0xMiden/miden-base/pull/1875)).
+- Added `get_item_init` and `get_map_item_init` procedures to `miden::account` module for accessing initial storage state ([#1883](https://github.com/0xMiden/miden-base/pull/1883)).
 
 ### Changes
 

--- a/crates/miden-lib/asm/kernels/transaction/api.masm
+++ b/crates/miden-lib/asm/kernels/transaction/api.masm
@@ -426,6 +426,66 @@ export.account_get_map_item
     # => [VALUE, pad(12)]
 end
 
+#! Gets an item from the account storage at its initial state (beginning of transaction).
+#!
+#! Inputs:  [index, pad(15)]
+#! Outputs: [INIT_VALUE, pad(12)]
+#!
+#! Where:
+#! - index is the index of the item to get.
+#! - INIT_VALUE is the initial value of the item at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the index is out of bounds.
+#!
+#! Invocation: dynexec
+export.account_get_item_init
+    # authenticate that the procedure invocation originates from the account context
+    exec.authenticate_account_origin
+    # => [storage_offset, storage_size, index, pad(15)]
+
+    # apply offset to storage slot index
+    exec.account::apply_storage_offset
+    # => [index_with_offset, pad(15)]
+
+    # fetch the initial account storage item
+    exec.account::get_item_init
+    # => [INIT_VALUE, pad(15)]
+
+    # truncate the stack
+    movup.4 drop movup.4 drop movup.4 drop
+    # => [INIT_VALUE, pad(12)]
+end
+
+#! Returns the initial VALUE located under the specified KEY within the map contained in the given
+#! account storage slot at the beginning of the transaction.
+#!
+#! Inputs:  [index, KEY, pad(11)]
+#! Outputs: [INIT_VALUE, pad(12)]
+#!
+#! Where:
+#! - index is the index of the storage slot that contains the map root.
+#! - INIT_VALUE is the initial value of the map item at KEY at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the index is out of bounds (>255).
+#! - the requested storage slot type is not map.
+#!
+#! Invocation: dynexec
+export.account_get_map_item_init
+    # authenticate that the procedure invocation originates from the account context
+    exec.authenticate_account_origin
+    # => [storage_offset, storage_size, index, KEY, pad(11)]
+
+    # apply offset to storage slot index
+    exec.account::apply_storage_offset
+    # => [index_with_offset, KEY, pad(11)]
+
+    # fetch the initial map item from account storage
+    exec.account::get_map_item_init
+    # => [INIT_VALUE, pad(12)]
+end
+
 #! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.
 #!
 #! Inputs:  [index, KEY, NEW_VALUE, pad(7)]

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -468,6 +468,27 @@ export.get_item
     # => [VALUE]
 end
 
+#! Gets an item from the account storage at its initial state (beginning of transaction).
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Inputs:  [index]
+#! Outputs: [INIT_VALUE]
+#!
+#! Where:
+#! - index is the index of the item to get.
+#! - INIT_VALUE is the initial value of the item at the beginning of the transaction.
+export.get_item_init
+    # get account initial storage slots section offset
+    exec.memory::get_account_initial_storage_slots_ptr
+    # => [account_initial_storage_slots_ptr, index]
+
+    # get the item from initial storage
+    swap mul.8 add padw movup.4 mem_loadw
+    # => [INIT_VALUE]
+end
+
 #! Sets an item in the account storage.
 #!
 #! Note:
@@ -560,6 +581,57 @@ export.get_map_item
 
     movup.4 drop
     # => [VALUE]
+end
+
+#! Returns the VALUE located under the specified KEY within the map contained in the given
+#! account storage slot at its initial state (beginning of transaction).
+#!
+#! Inputs:  [index, KEY]
+#! Outputs: [INIT_VALUE]
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Where:
+#! - index is the index of the storage slot that contains the map root.
+#! - INIT_VALUE is the initial value of the map item at KEY at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the requested storage slot type is not map.
+export.get_map_item_init
+    # get the storage slot type
+    dup exec.get_storage_slot_type
+    # => [slot_type, index, KEY]
+
+    # check if storage slot type is map
+    exec.constants::get_storage_slot_type_map eq
+    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
+    # => [index, KEY]
+
+    dup movdn.5
+    # => [index, KEY, index]
+
+    # fetch the initial account storage item, which is ROOT of the map
+    exec.get_item_init swapw
+    # => [KEY, INIT_ROOT, index]
+
+    emit.ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT
+    # => [KEY, INIT_ROOT, index]
+
+    # see hash_map_key's docs for why this is done
+    exec.hash_map_key
+    # => [HASHED_KEY, INIT_ROOT, index]
+
+    # fetch the VALUE located under HASHED_KEY in the tree
+    exec.smt::get
+    # => [INIT_VALUE, INIT_ROOT, index]
+
+    # remove the ROOT from the stack
+    swapw dropw
+    # => [INIT_VALUE, index]
+
+    movup.4 drop
+    # => [INIT_VALUE]
 end
 
 #! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -549,20 +549,65 @@ end
 #! Panics if:
 #! - the requested storage slot type is not map.
 export.get_map_item
-    # get the storage slot type
-    dup exec.get_storage_slot_type
-    # => [slot_type, index, KEY]
-
-    # check if storage slot type is map
-    exec.constants::get_storage_slot_type_map eq
-    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
-    # => [index, KEY]
-
+    # duplicate index for later use
     dup movdn.5
     # => [index, KEY, index]
 
     # fetch the account storage item, which is ROOT of the map
     exec.get_item swapw
+    # => [KEY, ROOT, index]
+
+    exec.get_map_item_raw
+end
+
+#! Returns the VALUE located under the specified KEY within the map contained in the given
+#! account storage slot at its initial state (beginning of transaction).
+#!
+#! Inputs:  [index, KEY]
+#! Outputs: [INIT_VALUE]
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Where:
+#! - index is the index of the storage slot that contains the map root.
+#! - INIT_VALUE is the initial value of the map item at KEY at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the requested storage slot type is not map.
+export.get_map_item_init
+    # duplicate index for later use
+    dup movdn.5
+    # => [index, KEY, index]
+
+    # fetch the initial account storage item, which is ROOT of the map
+    exec.get_item_init swapw
+    # => [KEY, INIT_ROOT, index]
+
+    exec.get_map_item_raw
+end
+
+#! Shared procedure for getting a map item from a storage slot.
+#!
+#! Inputs:  [KEY, ROOT, index]
+#! Outputs: [VALUE]
+#!
+#! Where:
+#! - KEY is the key to look up in the map.
+#! - ROOT is the root of the map.
+#! - index is the index of the storage slot that contains the map root.
+#! - VALUE is the value of the map item at KEY.
+#!
+#! Panics if:
+#! - the requested storage slot type is not map.
+proc.get_map_item_raw
+    # check storage slot type
+    dup.8 exec.get_storage_slot_type
+    # => [slot_type, KEY, ROOT, index]
+
+    # check if storage slot type is map
+    exec.constants::get_storage_slot_type_map eq
+    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
     # => [KEY, ROOT, index]
 
     emit.ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT
@@ -582,57 +627,6 @@ export.get_map_item
 
     movup.4 drop
     # => [VALUE]
-end
-
-#! Returns the VALUE located under the specified KEY within the map contained in the given
-#! account storage slot at its initial state (beginning of transaction).
-#!
-#! Inputs:  [index, KEY]
-#! Outputs: [INIT_VALUE]
-#!
-#! Note:
-#! - We assume that index has been validated and is within bounds.
-#!
-#! Where:
-#! - index is the index of the storage slot that contains the map root.
-#! - INIT_VALUE is the initial value of the map item at KEY at the beginning of the transaction.
-#!
-#! Panics if:
-#! - the requested storage slot type is not map.
-export.get_map_item_init
-    # get the storage slot type
-    dup exec.get_storage_slot_type
-    # => [slot_type, index, KEY]
-
-    # check if storage slot type is map
-    exec.constants::get_storage_slot_type_map eq
-    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
-    # => [index, KEY]
-
-    dup movdn.5
-    # => [index, KEY, index]
-
-    # fetch the initial account storage item, which is ROOT of the map
-    exec.get_item_init swapw
-    # => [KEY, INIT_ROOT, index]
-
-    emit.ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT
-    # => [KEY, INIT_ROOT, index]
-
-    # see hash_map_key's docs for why this is done
-    exec.hash_map_key
-    # => [HASHED_KEY, INIT_ROOT, index]
-
-    # fetch the VALUE located under HASHED_KEY in the tree
-    exec.smt::get
-    # => [INIT_VALUE, INIT_ROOT, index]
-
-    # remove the ROOT from the stack
-    swapw dropw
-    # => [INIT_VALUE, index]
-
-    movup.4 drop
-    # => [INIT_VALUE]
 end
 
 #! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -587,48 +587,6 @@ export.get_map_item_init
     exec.get_map_item_raw
 end
 
-#! Shared procedure for getting a map item from a storage slot.
-#!
-#! Inputs:  [KEY, ROOT, index]
-#! Outputs: [VALUE]
-#!
-#! Where:
-#! - KEY is the key to look up in the map.
-#! - ROOT is the root of the map.
-#! - index is the index of the storage slot that contains the map root.
-#! - VALUE is the value of the map item at KEY.
-#!
-#! Panics if:
-#! - the requested storage slot type is not map.
-proc.get_map_item_raw
-    # check storage slot type
-    dup.8 exec.get_storage_slot_type
-    # => [slot_type, KEY, ROOT, index]
-
-    # check if storage slot type is map
-    exec.constants::get_storage_slot_type_map eq
-    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
-    # => [KEY, ROOT, index]
-
-    emit.ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT
-    # => [KEY, ROOT, index]
-
-    # see hash_map_key's docs for why this is done
-    exec.hash_map_key
-    # => [HASHED_KEY, ROOT, index]
-
-    # fetch the VALUE located under HASHED_KEY in the tree
-    exec.smt::get
-    # => [VALUE, ROOT, index]
-
-    # remove the ROOT from the stack
-    swapw dropw
-    # => [VALUE, index]
-
-    movup.4 drop
-    # => [VALUE]
-end
-
 #! Stores NEW_VALUE under the specified KEY within the map contained in the given account storage slot.
 #!
 #! Note:
@@ -1232,6 +1190,48 @@ end
 export.get_item_raw
     # get the item from storage
     swap mul.8 add padw movup.4 mem_loadw
+    # => [VALUE]
+end
+
+#! Shared procedure for getting a map item from a storage slot.
+#!
+#! Inputs:  [KEY, ROOT, index]
+#! Outputs: [VALUE]
+#!
+#! Where:
+#! - KEY is the key to look up in the map.
+#! - ROOT is the root of the map.
+#! - index is the index of the storage slot that contains the map root.
+#! - VALUE is the value of the map item at KEY.
+#!
+#! Panics if:
+#! - the requested storage slot type is not map.
+proc.get_map_item_raw
+    # check storage slot type
+    dup.8 exec.get_storage_slot_type
+    # => [slot_type, KEY, ROOT, index]
+
+    # check if storage slot type is map
+    exec.constants::get_storage_slot_type_map eq
+    assert.err=ERR_ACCOUNT_READING_MAP_VALUE_FROM_NON_MAP_SLOT
+    # => [KEY, ROOT, index]
+
+    emit.ACCOUNT_STORAGE_BEFORE_GET_MAP_ITEM_EVENT
+    # => [KEY, ROOT, index]
+
+    # see hash_map_key's docs for why this is done
+    exec.hash_map_key
+    # => [HASHED_KEY, ROOT, index]
+
+    # fetch the VALUE located under HASHED_KEY in the tree
+    exec.smt::get
+    # => [VALUE, ROOT, index]
+
+    # remove the ROOT from the stack
+    swapw dropw
+    # => [VALUE, index]
+
+    movup.4 drop
     # => [VALUE]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account.masm
@@ -1,13 +1,12 @@
+use.$kernel::account_delta
+use.$kernel::account_id
+use.$kernel::asset_vault
+use.$kernel::constants
+use.$kernel::memory
 use.std::collections::mmr
 use.std::collections::smt
 use.std::crypto::hashes::rpo
 use.std::mem
-
-use.$kernel::account_id
-use.$kernel::asset_vault
-use.$kernel::account_delta
-use.$kernel::constants
-use.$kernel::memory
 
 # ERRORS
 # =================================================================================================
@@ -199,10 +198,10 @@ end
 
 #! Computes the account commitment of the current account.
 #!
-#! Notice that there is no caching (and, hence, dirty flag) for the commitment of the entire 
-#! account. Assuming that the storage commitment is current, computing account commitment is 
+#! Notice that there is no caching (and, hence, dirty flag) for the commitment of the entire
+#! account. Assuming that the storage commitment is current, computing account commitment is
 #! relatively cheap — essentially is consists of just 2 permutations of the hash function and takes
-#! relatively small number of cycles, so it would not be worth adding a separate caching mechanism 
+#! relatively small number of cycles, so it would not be worth adding a separate caching mechanism
 #! for this.
 #!
 #! Inputs:  []
@@ -466,7 +465,7 @@ export.get_item
     # => [acct_storage_slots_section_offset, index]
 
     # get the item from storage
-    swap mul.8 add padw movup.4 mem_loadw
+    exec.get_item_raw
     # => [VALUE]
 end
 
@@ -487,7 +486,7 @@ export.get_item_init
     # => [account_initial_storage_slots_ptr, index]
 
     # get the item from initial storage
-    swap mul.8 add padw movup.4 mem_loadw
+    exec.get_item_raw
     # => [INIT_VALUE]
 end
 
@@ -931,7 +930,7 @@ end
 #!
 #! Panics if:
 #! - the asset is not valid.
-#! - the total value of the fungible asset is greater than or equal to 2^63 after the new asset was 
+#! - the total value of the fungible asset is greater than or equal to 2^63 after the new asset was
 #!   added.
 #! - the vault already contains the same non-fungible asset.
 export.add_asset_to_vault
@@ -1221,8 +1220,26 @@ export.save_account_procedure_data
     # OS => []
 end
 
-# HELPER PROCEDURES
+# HELPER PROCEDURES
 # =================================================================================================
+
+#! Gets an item from storage using the provided storage slots pointer and index.
+#!
+#! Note:
+#! - We assume that index has been validated and is within bounds.
+#!
+#! Inputs:  [storage_slots_ptr, index]
+#! Outputs: [VALUE]
+#!
+#! Where:
+#! - storage_slots_ptr is the pointer to the storage slots section.
+#! - index is the index of the item to get.
+#! - VALUE is the value of the item.
+export.get_item_raw
+    # get the item from storage
+    swap mul.8 add padw movup.4 mem_loadw
+    # => [VALUE]
+end
 
 #! Sets an item in the account storage. Doesn't emit any events.
 #!
@@ -1421,10 +1438,10 @@ end
 
 #! Makes the account storage commitment up-to-date.
 #!
-#! Notice that the account storage commitment got updated only if it is outdated: if the account 
+#! Notice that the account storage commitment got updated only if it is outdated: if the account
 #! storage changes, its commitment will be recomputed by hashing the storage slots. Then this newly
 #! computed storage commitment updates the storage commitment in memory. If the storage commitment
-#! is up-to-date, this procedure does nothing. 
+#! is up-to-date, this procedure does nothing.
 #!
 #! Inputs:  []
 #! Outputs: []
@@ -1436,7 +1453,7 @@ proc.refresh_storage_commitment
     # => [should_recompute_storage_commitment]
 
     if.true
-        # dirty flag being equal 1 ensures that we have at least one storage slot, so we have to 
+        # dirty flag being equal 1 ensures that we have at least one storage slot, so we have to
         # hash the storage anyway
 
         # get number of storage slots
@@ -1468,7 +1485,7 @@ proc.refresh_storage_commitment
         # => []
 
         # update the storage commitment dirty flag, indicating that the commitment is up-to-date
-        push.0 
+        push.0
         exec.memory::set_native_account_storage_commitment_dirty_flag
         # => []
     end

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -1,9 +1,9 @@
-use.$kernel::memory
-use.$kernel::link_map
-use.$kernel::constants
 use.$kernel::account
 use.$kernel::asset
 use.$kernel::asset_vault
+use.$kernel::constants
+use.$kernel::link_map
+use.$kernel::memory
 use.std::crypto::hashes::rpo
 use.std::math::u64
 
@@ -173,7 +173,7 @@ proc.update_value_slot_delta
     dup exec.account::get_item
     # => [CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
-    dup.4 exec.get_item_initial
+    dup.4 exec.account::get_item_init
     # => [INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
     eqw not
@@ -389,7 +389,6 @@ proc.update_fungible_asset_delta.2
     # => [RATE, RATE, PERM]
 end
 
-
 #! Updates the given delta hasher with the non-fungible asset vault delta.
 #!
 #! Inputs:  [RATE, RATE, PERM]
@@ -442,9 +441,9 @@ proc.update_non_fungible_asset_delta.2
             hperm
             # => [RATE, RATE, PERM]
         else
-          # discard the two key and value words loaded from the map
-          dropw dropw
-          # => [RATE, RATE, PERM]
+            # discard the two key and value words loaded from the map
+            dropw dropw
+            # => [RATE, RATE, PERM]
         end
         # => [RATE, RATE, PERM]
 
@@ -459,27 +458,6 @@ proc.update_non_fungible_asset_delta.2
     # drop iter
     drop
     # => [RATE, RATE, PERM]
-end
-
-#! Returns the initial value of a storage slot from the account storage.
-#!
-#! This is the value of the slot at the beginning of the transaction.
-#!
-#! If this this procedure is moved to the account, additional assertions are necessary to make it
-#! safe to use.
-#!
-#! Note: Assumes the index is within bounds.
-#!
-#! Inputs:  [index]
-#! Outputs: [INIT_VALUE]
-proc.get_item_initial
-    # get account storage slots section offset
-    exec.memory::get_native_account_initial_storage_slots_ptr
-    # => [account_delta_initial_storage_slots_ptr, index]
-
-    # get the item from storage
-    swap mul.8 add padw movup.4 mem_loadw
-    # => [INIT_VALUE]
 end
 
 # DELTA BOOKKEEPING
@@ -679,7 +657,6 @@ export.add_non_fungible_asset
     exec.link_map::set drop
     # => []
 end
-
 
 #! Removes the given non-fungible asset from the non-fungible asset vault delta.
 #!

--- a/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/memory.masm
@@ -1354,6 +1354,33 @@ export.get_native_account_initial_storage_slots_ptr
   exec.get_native_account_data_ptr add.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET
 end
 
+#! Returns the memory pointer to the initial storage slots of the current account.
+#!
+#! For the native account, this returns the pointer to the initial storage slots section.
+#! For foreign accounts, this returns the regular storage slots pointer since foreign accounts
+#! are read-only and their initial and current storage state always matches.
+#!
+#! Inputs:  []
+#! Outputs: [account_initial_storage_slots_ptr]
+#!
+#! Where:
+#! - account_initial_storage_slots_ptr is the memory pointer to the initial storage slot values.
+export.get_account_initial_storage_slots_ptr
+    exec.is_native_account
+    # => [is_native_account]
+    
+    if.true
+        # For native account, return the initial storage slots pointer
+        exec.get_native_account_initial_storage_slots_ptr
+        # => [account_initial_storage_slots_ptr]
+    else
+        # For foreign account, return the regular storage slots pointer since
+        # foreign accounts are read-only and initial == current
+        exec.get_account_storage_slots_section_ptr
+        # => [account_initial_storage_slots_ptr]
+    end
+end
+
 ### ACCOUNT DELTA #################################################
 
 #! Returns the link map pointer to the fungible asset vault delta.

--- a/crates/miden-lib/asm/miden/account.masm
+++ b/crates/miden-lib/asm/miden/account.masm
@@ -64,7 +64,7 @@ end
 #! Returns the nonce of the current account.
 #!
 #! This procedure always returns the initial account nonce, as the nonce can only be incremented
-#! in the authentication procedure when signing the transaction after all user code has been 
+#! in the authentication procedure when signing the transaction after all user code has been
 #! executed.
 #!
 #! Inputs:  []
@@ -265,7 +265,6 @@ export.get_item
 end
 
 #! Gets an item from the account storage at its initial state (beginning of transaction).
-#! Panics if the index is out of bounds.
 #!
 #! Inputs:  [index]
 #! Outputs: [INIT_VALUE]
@@ -424,7 +423,7 @@ end
 
 #! Gets the account code commitment of the current account.
 #!
-#! Notice that the account code cannot be changed during the user code execution, so the code 
+#! Notice that the account code cannot be changed during the user code execution, so the code
 #! commitment doesn't change during transaction execution: commitment returned by this procedure
 #! could be used as both the initial and the current.
 #!
@@ -478,7 +477,7 @@ end
 
 #! Computes the latest account storage commitment of the current account.
 #!
-#! Notice that this procedure always returns the latest commitment, but it doesn't actually always 
+#! Notice that this procedure always returns the latest commitment, but it doesn't actually always
 #! recompute it: recomputation is performed only if the account's storage has been changed,
 #! otherwise the cached value is returned.
 #!

--- a/crates/miden-lib/asm/miden/account.masm
+++ b/crates/miden-lib/asm/miden/account.masm
@@ -264,7 +264,7 @@ export.get_item
     # => [VALUE]
 end
 
-#! Gets an item from the account storage at its initial state (beginning of transaction).
+#! Gets the initial item from the account storage slot as it was at the beginning of the transaction.
 #!
 #! Inputs:  [index]
 #! Outputs: [INIT_VALUE]
@@ -390,7 +390,7 @@ export.set_map_item
     # => [OLD_MAP_ROOT, OLD_MAP_VALUE]
 end
 
-#! Gets a map item from the account storage at its initial state (beginning of transaction).
+#! Gets the initial VALUE from the account storage map as it was at the beginning of the transaction.
 #!
 #! Inputs:  [index, KEY]
 #! Outputs: [INIT_VALUE]

--- a/crates/miden-lib/asm/miden/account.masm
+++ b/crates/miden-lib/asm/miden/account.masm
@@ -264,6 +264,39 @@ export.get_item
     # => [VALUE]
 end
 
+#! Gets an item from the account storage at its initial state (beginning of transaction).
+#! Panics if the index is out of bounds.
+#!
+#! Inputs:  [index]
+#! Outputs: [INIT_VALUE]
+#!
+#! Where:
+#! - index is the index of the item to get.
+#! - INIT_VALUE is the initial value of the item at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the index of the requested item is out of bounds.
+#!
+#! Invocation: exec
+export.get_item_init
+    push.0.0 movup.2
+    # => [index, 0, 0]
+
+    exec.kernel_proc_offsets::account_get_item_init_offset
+    # => [offset, index, 0, 0]
+
+    # pad the stack
+    padw swapw padw padw swapdw
+    # => [offset, index, pad(14)]
+
+    syscall.exec_kernel_proc
+    # => [INIT_VALUE, pad(12)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw
+    # => [INIT_VALUE]
+end
+
 #! Sets an item in the account storage. Panics if the index is out of bounds.
 #!
 #! Inputs:  [index, VALUE]
@@ -356,6 +389,37 @@ export.set_map_item
     # clean the stack
     swapdw dropw dropw
     # => [OLD_MAP_ROOT, OLD_MAP_VALUE]
+end
+
+#! Gets a map item from the account storage at its initial state (beginning of transaction).
+#!
+#! Inputs:  [index, KEY]
+#! Outputs: [INIT_VALUE]
+#!
+#! Where:
+#! - index is the index of the map where the KEY VALUE should be read.
+#! - KEY is the key of the item to get.
+#! - INIT_VALUE is the initial value of the item at the beginning of the transaction.
+#!
+#! Panics if:
+#! - the index for the map is out of bounds, meaning > 255.
+#! - the slot item at index is not a map.
+#!
+#! Invocation: exec
+export.get_map_item_init
+    exec.kernel_proc_offsets::account_get_map_item_init_offset
+    # => [offset, index, KEY]
+
+    # pad the stack
+    push.0.0 movdn.7 movdn.7 padw padw swapdw
+    # => [offset, index, KEY, pad(10)]
+
+    syscall.exec_kernel_proc
+    # => [INIT_VALUE, pad(12)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw
+    # => [INIT_VALUE]
 end
 
 #! Gets the account code commitment of the current account.

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -23,11 +23,11 @@ const.ACCOUNT_GET_CODE_COMMITMENT_OFFSET=7
 const.ACCOUNT_GET_INITIAL_STORAGE_COMMITMENT_OFFSET=8
 const.ACCOUNT_COMPUTE_STORAGE_COMMITMENT_OFFSET=9
 const.ACCOUNT_GET_ITEM_OFFSET=10
-const.ACCOUNT_SET_ITEM_OFFSET=11
-const.ACCOUNT_GET_MAP_ITEM_OFFSET=12
-const.ACCOUNT_SET_MAP_ITEM_OFFSET=13
-const.ACCOUNT_GET_ITEM_INIT_OFFSET=14
-const.ACCOUNT_GET_MAP_ITEM_INIT_OFFSET=15
+const.ACCOUNT_GET_ITEM_INIT_OFFSET=11
+const.ACCOUNT_SET_ITEM_OFFSET=12
+const.ACCOUNT_GET_MAP_ITEM_OFFSET=13
+const.ACCOUNT_GET_MAP_ITEM_INIT_OFFSET=14
+const.ACCOUNT_SET_MAP_ITEM_OFFSET=15
 
 # Vault
 const.ACCOUNT_GET_INITIAL_VAULT_ROOT_OFFSET=16
@@ -44,7 +44,6 @@ const.ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET=22
 const.ACCOUNT_WAS_PROCEDURE_CALLED_OFFSET=23
 
 ### Faucet ######################################
-
 const.FAUCET_MINT_ASSET_OFFSET=24
 const.FAUCET_BURN_ASSET_OFFSET=25
 const.FAUCET_GET_TOTAL_FUNGIBLE_ASSET_ISSUANCE_OFFSET=26
@@ -101,7 +100,7 @@ const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=49      # mutator
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_get_initial_commitment` kernel procedure required to 
+#! - proc_offset is the offset of the `account_get_initial_commitment` kernel procedure required to
 #!   get the address where this procedure is stored.
 export.account_get_initial_commitment_offset
     push.ACCOUNT_GET_INITIAL_COMMITMENT_OFFSET
@@ -125,7 +124,7 @@ end
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_compute_delta_commitment` kernel procedure required 
+#! - proc_offset is the offset of the `account_compute_delta_commitment` kernel procedure required
 #!   to get the address where this procedure is stored.
 export.account_compute_delta_commitment_offset
     push.ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET
@@ -149,7 +148,7 @@ end
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_get_native_id` kernel procedure required to get the 
+#! - proc_offset is the offset of the `account_get_native_id` kernel procedure required to get the
 #!   address where this procedure is stored.
 export.account_get_native_id_offset
     push.ACCOUNT_GET_NATIVE_ID_OFFSET
@@ -209,7 +208,7 @@ end
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `account_get_initial_storage_commitment` kernel procedure 
+#! - proc_offset is the offset of the `account_get_initial_storage_commitment` kernel procedure
 #!   required to get the address where this procedure is stored.
 export.account_get_initial_storage_commitment_offset
     push.ACCOUNT_GET_INITIAL_STORAGE_COMMITMENT_OFFSET
@@ -539,7 +538,7 @@ end
 #! Outputs: [proc_offset]
 #!
 #! Where:
-#! - proc_offset is the offset of the `input_note_get_serial_number` kernel procedure required to 
+#! - proc_offset is the offset of the `input_note_get_serial_number` kernel procedure required to
 #!   get the address where this procedure is stored.
 export.input_note_get_serial_number_offset
     push.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET

--- a/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
+++ b/crates/miden-lib/asm/miden/kernel_proc_offsets.masm
@@ -26,67 +26,69 @@ const.ACCOUNT_GET_ITEM_OFFSET=10
 const.ACCOUNT_SET_ITEM_OFFSET=11
 const.ACCOUNT_GET_MAP_ITEM_OFFSET=12
 const.ACCOUNT_SET_MAP_ITEM_OFFSET=13
+const.ACCOUNT_GET_ITEM_INIT_OFFSET=14
+const.ACCOUNT_GET_MAP_ITEM_INIT_OFFSET=15
 
 # Vault
-const.ACCOUNT_GET_INITIAL_VAULT_ROOT_OFFSET=14
-const.ACCOUNT_GET_VAULT_ROOT_OFFSET=15
-const.ACCOUNT_ADD_ASSET_OFFSET=16
-const.ACCOUNT_REMOVE_ASSET_OFFSET=17
-const.ACCOUNT_GET_BALANCE_OFFSET=18
-const.ACCOUNT_HAS_NON_FUNGIBLE_ASSET_OFFSET=19
+const.ACCOUNT_GET_INITIAL_VAULT_ROOT_OFFSET=16
+const.ACCOUNT_GET_VAULT_ROOT_OFFSET=17
+const.ACCOUNT_ADD_ASSET_OFFSET=18
+const.ACCOUNT_REMOVE_ASSET_OFFSET=19
+const.ACCOUNT_GET_BALANCE_OFFSET=20
+const.ACCOUNT_HAS_NON_FUNGIBLE_ASSET_OFFSET=21
 
 # Delta
-const.ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET=20
+const.ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET=22
 
 # Procedure introspection
-const.ACCOUNT_WAS_PROCEDURE_CALLED_OFFSET=21
+const.ACCOUNT_WAS_PROCEDURE_CALLED_OFFSET=23
 
 ### Faucet ######################################
 
-const.FAUCET_MINT_ASSET_OFFSET=22
-const.FAUCET_BURN_ASSET_OFFSET=23
-const.FAUCET_GET_TOTAL_FUNGIBLE_ASSET_ISSUANCE_OFFSET=24
-const.FAUCET_IS_NON_FUNGIBLE_ASSET_ISSUED_OFFSET=25
+const.FAUCET_MINT_ASSET_OFFSET=24
+const.FAUCET_BURN_ASSET_OFFSET=25
+const.FAUCET_GET_TOTAL_FUNGIBLE_ASSET_ISSUANCE_OFFSET=26
+const.FAUCET_IS_NON_FUNGIBLE_ASSET_ISSUED_OFFSET=27
 
 ### Note ########################################
 
 # input notes
-const.INPUT_NOTE_GET_METADATA_OFFSET=26
-const.INPUT_NOTE_GET_ASSETS_INFO_OFFSET=27
-const.INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET=28
-const.INPUT_NOTE_GET_INPUTS_INFO_OFFSET=29
-const.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET=30
-const.INPUT_NOTE_GET_RECIPIENT_OFFSET=31
+const.INPUT_NOTE_GET_METADATA_OFFSET=28
+const.INPUT_NOTE_GET_ASSETS_INFO_OFFSET=29
+const.INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET=30
+const.INPUT_NOTE_GET_INPUTS_INFO_OFFSET=31
+const.INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET=32
+const.INPUT_NOTE_GET_RECIPIENT_OFFSET=33
 
 # output notes
-const.OUTPUT_NOTE_CREATE_OFFSET=32
-const.OUTPUT_NOTE_GET_METADATA_OFFSET=33
-const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=34
-const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=35
-const.OUTPUT_NOTE_ADD_ASSET_OFFSET=36
+const.OUTPUT_NOTE_CREATE_OFFSET=34
+const.OUTPUT_NOTE_GET_METADATA_OFFSET=35
+const.OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET=36
+const.OUTPUT_NOTE_GET_RECIPIENT_OFFSET=37
+const.OUTPUT_NOTE_ADD_ASSET_OFFSET=38
 
 ### Tx ##########################################
 
 # input notes
-const.TX_GET_NUM_INPUT_NOTES_OFFSET=37
-const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=38
+const.TX_GET_NUM_INPUT_NOTES_OFFSET=39
+const.TX_GET_INPUT_NOTES_COMMITMENT_OFFSET=40
 
 # output notes
-const.TX_GET_NUM_OUTPUT_NOTES_OFFSET=39
-const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=40
+const.TX_GET_NUM_OUTPUT_NOTES_OFFSET=41
+const.TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET=42
 
 # block info
-const.TX_GET_BLOCK_COMMITMENT_OFFSET=41
-const.TX_GET_BLOCK_NUMBER_OFFSET=42
-const.TX_GET_BLOCK_TIMESTAMP_OFFSET=43
+const.TX_GET_BLOCK_COMMITMENT_OFFSET=43
+const.TX_GET_BLOCK_NUMBER_OFFSET=44
+const.TX_GET_BLOCK_TIMESTAMP_OFFSET=45
 
 # foreign context
-const.TX_START_FOREIGN_CONTEXT_OFFSET=44
-const.TX_END_FOREIGN_CONTEXT_OFFSET=45
+const.TX_START_FOREIGN_CONTEXT_OFFSET=46
+const.TX_END_FOREIGN_CONTEXT_OFFSET=47
 
 # expiration data
-const.TX_GET_EXPIRATION_DELTA_OFFSET=46               # accessor
-const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=47      # mutator
+const.TX_GET_EXPIRATION_DELTA_OFFSET=48               # accessor
+const.TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=49      # mutator
 
 # ACCESSORS
 # -------------------------------------------------------------------------------------------------
@@ -271,6 +273,30 @@ end
 #!   address where this procedure is stored.
 export.account_set_map_item_offset
     push.ACCOUNT_SET_MAP_ITEM_OFFSET
+end
+
+#! Returns the offset of the `account_get_item_init` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `account_get_item_init` kernel procedure required to get the
+#!   address where this procedure is stored.
+export.account_get_item_init_offset
+    push.ACCOUNT_GET_ITEM_INIT_OFFSET
+end
+
+#! Returns the offset of the `account_get_map_item_init` kernel procedure.
+#!
+#! Inputs:  []
+#! Outputs: [proc_offset]
+#!
+#! Where:
+#! - proc_offset is the offset of the `account_get_map_item_init` kernel procedure required to get the
+#!   address where this procedure is stored.
+export.account_get_map_item_init_offset
+    push.ACCOUNT_GET_MAP_ITEM_INIT_OFFSET
 end
 
 #! Returns the offset of the `account_get_initial_vault_root` kernel procedure.

--- a/crates/miden-lib/src/testing/mock_account_code.rs
+++ b/crates/miden-lib/src/testing/mock_account_code.rs
@@ -52,6 +52,17 @@ const MOCK_ACCOUNT_CODE: &str = "
         # => [VALUE, pad(12)]
     end
 
+    # Stack:  [index, pad(15)]
+    # Output: [VALUE, pad(12)]
+    export.get_item_init
+        exec.account::get_item_init
+        # => [VALUE, pad(15)]
+
+        # truncate the stack
+        movup.8 drop movup.8 drop movup.8 drop
+        # => [VALUE, pad(12)]
+    end
+
     # Stack:  [index, KEY, VALUE, pad(7)]
     # Output: [OLD_MAP_ROOT, OLD_MAP_VALUE, pad(8)]
     export.set_map_item
@@ -63,6 +74,12 @@ const MOCK_ACCOUNT_CODE: &str = "
     # Output: [VALUE, pad(12)]
     export.get_map_item
         exec.account::get_map_item
+    end
+
+    # Stack:  [index, KEY, pad(11)]
+    # Output: [VALUE, pad(12)]
+    export.get_map_item_init
+        exec.account::get_map_item_init
     end
 
     # Stack:  [pad(16)]

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -6,7 +6,7 @@ use miden_objects::{Word, word};
 // ================================================================================================
 
 /// Hashes of all dynamically executed kernel procedures.
-pub const KERNEL_PROCEDURES: [Word; 48] = [
+pub const KERNEL_PROCEDURES: [Word; 50] = [
     // account_get_initial_commitment
     word!("0x920898348bacd6d98a399301eb308478fd32b32eab019a5a6ef7a6b44abb61f6"),
     // account_compute_current_commitment
@@ -35,6 +35,10 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     word!("0x061afed82416f597aa87e2de48d7dad96a40c5f3e2c839d6522bafd3646414ca"),
     // account_set_map_item
     word!("0xb539c160a862fedb3a4bd81bcea2076adc54c4e064a2c74b8770cef778ec5c59"),
+    // account_get_item_init
+    word!("0x46948d2c64c5b8979cbf1d628a90459b54b41491db5e0f1cff8747c9901da165"),
+    // account_get_map_item_init
+    word!("0x94a0f8e9752c98aaca97e2e5688de6144a0bb2cc2aadc7cee71618e32caba311"),
     // account_get_initial_vault_root
     word!("0x4d4d91079aaacad1bc86b29a0d61d25508ccb705c29d1b1357016f7373bf299e"),
     // account_get_vault_root

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -52,7 +52,7 @@ pub const KERNEL_PROCEDURES: [Word; 50] = [
     // account_has_non_fungible_asset
     word!("0x9c0f7851d3211ff4744393b673ce4e1aeb05525dc9186a218c8ff8d6f1a04ee7"),
     // account_compute_delta_commitment
-    word!("0x95dab713c8f9fe01a4c81d1fb57737ac6a45171659456dbc03df049654db3d78"),
+    word!("0xde5f39d0adeab125693186306de47ff7169f90f688df20afa98a90279551cf1f"),
     // account_was_procedure_called
     word!("0x84c8c518a005605619909976ce54c41d6a88505e815421ff4b5516d0285b28bf"),
     // faucet_mint_asset

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -32,13 +32,13 @@ pub const KERNEL_PROCEDURES: [Word; 50] = [
     // account_set_item
     word!("0xd2232daa3895669f2bb34af764504d72432fb119eb0be0ce07481290c8701af8"),
     // account_get_map_item
-    word!("0x061afed82416f597aa87e2de48d7dad96a40c5f3e2c839d6522bafd3646414ca"),
+    word!("0x95449dd3a32ca3e069acc132e8f44fa87679e2f373f4ca7ae1807246802c5d0d"),
     // account_set_map_item
     word!("0xb539c160a862fedb3a4bd81bcea2076adc54c4e064a2c74b8770cef778ec5c59"),
     // account_get_item_init
     word!("0x46948d2c64c5b8979cbf1d628a90459b54b41491db5e0f1cff8747c9901da165"),
     // account_get_map_item_init
-    word!("0x94a0f8e9752c98aaca97e2e5688de6144a0bb2cc2aadc7cee71618e32caba311"),
+    word!("0x2e84c009a58b5fda1547865090ac446294d4db20d0aefef3d9e4c6a1a93df8fd"),
     // account_get_initial_vault_root
     word!("0x4d4d91079aaacad1bc86b29a0d61d25508ccb705c29d1b1357016f7373bf299e"),
     // account_get_vault_root
@@ -62,7 +62,7 @@ pub const KERNEL_PROCEDURES: [Word; 50] = [
     // faucet_get_total_fungible_asset_issuance
     word!("0x7d32952d4dc0edd0311e3424b8128df2d48cf949f800c28218fbc851a8db42b5"),
     // faucet_is_non_fungible_asset_issued
-    word!("0xe0d7571e530b703ededf549f5ca8c57c5cffe0d1d9f59da20e5db05ca18de58b"),
+    word!("0xfe8db6e0903ad0d6a368cedd197f756ade6c17d275d131fc8e1a07f9cb96875e"),
     // input_note_get_metadata
     word!("0x7ad3e94585e7a397ee27443c98b376ed8d4ba762122af6413fde9314c00a6219"),
     // input_note_get_assets_info

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -29,16 +29,16 @@ pub const KERNEL_PROCEDURES: [Word; 50] = [
     word!("0x2e508f8505188ce9b6c46be727e2c1a237806a19402486e38105665b87191526"),
     // account_get_item
     word!("0x011e508cf9b261c33e5f3da1afbf23caefa1f6bc7eac9de2cd123c77fa74f02a"),
+    // account_get_item_init
+    word!("0x46948d2c64c5b8979cbf1d628a90459b54b41491db5e0f1cff8747c9901da165"),
     // account_set_item
     word!("0xd2232daa3895669f2bb34af764504d72432fb119eb0be0ce07481290c8701af8"),
     // account_get_map_item
     word!("0x95449dd3a32ca3e069acc132e8f44fa87679e2f373f4ca7ae1807246802c5d0d"),
-    // account_set_map_item
-    word!("0x33309593aa405279a27907cee07b0cde54dbf4c088d0995a05f61e60236cfb0f"),
-    // account_get_item_init
-    word!("0x46948d2c64c5b8979cbf1d628a90459b54b41491db5e0f1cff8747c9901da165"),
     // account_get_map_item_init
     word!("0x2e84c009a58b5fda1547865090ac446294d4db20d0aefef3d9e4c6a1a93df8fd"),
+    // account_set_map_item
+    word!("0x33309593aa405279a27907cee07b0cde54dbf4c088d0995a05f61e60236cfb0f"),
     // account_get_initial_vault_root
     word!("0x4d4d91079aaacad1bc86b29a0d61d25508ccb705c29d1b1357016f7373bf299e"),
     // account_get_vault_root

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -51,6 +51,7 @@ use crate::executor::CodeExecutor;
 use crate::{
     Auth,
     MockChain,
+    MockChainBuilder,
     TransactionContextBuilder,
     assert_execution_error,
     assert_transaction_executor_error,
@@ -1261,6 +1262,241 @@ fn incrementing_nonce_twice_fails() -> anyhow::Result<()> {
         .execute_blocking();
 
     assert_transaction_executor_error!(result, ERR_ACCOUNT_NONCE_CAN_ONLY_BE_INCREMENTED_ONCE);
+
+    Ok(())
+}
+
+// ACCOUNT INITIAL STORAGE TESTS
+// ================================================================================================
+
+#[test]
+fn test_get_item_init() -> miette::Result<()> {
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build().unwrap();
+
+    // Test that get_item_init returns the initial value before any changes
+    let code = format!(
+        "
+        use.$kernel::account
+        use.$kernel::prologue
+        use.mock::account->mock_account
+
+        begin
+            exec.prologue::prepare_transaction
+
+            # get initial value of storage slot 0
+            push.0
+            exec.account::get_item_init
+
+            push.{expected_initial_value}
+            assert_eqw.err=\"initial value should match expected\"
+
+            # modify the storage slot
+            push.9.10.11.12.0
+            call.mock_account::set_item dropw drop
+
+            # get_item should return the new value
+            push.0
+            exec.account::get_item
+            push.9.10.11.12
+            assert_eqw.err=\"current value should be updated\"
+
+            # get_item_init should still return the initial value
+            push.0
+            exec.account::get_item_init
+            push.{expected_initial_value}
+            assert_eqw.err=\"initial value should remain unchanged\"
+        end
+        ",
+        expected_initial_value = &AccountStorage::mock_item_0().slot.value(),
+    );
+
+    tx_context.execute_code(&code).unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn test_get_map_item_init() -> miette::Result<()> {
+    let account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(MockAccountComponent::with_slots(vec![AccountStorage::mock_item_2().slot]))
+        .build_existing()
+        .unwrap();
+
+    let tx_context = TransactionContextBuilder::new(account).build().unwrap();
+
+    // Use the first key-value pair from the mock storage
+    let (initial_key, initial_value) = STORAGE_LEAVES_2[0];
+    let new_key = Word::from([201, 202, 203, 204u32]);
+    let new_value = Word::from([301, 302, 303, 304u32]);
+
+    let code = format!(
+        "
+        use.$kernel::prologue
+        use.mock::account->mock_account
+
+        begin
+            exec.prologue::prepare_transaction
+
+            # get initial value from map
+            push.{initial_key}
+            push.0
+            call.mock_account::get_map_item_init
+            push.{initial_value}
+            assert_eqw.err=\"initial map value should match expected\"
+
+            # add a new key-value pair to the map
+            push.{new_value}
+            push.{new_key}
+            push.0
+            call.mock_account::set_map_item dropw dropw
+
+            # get_map_item should return the new value
+            push.{new_key}
+            push.0
+            call.mock_account::get_map_item
+            push.{new_value}
+            assert_eqw.err=\"current map value should be updated\"
+
+            # get_map_item_init should still return the initial value for the initial key
+            push.{initial_key}
+            push.0
+            call.mock_account::get_map_item_init
+            push.{initial_value}
+            assert_eqw.err=\"initial map value should remain unchanged\"
+
+            # get_map_item_init for the new key should return empty word (default)
+            push.{new_key}
+            push.0
+            call.mock_account::get_map_item_init
+            push.0.0.0.0
+            assert_eqw.err=\"new key should have empty initial value\"
+
+            dropw dropw
+        end
+        ",
+        initial_key = &initial_key,
+        initial_value = &initial_value,
+        new_key = &new_key,
+        new_value = &new_value,
+    );
+
+    tx_context.execute_code(&code).unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> miette::Result<()> {
+    let mut mock_chain = MockChain::builder();
+
+    // Create a native account and add it to the mock chain
+    let native_account = mock_chain
+        .add_existing_mock_account(Auth::IncrNonce)
+        .expect("failed to add native account");
+
+    mock_chain.build().expect("failed to build mock chain");
+
+    let (map_key, map_value) = STORAGE_LEAVES_2[0];
+
+    // Create foreign procedures that test get_item_init and get_map_item_init
+    let foreign_account_code_source = "
+        use.miden::account
+        use.std::sys
+
+
+        export.test_get_item_init
+            push.0
+            exec.account::get_item_init
+            exec.sys::truncate_stack
+        end
+
+        export.test_get_map_item_init
+            exec.account::get_map_item_init
+            exec.sys::truncate_stack
+        end
+    ";
+
+    let foreign_account_component = AccountComponent::compile(
+        foreign_account_code_source,
+        TransactionKernel::with_kernel_library(Arc::new(DefaultSourceManager::default())),
+        vec![AccountStorage::mock_item_0().slot, AccountStorage::mock_item_2().slot],
+    )
+    .unwrap()
+    .with_supports_all_types();
+
+    // Update the foreign account to use the new component
+    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(foreign_account_component.clone())
+        .build_existing()
+        .unwrap();
+
+    // Rebuild the mock chain with the updated foreign account
+    let mut mock_chain =
+        MockChainBuilder::with_accounts([native_account.clone(), foreign_account.clone()])
+            .unwrap()
+            .build()
+            .unwrap();
+    mock_chain.prove_next_block().unwrap();
+
+    let foreign_account_inputs = mock_chain
+        .get_foreign_account_inputs(foreign_account.id())
+        .expect("failed to get foreign account inputs");
+
+    let code = format!(
+        "
+        use.std::sys
+        use.miden::tx
+
+        begin
+
+            # Test get_item_init on foreign account
+            padw padw padw push.0.0
+            push.{test_get_item_init_hash}
+            push.{foreign_account_id_suffix}.{foreign_account_id_prefix}
+            exec.tx::execute_foreign_procedure
+            push.{expected_value_slot_0}
+            assert_eqw.err=\"foreign account get_item_init should work\"
+
+            # Test get_map_item_init on foreign account
+            padw padw push.0.0
+            push.{map_key}
+            push.1
+            push.{test_get_map_item_init_hash}
+            push.{foreign_account_id_suffix}.{foreign_account_id_prefix}
+            exec.tx::execute_foreign_procedure
+            push.{map_value}
+            assert_eqw.err=\"foreign account get_map_item_init should work\"
+
+            exec.sys::truncate_stack
+        end
+        ",
+        foreign_account_id_prefix = foreign_account.id().prefix().as_felt(),
+        foreign_account_id_suffix = foreign_account.id().suffix(),
+        expected_value_slot_0 = &AccountStorage::mock_item_0().slot.value(),
+        map_key = &map_key,
+        map_value = &map_value,
+        test_get_item_init_hash = foreign_account.code().procedures()[1].mast_root(),
+        test_get_map_item_init_hash = foreign_account.code().procedures()[2].mast_root(),
+    );
+
+    let tx_script = ScriptBuilder::with_mock_libraries()
+        .unwrap()
+        .with_dynamically_linked_library(foreign_account_component.library())
+        .unwrap()
+        .compile_tx_script(code)
+        .unwrap();
+
+    mock_chain
+        .build_tx_context(native_account.id(), &[], &[])
+        .expect("failed to build tx context")
+        .foreign_accounts(vec![foreign_account_inputs])
+        .tx_script(tx_script)
+        .build()
+        .unwrap()
+        .execute_blocking()
+        .unwrap();
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -1552,3 +1552,104 @@ fn foreign_account_data_memory_assertions(foreign_account: &Account, process: &P
         );
     }
 }
+
+/// Test that get_item_init and get_map_item_init work correctly with foreign accounts.
+#[test]
+fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> anyhow::Result<()> {
+    // Create a native account
+    let native_account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(MockAccountComponent::with_empty_slots())
+        .storage_mode(AccountStorageMode::Public)
+        .build_existing()?;
+
+    let (map_key, map_value) = STORAGE_LEAVES_2[0];
+
+    // Create foreign procedures that test get_item_init and get_map_item_init
+    let foreign_account_code_source = "
+        use.miden::account
+        use.std::sys
+
+
+        export.test_get_item_init
+            push.0
+            exec.account::get_item_init
+            exec.sys::truncate_stack
+        end
+
+        export.test_get_map_item_init
+            exec.account::get_map_item_init
+            exec.sys::truncate_stack
+        end
+    ";
+
+    let foreign_account_component = AccountComponent::compile(
+        NamedSource::new("foreign_account", foreign_account_code_source),
+        TransactionKernel::assembler(),
+        vec![AccountStorage::mock_item_0().slot, AccountStorage::mock_item_2().slot],
+    )?
+    .with_supports_all_types();
+
+    // Update the foreign account to use the new component
+    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(foreign_account_component.clone())
+        .build_existing()?;
+
+    // Rebuild the mock chain with the updated foreign account
+    let mut mock_chain =
+        MockChainBuilder::with_accounts([native_account.clone(), foreign_account.clone()])?
+            .build()?;
+    mock_chain.prove_next_block()?;
+
+    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
+
+    let code = format!(
+        "
+        use.std::sys
+        use.miden::tx
+
+        begin
+
+            # Test get_item_init on foreign account
+            padw padw padw push.0.0
+            push.0
+            procref.::foreign_account::test_get_item_init
+            push.{foreign_account_id_suffix}.{foreign_account_id_prefix}
+            exec.tx::execute_foreign_procedure
+            push.{expected_value_slot_0}
+            assert_eqw.err=\"foreign account get_item_init should work\"
+
+            # Test get_map_item_init on foreign account
+            padw padw push.0.0
+            push.{map_key}
+            push.1
+            procref.::foreign_account::test_get_map_item_init
+            push.{foreign_account_id_suffix}.{foreign_account_id_prefix}
+            exec.tx::execute_foreign_procedure
+            push.{map_value}
+            assert_eqw.err=\"foreign account get_map_item_init should work\"
+
+            exec.sys::truncate_stack
+        end
+        ",
+        foreign_account_id_prefix = foreign_account.id().prefix().as_felt(),
+        foreign_account_id_suffix = foreign_account.id().suffix(),
+        expected_value_slot_0 = &AccountStorage::mock_item_0().slot.value(),
+        map_key = &map_key,
+        map_value = &map_value,
+    );
+
+    let tx_script = ScriptBuilder::with_mock_libraries()?
+        .with_dynamically_linked_library(foreign_account_component.library())?
+        .compile_tx_script(code)?;
+
+    mock_chain
+        .build_tx_context(native_account.id(), &[], &[])?
+        .foreign_accounts(vec![foreign_account_inputs])
+        .tx_script(tx_script)
+        .build()?
+        .execute_blocking()?;
+
+    Ok(())
+}

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -1590,13 +1590,12 @@ fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> anyhow::Re
     )?
     .with_supports_all_types();
 
-    // Update the foreign account to use the new component
     let foreign_account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
-    // Rebuild the mock chain with the updated foreign account
+    // Create the mock chain with both accounts
     let mut mock_chain =
         MockChainBuilder::with_accounts([native_account.clone(), foreign_account.clone()])?
             .build()?;

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -36,10 +36,10 @@ Account procedures can be used to read and write to account storage, add or remo
 | `compute_current_commitment` | Computes and returns the account commitment from account data stored in memory.<br><br>Inputs: `[]`<br>Outputs: `[ACCOUNT_COMMITMENT]` | Any |
 | `compute_delta_commitment` | Computes the commitment to the native account's delta. Can only be called from auth procedures.<br><br>Inputs: `[]`<br>Outputs: `[DELTA_COMMITMENT]` | Auth |
 | `get_item` | Gets an item from the account storage.<br><br>Inputs: `[index]`<br>Outputs: `[VALUE]` | Account |
-| `get_item_init` | Gets an item from the account storage as it was at the beginning of the transaction.<br><br>Inputs: `[index]`<br>Outputs: `[VALUE]` | Account |
+| `get_item_init` | Gets the initial item from the account storage slot as it was at the beginning of the transaction.<br><br>Inputs: `[index]`<br>Outputs: `[VALUE]` | Account |
 | `set_item` | Sets an item in the account storage.<br><br>Inputs: `[index, VALUE]`<br>Outputs: `[OLD_VALUE]` | Native & Account |
 | `get_map_item` | Returns the VALUE located under the specified KEY within the map contained in the given account storage slot.<br><br>Inputs: `[index, KEY]`<br>Outputs: `[VALUE]` | Account |
-| `get_map_item_init` | Returns the VALUE located under the specified KEY within the map contained in the given account storage slot as it was at the beginning of the transaction.<br><br>Inputs: `[index, KEY]`<br>Outputs: `[VALUE]` | Account |
+| `get_map_item_init` | Gets the initial VALUE from the account storage map as it was at the beginning of the transaction.<br><br>Inputs: `[index, KEY]`<br>Outputs: `[VALUE]` | Account |
 | `set_map_item` | Sets VALUE under the specified KEY within the map contained in the given account storage slot.<br><br>Inputs: `[index, KEY, VALUE]`<br>Outputs: `[OLD_MAP_ROOT, OLD_MAP_VALUE]` | Native & Account |
 | `get_code_commitment` | Gets the account code commitment of the current account.<br><br>Inputs: `[]`<br>Outputs: `[CODE_COMMITMENT]` | Account |
 | `get_initial_storage_commitment` | Returns the storage commitment of the native account at the beginning of the transaction.<br><br>Inputs: `[]`<br>Outputs: `[INIT_STORAGE_COMMITMENT]` | Any |

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -36,8 +36,10 @@ Account procedures can be used to read and write to account storage, add or remo
 | `compute_current_commitment` | Computes and returns the account commitment from account data stored in memory.<br><br>Inputs: `[]`<br>Outputs: `[ACCOUNT_COMMITMENT]` | Any |
 | `compute_delta_commitment` | Computes the commitment to the native account's delta. Can only be called from auth procedures.<br><br>Inputs: `[]`<br>Outputs: `[DELTA_COMMITMENT]` | Auth |
 | `get_item` | Gets an item from the account storage.<br><br>Inputs: `[index]`<br>Outputs: `[VALUE]` | Account |
+| `get_item_init` | Gets an item from the account storage as it was at the beginning of the transaction.<br><br>Inputs: `[index]`<br>Outputs: `[VALUE]` | Account |
 | `set_item` | Sets an item in the account storage.<br><br>Inputs: `[index, VALUE]`<br>Outputs: `[OLD_VALUE]` | Native & Account |
 | `get_map_item` | Returns the VALUE located under the specified KEY within the map contained in the given account storage slot.<br><br>Inputs: `[index, KEY]`<br>Outputs: `[VALUE]` | Account |
+| `get_map_item_init` | Returns the VALUE located under the specified KEY within the map contained in the given account storage slot as it was at the beginning of the transaction.<br><br>Inputs: `[index, KEY]`<br>Outputs: `[VALUE]` | Account |
 | `set_map_item` | Sets VALUE under the specified KEY within the map contained in the given account storage slot.<br><br>Inputs: `[index, KEY, VALUE]`<br>Outputs: `[OLD_MAP_ROOT, OLD_MAP_VALUE]` | Native & Account |
 | `get_code_commitment` | Gets the account code commitment of the current account.<br><br>Inputs: `[]`<br>Outputs: `[CODE_COMMITMENT]` | Account |
 | `get_initial_storage_commitment` | Returns the storage commitment of the native account at the beginning of the transaction.<br><br>Inputs: `[]`<br>Outputs: `[INIT_STORAGE_COMMITMENT]` | Any |


### PR DESCRIPTION
This PR adds two new kernel procedures:

* `account::get_item_init`
* `account::get_map_item_init`

Additionally this PR adds three tests to test the functionality of the kernel procedures listed above.

Tests:
1. `test_get_item_init`: tests that `get_item_init` procedure returns the initial storage slot value.
2. `test_get_map_item_init`: tests that `get_map_item_init` procedure returns initial map values.
3. `test_get_item_init_and_get_map_item_init_with_foreign_account`: tests `get_item_init` & `get_map_item_init` in the contex of a FPI call. 

Resolves: #1880 