### PR TITLE
Auth considerated consumption checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.5 ()
+## 0.11.5 (2025-10-01)
 
 - Add new `can_consume` method to the `NoteConsumptionChecker` ([#1928](https://github.com/0xMiden/miden-base/pull/1928)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.5 ()
+
+- Add new `can_consume` method to the `NoteConsumptionChecker` ([#1928](https://github.com/0xMiden/miden-base/pull/1928)).
+
 ## 0.11.4 (2025-09-17)
 
 - Updated `miden-vm` dependencies to `0.17.2` patch version. ([#1905](https://github.com/0xMiden/miden-base/pull/1905))

--- a/crates/miden-lib/asm/account_components/multisig_rpo_falcon_512.masm
+++ b/crates/miden-lib/asm/account_components/multisig_rpo_falcon_512.masm
@@ -9,9 +9,6 @@ use.miden::tx
 
 # Auth Request Constants
 
-# The event to request an authentication signature.
-const.AUTH_REQUEST=131087
-
 # The event emitted when a signature is not found for a required signer.
 const.UNAUTHORIZED_EVENT=131102
 

--- a/crates/miden-lib/asm/miden/auth/rpo_falcon512.masm
+++ b/crates/miden-lib/asm/miden/auth/rpo_falcon512.masm
@@ -9,9 +9,6 @@ use.std::crypto::dsa::rpo_falcon512
 # The event to request an authentication signature.
 const.AUTH_REQUEST=131087
 
-# The event emitted when a signature is not found for a required signer.
-const.UNAUTHORIZED_EVENT=131102
-
 # The slot in this component's storage layout where the public key is stored.
 const.PUBLIC_KEY_SLOT=0
 
@@ -74,8 +71,8 @@ end
 
 #! Verify signatures for all required signers in a loop.
 #!
-#! This procedure iterates through the required number of signers, fetches their public keys
-#! from the provided account storage map slot, verifies their signatures against the transaction message,
+#! This procedure iterates through the required number of signers, fetches their public keys from
+#! the provided account storage map slot, verifies their signatures against the transaction message,
 #! and returns the number of successfully verified signatures.
 #!
 #! Inputs:  [pub_key_slot_idx, num_of_approvers, MSG]

--- a/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
@@ -3,7 +3,6 @@ use core::slice;
 use assert_matches::assert_matches;
 use miden_lib::testing::account_component::MockAccountComponent;
 use miden_lib::testing::note::NoteBuilder;
-use miden_lib::transaction::TransactionKernelError;
 use miden_lib::utils::ScriptBuilder;
 use miden_objects::account::{
     AccountBuilder,
@@ -16,7 +15,6 @@ use miden_objects::account::{
 use miden_objects::testing::account_id::ACCOUNT_ID_SENDER;
 use miden_objects::transaction::OutputNote;
 use miden_objects::{Felt, FieldElement, Word};
-use miden_processor::ExecutionError;
 use miden_testing::{Auth, MockChain};
 use miden_tx::TransactionExecutorError;
 
@@ -164,14 +162,7 @@ fn test_rpo_falcon_acl() -> anyhow::Result<()> {
 
     let executed_tx_no_auth = tx_context_no_auth.execute_blocking();
 
-    assert_matches!(executed_tx_no_auth, Err(TransactionExecutorError::TransactionProgramExecutionFailed(
-        execution_error
-    )) => {
-        assert_matches!(execution_error, ExecutionError::EventError { error, .. } => {
-            let kernel_error = error.downcast_ref::<TransactionKernelError>().unwrap();
-            assert_matches!(kernel_error, TransactionKernelError::MissingAuthenticator);
-        })
-    });
+    assert_matches!(executed_tx_no_auth, Err(TransactionExecutorError::MissingAuthenticator));
 
     // Test 4: Transaction WITHOUT authenticator calling non-trigger procedure (should succeed)
     let tx_context_no_trigger = mock_chain
@@ -256,14 +247,7 @@ fn test_rpo_falcon_acl_with_disallow_unauthorized_input_notes() -> anyhow::Resul
 
     // This should fail with MissingAuthenticator error because input notes are being consumed
     // and allow_unauthorized_input_notes is false
-    assert_matches!(executed_tx_no_auth, Err(TransactionExecutorError::TransactionProgramExecutionFailed(
-        execution_error
-    )) => {
-        assert_matches!(execution_error, ExecutionError::EventError { error, .. } => {
-            let kernel_error = error.downcast_ref::<TransactionKernelError>().unwrap();
-            assert_matches!(kernel_error, TransactionKernelError::MissingAuthenticator);
-        })
-    });
+    assert_matches!(executed_tx_no_auth, Err(TransactionExecutorError::MissingAuthenticator));
 
     Ok(())
 }

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -35,7 +35,12 @@ mod data_store;
 pub use data_store::DataStore;
 
 mod notes_checker;
-pub use notes_checker::{FailedNote, NoteConsumptionChecker, NoteConsumptionInfo};
+pub use notes_checker::{
+    FailedNote,
+    NoteConsumptionChecker,
+    NoteConsumptionInfo,
+    NoteConsumptionStatus,
+};
 
 // TRANSACTION EXECUTOR
 // ================================================================================================
@@ -456,6 +461,9 @@ fn map_execution_error(exec_err: ExecutionError) -> TransactionExecutorError {
                         account_balance: *account_balance,
                         tx_fee: *tx_fee,
                     }
+                },
+                Some(TransactionKernelError::MissingAuthenticator) => {
+                    TransactionExecutorError::MissingAuthenticator
                 },
                 _ => TransactionExecutorError::TransactionProgramExecutionFailed(exec_err),
             }

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -10,6 +10,8 @@ use miden_processor::fast::FastProcessor;
 
 use super::TransactionExecutor;
 use crate::auth::TransactionAuthenticator;
+use crate::errors::TransactionCheckerError;
+use crate::executor::map_execution_error;
 use crate::{DataStore, NoteCheckerError, TransactionExecutorError};
 
 // NOTE CONSUMPTION INFO
@@ -108,6 +110,61 @@ where
             .await
     }
 
+    /// Checks whether the provided input note could be consumed by the provided account by
+    /// executing a transaction at the specified block height.
+    ///
+    /// This function takes into account the possibility that the signatures may not be loaded into
+    /// the transaction context and returns the [`NoteConsumptionStatus`] result accordingly.
+    ///
+    /// This function first applies the static analysis of the provided note, and if it doesn't
+    /// reveal any errors next it tries to execute the transaction. Based on the execution result,
+    /// it either returns a [`NoteCheckerError`] or the [`NoteConsumptionStatus`]: depending on
+    /// whether the execution succeeded, failed in the prologue, during the note execution process
+    /// or in the epilogue.
+    pub async fn can_consume(
+        &self,
+        account_id: AccountId,
+        block_ref: BlockNumber,
+        note: InputNote,
+        tx_args: TransactionArgs,
+    ) -> Result<NoteConsumptionStatus, NoteCheckerError> {
+        // TODO: apply the static analysis before executing the tx
+
+        // try to consume the provided note
+        match self
+            .try_execute_notes(
+                account_id,
+                block_ref,
+                InputNotes::new_unchecked(vec![note]),
+                &tx_args,
+            )
+            .await
+        {
+            // execution succeeded
+            Ok(()) => Ok(NoteConsumptionStatus::Consumable),
+            Err(tx_checker_error) => {
+                match tx_checker_error {
+                    // execution failed on the preparation stage, before we actually executed the tx
+                    TransactionCheckerError::TransactionPreparation(e) => {
+                        Err(NoteCheckerError::TransactionPreparation(e))
+                    },
+                    // execution failed during the prologue
+                    TransactionCheckerError::PrologueExecution(e) => {
+                        Err(NoteCheckerError::PrologueExecution(e))
+                    },
+                    // execution failed during the note processing
+                    TransactionCheckerError::NoteExecution { .. } => {
+                        Ok(NoteConsumptionStatus::Unconsumable)
+                    },
+                    // execution failed during the epilogue
+                    TransactionCheckerError::EpilogueExecution(epilogue_error) => {
+                        Ok(handle_epilogue_error(epilogue_error))
+                    },
+                }
+            },
+        }
+    }
+
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
 
@@ -145,7 +202,7 @@ where
                         candidate_notes.into_iter().map(InputNote::into_note).collect::<Vec<_>>();
                     return Ok(NoteConsumptionInfo::new(successful, failed_notes));
                 },
-                Err(NoteCheckerError::NoteExecutionFailed { failed_note_index, error }) => {
+                Err(TransactionCheckerError::NoteExecution { failed_note_index, error }) => {
                     // SAFETY: Failed note index is in bounds of the candidate notes.
                     let failed_note = candidate_notes.remove(failed_note_index).into_note();
                     failed_notes.push(FailedNote::new(failed_note, Some(error)));
@@ -156,7 +213,7 @@ where
                     }
                     // Continue and process the next set of candidates.
                 },
-                Err(NoteCheckerError::EpilogueExecutionFailed(_)) => {
+                Err(TransactionCheckerError::EpilogueExecution(_)) => {
                     let consumption_info = self
                         .find_largest_executable_combination(
                             target_account_id,
@@ -168,7 +225,12 @@ where
                         .await;
                     return Ok(consumption_info);
                 },
-                Err(error) => return Err(error),
+                Err(TransactionCheckerError::PrologueExecution(err)) => {
+                    return Err(NoteCheckerError::PrologueExecution(err));
+                },
+                Err(TransactionCheckerError::TransactionPreparation(err)) => {
+                    return Err(NoteCheckerError::TransactionPreparation(err));
+                },
             }
         }
     }
@@ -250,7 +312,7 @@ where
         block_ref: BlockNumber,
         notes: InputNotes<InputNote>,
         tx_args: &TransactionArgs,
-    ) -> Result<(), NoteCheckerError> {
+    ) -> Result<(), TransactionCheckerError> {
         if notes.is_empty() {
             return Ok(());
         }
@@ -264,14 +326,14 @@ where
             .0
             .prepare_transaction(account_id, block_ref, notes, tx_args, None)
             .await
-            .map_err(NoteCheckerError::TransactionPreparationFailed)?;
+            .map_err(TransactionCheckerError::TransactionPreparation)?;
 
         let processor =
             FastProcessor::new_with_advice_inputs(stack_inputs.as_slice(), advice_inputs);
         let result = processor
             .execute(&TransactionKernel::main(), &mut host)
             .await
-            .map_err(TransactionExecutorError::TransactionProgramExecutionFailed);
+            .map_err(map_execution_error);
 
         match result {
             Ok(_) => Ok(()),
@@ -281,7 +343,7 @@ where
                 // Empty notes vector means that we didn't process the notes, so an error
                 // occurred.
                 if notes.is_empty() {
-                    return Err(NoteCheckerError::PrologueExecutionFailed(error));
+                    return Err(TransactionCheckerError::PrologueExecution(error));
                 }
 
                 let ((_, last_note_interval), success_notes) =
@@ -290,13 +352,60 @@ where
                 // If the interval end of the last note is specified, then an error occurred after
                 // notes processing.
                 if last_note_interval.end().is_some() {
-                    Err(NoteCheckerError::EpilogueExecutionFailed(error))
+                    Err(TransactionCheckerError::EpilogueExecution(error))
                 } else {
                     // Return the index of the failed note.
                     let failed_note_index = success_notes.len();
-                    Err(NoteCheckerError::NoteExecutionFailed { failed_note_index, error })
+                    Err(TransactionCheckerError::NoteExecution { failed_note_index, error })
                 }
             },
         }
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Handle the epilogue error during the note consumption check in the `can_consume` method.
+///
+/// The goal of this helper function is to handle the cases where the account couldn't consume the
+/// note because of some epilogue check failure, e.g. absence of the authenticator.
+fn handle_epilogue_error(epilogue_error: TransactionExecutorError) -> NoteConsumptionStatus {
+    match epilogue_error {
+        // `Unauthorized` is returned for the multisig accounts if the transaction doesn't have
+        // enough signatures.
+        TransactionExecutorError::Unauthorized(_)
+        // `MissingAuthenticator` is returned for the account with the basic auth if the
+        // authenticator was not provided to the executor (UnreachableAuth).
+        | TransactionExecutorError::MissingAuthenticator => {
+            // Both these cases signal that there is a probability that the provided note could be
+            // consumed if the authentication is provided.
+            NoteConsumptionStatus::UnconsumableWithoutAuthorization
+        },
+        // TODO: apply additional checks to get the verbose error reason
+        _ => NoteConsumptionStatus::Unconsumable,
+    }
+}
+
+// HELPER STRUCTURES
+// ================================================================================================
+
+/// Describes if a note could be consumed under a specific conditions: target account state
+/// and block height.
+///
+/// The status does not account for any authorization that may be required to consume the
+/// note, nor does it indicate whether the account has sufficient fees to consume it.
+#[derive(Debug, PartialEq)]
+pub enum NoteConsumptionStatus {
+    /// The note can be consumed by the account at the specified block height.
+    Consumable,
+    /// The note can be consumed by the account after the required block height is achieved.
+    ConsumableAfter(BlockNumber),
+    /// The note cannot be consumed by the account without the authorization.
+    UnconsumableWithoutAuthorization,
+    /// The note cannot be consumed by the account at the specified conditions (i.e., block
+    /// height and account state).    
+    Unconsumable,
+    /// The note cannot be consumed by the specified account under any conditions.
+    Incompatible,
 }

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -16,6 +16,7 @@ pub use executor::{
     MastForestStore,
     NoteConsumptionChecker,
     NoteConsumptionInfo,
+    NoteConsumptionStatus,
     TransactionExecutor,
     TransactionExecutorHost,
 };


### PR DESCRIPTION
This PR adds a new `check_note_consumability_without_signatures` method to the `NoteConsumptionChecker`, which checks whether the provided note could be consumed by the provided account by executing the transaction.

This method then checks the result of the transaction: it's capable of determine whether the transaction failed because of the authorization error.

TODO list for the follow up PRs:
- Add static checks for the well-known notes.
- Add more granularity to the handling of the errors which were raised from the epilogue (handle the insufficient fee case and so on).

Closes: #1881 