### PR TITLE
Replace word functionality with `std::word` procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [BREAKING] Move `TransactionKernelError` to miden-tx ([#1859](https://github.com/0xMiden/miden-base/pull/1859)).
 - Change terminology of "current note" to "active note" ([#1863](https://github.com/0xMiden/miden-base/issues/1863)).
 - [BREAKING] Move and rename `miden::tx::{add_asset_to_note, create_note}` procedures to `miden::output_note::{add_asset, create}` ([#1874](https://github.com/0xMiden/miden-base/pull/1874)).
-- Replace `eqw` usages with `exec.word::test_eq` and `exec.word::eq`, remove `is_key_greater` and `is_key_less` from `link_map` module ([#1897](https://github.com/0xMiden/miden-base/pull/1897))
+- Replace `eqw` usages with `exec.word::test_eq` and `exec.word::eq`, remove `is_key_greater` and `is_key_less` from `link_map` module ([#1897](https://github.com/0xMiden/miden-base/pull/1897)).
 
 ## 0.11.3 (2025-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [BREAKING] Move `TransactionKernelError` to miden-tx ([#1859](https://github.com/0xMiden/miden-base/pull/1859)).
 - Change terminology of "current note" to "active note" ([#1863](https://github.com/0xMiden/miden-base/issues/1863)).
 - [BREAKING] Move and rename `miden::tx::{add_asset_to_note, create_note}` procedures to `miden::output_note::{add_asset, create}` ([#1874](https://github.com/0xMiden/miden-base/pull/1874)).
+- Replace `eqw` usages with `exec.word::test_eq` and `exec.word::eq`, remove `is_key_greater` and `is_key_less` from `link_map` module ([#1897](https://github.com/0xMiden/miden-base/pull/1897))
 
 ## 0.11.3 (2025-09-15)
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/account_delta.masm
@@ -6,6 +6,7 @@ use.$kernel::asset
 use.$kernel::asset_vault
 use.std::crypto::hashes::rpo
 use.std::math::u64
+use.std::word
 
 # ERRORS
 # =================================================================================================
@@ -176,7 +177,7 @@ proc.update_value_slot_delta
     dup.4 exec.get_item_initial
     # => [INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
-    eqw not
+    exec.word::test_eq not
     # => [was_changed, INIT_VALUE, CURRENT_VALUE, slot_idx, RATE, RATE, PERM]
 
     # only include in delta if the slot's value has changed
@@ -252,7 +253,7 @@ proc.update_map_slot_delta.4
         swapw.2
         # => [NEW_VALUE, INIT_VALUE, KEY, ...]
 
-        eqw not
+        exec.word::test_eq not
         # => [was_changed, NEW_VALUE, INIT_VALUE, KEY, ...]
 
         # if the key-value pair has actually changed, update the hasher

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -1,4 +1,5 @@
 use.std::collections::smt
+use.std::word
 
 use.$kernel::account_id
 use.$kernel::asset
@@ -154,11 +155,7 @@ export.has_non_fungible_asset
     # => [ASSET]
 
     # compare with EMPTY_WORD to assess if the asset exists in the vault
-    padw eqw not
-    # => [has_asset, PAD, ASSET]
-
-    # organize the stack for return
-    movdn.4 dropw movdn.4 dropw
+    exec.word::eqz not
     # => [has_asset]
 end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/link_map.masm
@@ -1,4 +1,5 @@
 use.std::collections::smt
+use.std::word
 use.$kernel::memory
 
 # A link map is a map data structure based on a sorted linked list.
@@ -835,11 +836,10 @@ end
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
 proc.assert_key_is_greater
-    exec.get_key swapw
-    # => [KEY, ENTRY_KEY]
+    exec.get_key
+    # => [ENTRY_KEY, KEY]
 
-    exec.is_key_greater assert.err=ERR_LINK_MAP_PROVIDED_KEY_NOT_GREATER_THAN_ENTRY_KEY
-    # => []
+    exec.word::gt assert.err=ERR_LINK_MAP_PROVIDED_KEY_NOT_GREATER_THAN_ENTRY_KEY
 end
 
 #! Asserts that the KEY is less than the key in the entry pointer.
@@ -847,10 +847,10 @@ end
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
 proc.assert_key_is_less
-    exec.get_key swapw
-    # => [KEY, ENTRY_KEY]
+    exec.get_key
+    # => [ENTRY_KEY, KEY]
 
-    exec.is_key_less assert.err=ERR_LINK_MAP_PROVIDED_KEY_NOT_LESS_THAN_ENTRY_KEY
+    exec.word::lt assert.err=ERR_LINK_MAP_PROVIDED_KEY_NOT_LESS_THAN_ENTRY_KEY
     # => []
 end
 
@@ -924,144 +924,4 @@ export.assert_entry_ptr_is_valid
 
     # this assertion is always true if is_empty_map is true
     or assert.err=ERR_LINK_MAP_MAP_PTR_IN_ENTRY_DOES_NOT_MATCH_EXPECTED_MAP_PTR
-end
-
-# COMPARISON OPERATIONS
-# -------------------------------------------------------------------------------------------------
-
-#! Returns true if KEY1 is strictly greater than KEY2, false otherwise.
-#!
-#! The implementation avoids branching for performance reasons.
-#! The procedure is exported for testing purposes only.
-#!
-#! For reference, this is equivalent to the following Rust function:
-#!
-#! fn is_key_greater(key1: Word, key2: Word) -> bool {
-#!     let mut result = false;
-#!     let mut cont = true;
-#!
-#!     for i in (0..4).rev() {
-#!         let gt = key1[i].as_int() > key2[i].as_int();
-#!         let eq = key1[i].as_int() == key2[i].as_int();
-#!         result |= gt & cont;
-#!         cont &= eq;
-#!     }
-#!
-#!     result
-#! }
-#!
-#! Inputs:  [KEY1, KEY2]
-#! Outputs: [is_key_greater]
-export.is_key_greater
-    exec.arrange_words_adjacent
-    # => [2_3, 1_3, 2_2, 1_2, 2_1, 1_1, 2_0, 1_0]
-
-    push.1.0
-    # => [is_key_greater, continue, 2_3, 1_3, 2_2, 1_2, 2_1, 1_1, 2_0, 1_0]
-
-    repeat.4
-        movup.3 movup.3
-        # => [2_x, 1_x, is_key_greater, continue, <remaining_felts>]
-
-        # check 1_x == 2_x; if so, we continue
-        dup dup.2 eq
-        # => [is_felt_eq, 2_x, 1_x, is_key_greater, continue, <remaining_felts>]
-
-        movdn.3
-        # => [2_x, 1_x, is_key_greater, is_felt_eq, continue, <remaining_felts>]
-
-        # check 1_x > 2_x
-        gt
-        # => [is_felt_gt, is_key_greater, is_felt_eq, continue, <remaining_felts>]
-
-        dup.3 and
-        # => [is_felt_gt_if_continue, is_key_greater, is_felt_eq, continue, <remaining_felts>]
-
-        or movdn.2
-        # => [is_felt_eq, continue, is_key_greater, <remaining_felts>]
-
-        # keeps continue at 1 if the felts are equal
-        # sets continue to 0 if the felts are not equal
-        and
-        # => [continue, is_key_greater, <remaining_felts>]
-
-        swap
-        # => [is_key_greater, continue, <remaining_felts>]
-    end
-    # => [is_key_greater, continue]
-
-    swap drop
-    # => [is_key_greater]
-end
-
-#! Returns true if KEY1 is strictly less than KEY2, false otherwise.
-#!
-#! The implementation avoids branching for performance reasons.
-#! The procedure is exported for testing purposes only.
-#!
-#! From an implementation standpoint this is exactly the same as `is_key_greater` except it uses
-#! `lt` rather than `gt`. See its docs for details.
-#!
-#! Inputs:  [KEY1, KEY2]
-#! Outputs: [is_key_less]
-export.is_key_less
-    exec.arrange_words_adjacent
-    # => [2_3, 1_3, 2_2, 1_2, 2_1, 1_1, 2_0, 1_0]
-
-    push.1.0
-    # => [is_key_less, continue, 2_3, 1_3, 2_2, 1_2, 2_1, 1_1, 2_0, 1_0]
-
-    repeat.4
-        movup.3 movup.3
-        # => [2_x, 1_x, is_key_less, continue, <remaining_felts>]
-
-        # check 1_x == 2_x; if so, we continue
-        dup dup.2 eq
-        # => [is_felt_eq, 2_x, 1_x, is_key_less, continue, <remaining_felts>]
-
-        movdn.3
-        # => [2_x, 1_x, is_key_less, is_felt_eq, continue, <remaining_felts>]
-
-        # check 1_x < 2_x
-        lt
-        # => [is_felt_lt, is_key_less, is_felt_eq, continue, <remaining_felts>]
-
-        dup.3 and
-        # => [is_felt_lt_if_continue, is_key_less, is_felt_eq, continue, <remaining_felts>]
-
-        or movdn.2
-        # => [is_felt_eq, continue, is_key_less, <remaining_felts>]
-
-        # keeps continue at 1 if the felts are equal
-        # sets continue to 0 if the felts are not equal
-        and
-        # => [continue, is_key_less, <remaining_felts>]
-
-        swap
-        # => [is_key_less, continue, <remaining_felts>]
-    end
-    # => [is_key_less, continue]
-
-    swap drop
-    # => [is_key_less]
-end
-
-#! Arranges the given words such that the corresponding elements are next to each other.
-#!
-#! Inputs:  [KEY1, KEY2]
-#! Outputs: [key2_3, key1_3, key2_2, key1_2, key2_1, key1_1, key2_0, key1_0]
-proc.arrange_words_adjacent
-    # => [1_3, 1_2, 1_1, 1_0, 2_3, 2_2, 2_1, 2_0]
-
-    movup.3 movup.7
-    # => [2_0, 1_0, 1_3, 1_2, 1_1, 2_3, 2_2, 2_1]
-
-    movup.4 movup.7
-    # => [2_1, 1_1, 2_0, 1_0, 1_3, 1_2, 2_3, 2_2]
-
-    movup.5 movup.7
-    # => [2_2, 1_2, 2_1, 1_1, 2_0, 1_0, 1_3, 2_3]
-
-    movup.6 movup.7
-    # => [2_3, 1_3, 2_2, 1_2, 2_1, 1_1, 2_0, 1_0]
 end

--- a/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/output_note.masm
@@ -3,6 +3,7 @@ use.$kernel::memory
 use.$kernel::note
 use.$kernel::asset
 use.$kernel::constants
+use.std::word
 
 # CONSTANTS
 # =================================================================================================
@@ -499,7 +500,8 @@ proc.add_non_fungible_asset
 
     while.true
         # load the asset and compare
-        mem_loadw eqw assertz.err=ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS
+        mem_loadw exec.word::test_eq
+        assertz.err=ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS
         # => [ASSET', ASSET, end_asset_ptr, asset_ptr, note_ptr, num_of_assets, note_idx]
 
         # drop ASSET' and increment the asset pointer

--- a/crates/miden-lib/src/transaction/kernel_procedures.rs
+++ b/crates/miden-lib/src/transaction/kernel_procedures.rs
@@ -34,27 +34,27 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     // account_get_map_item
     word!("0x061afed82416f597aa87e2de48d7dad96a40c5f3e2c839d6522bafd3646414ca"),
     // account_set_map_item
-    word!("0xb539c160a862fedb3a4bd81bcea2076adc54c4e064a2c74b8770cef778ec5c59"),
+    word!("0x33309593aa405279a27907cee07b0cde54dbf4c088d0995a05f61e60236cfb0f"),
     // account_get_initial_vault_root
     word!("0x4d4d91079aaacad1bc86b29a0d61d25508ccb705c29d1b1357016f7373bf299e"),
     // account_get_vault_root
     word!("0x42a2bfb8eac4fce9bbf75ea15215b00729faeeaf7fff784692948d3f618a9bb7"),
     // account_add_asset
-    word!("0x9a96c031f9ca6d839acc5ce6aa01b63ddba91fe312ea824ccd224c365cc1327d"),
+    word!("0x8e7c972f1eaa807de54df810f851db14557bb88c846c7bcb3d21340f34834c57"),
     // account_remove_asset
-    word!("0x8372d56ed394254481026d264b8ea97c2342ba42db21c61b2e96c6bf06d950a9"),
+    word!("0xc5ac5f912281dca3f8f778e713f564f71695af68d094937072a303ea0d8385c0"),
     // account_get_balance
     word!("0xb4e92ae0196ca128a451e40dd8a5ff56c13919efa67f63dca488214fbba3ffbc"),
     // account_has_non_fungible_asset
-    word!("0x9c0f7851d3211ff4744393b673ce4e1aeb05525dc9186a218c8ff8d6f1a04ee7"),
+    word!("0x62776e8641d241f404724cf115c416e4918b75ced3625a5cd21d487fd7aef68b"),
     // account_compute_delta_commitment
-    word!("0x95dab713c8f9fe01a4c81d1fb57737ac6a45171659456dbc03df049654db3d78"),
+    word!("0x01cf0da392179c475c4ffdca0f0114932e09b75189433969debe1895881bf8b0"),
     // account_was_procedure_called
     word!("0x84c8c518a005605619909976ce54c41d6a88505e815421ff4b5516d0285b28bf"),
     // faucet_mint_asset
-    word!("0x80876450b0bcff4534e17cd850c75bcfdff4cc0b00703465f713d350001cce79"),
+    word!("0xbdd92de4f1308992f95c45de90a79799ff96439494088d715bd7838880625433"),
     // faucet_burn_asset
-    word!("0xa78c7ae04e75f6e447fa72df757dfb0854a3236b86ece2b5478a757b3c156ad5"),
+    word!("0x17b95ae638852d24116254223385d5c627820000880b7f60f39c5b3cb5e5231e"),
     // faucet_get_total_fungible_asset_issuance
     word!("0x7d32952d4dc0edd0311e3424b8128df2d48cf949f800c28218fbc851a8db42b5"),
     // faucet_is_non_fungible_asset_issued
@@ -80,7 +80,7 @@ pub const KERNEL_PROCEDURES: [Word; 48] = [
     // output_note_get_recipient
     word!("0xc824115ed79a2e1670daed8c18fba1bc15f54c5ec0ec6699de69a00b21d9df92"),
     // output_note_add_asset
-    word!("0x47673b932aac8c186cb0979bbc3c4c2afa00fa1b80c0afb5e5efb4924bba48d9"),
+    word!("0xb40136c331981a3aff1cc2879e394517abef86a75e4ee5180161976ac360f43d"),
     // tx_get_num_input_notes
     word!("0xfcc186d4b65c584f3126dda1460b01eef977efd76f9e36f972554af28e33c685"),
     // tx_get_input_notes_commitment

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -72,6 +72,8 @@ pub fn compute_current_commitment() -> miette::Result<()> {
 
     let tx_script = format!(
         r#"
+        use.std::word
+
         use.miden::prologue
         use.miden::account
         use.mock::account->mock_account
@@ -115,10 +117,10 @@ pub fn compute_current_commitment() -> miette::Result<()> {
             swapdw dropw dropw swapw dropw
             # => [STORAGE_COMMITMENT1, STORAGE_COMMITMENT0]
 
-            eqw not assert.err="storage commitment should have been updated by compute_current_commitment"
-            # => [STORAGE_COMMITMENT1, STORAGE_COMMITMENT0]
-
-            dropw dropw dropw dropw
+            # assert that the commitment has changed
+            exec.word::eq 
+            assertz.err="storage commitment should have been updated by compute_current_commitment"
+            # => []
         end
     "#,
         key = &key,
@@ -609,6 +611,7 @@ fn test_account_component_storage_offset() -> miette::Result<()> {
     // We will then assert that we are able to retrieve the correct elements from storage
     // insuring consistent "set" and "get" using offsets.
     let source_code_component1 = "
+        use.std::word
         use.miden::account
 
         export.foo_write
@@ -621,13 +624,14 @@ fn test_account_component_storage_offset() -> miette::Result<()> {
         export.foo_read
             push.0
             exec.account::get_item
-            push.1.2.3.4 eqw assert
-
-            dropw dropw
+            push.1.2.3.4 
+            
+            exec.word::eq assert
         end
     ";
 
     let source_code_component2 = "
+        use.std::word
         use.miden::account
 
         export.bar_write
@@ -640,9 +644,9 @@ fn test_account_component_storage_offset() -> miette::Result<()> {
         export.bar_read
             push.0
             exec.account::get_item
-            push.5.6.7.8 eqw assert
-
-            dropw dropw
+            push.5.6.7.8 
+            
+            exec.word::eq assert
         end
     ";
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -535,6 +535,7 @@ fn test_epilogue_empty_transaction_with_empty_output_note() -> anyhow::Result<()
     // create an empty output note in the transaction script
     let tx_script_source = format!(
         r#"
+        use.std::word
         use.miden::output_note
         use.$kernel::prologue
         use.$kernel::epilogue
@@ -562,10 +563,12 @@ fn test_epilogue_empty_transaction_with_empty_output_note() -> anyhow::Result<()
             # make sure that output note was created: compare the output note hash with an empty
             # word
             exec.note::compute_output_notes_commitment
-            padw eqw assertz.err="output note was created, but the output notes hash remains to be zeros"
+            exec.word::eqz assertz.err="output note was created, but the output notes hash remains to be zeros"
+            # => [note_idx, GARBAGE(15)]
 
             # clean the stack
             dropw dropw dropw dropw
+            # => []
 
             exec.epilogue::finalize_transaction
         end


### PR DESCRIPTION
This PR replaces all usages of `eqw` instruction with `exec.word::test_eq` or `exec.word::eq` procedure execution. 
It also removes `is_key_greater` and `is_key_less` helper procedures from the `link_map` kernel module, replacing their usages with the `exec.word::gt` and `exec.word::lt` procedure executions.

Closes: #1658.