### PR TITLE
chore: align AccountCode Eq with Ord by comparing commitment only

### DIFF
--- a/crates/miden-objects/src/account/code/mod.rs
+++ b/crates/miden-objects/src/account/code/mod.rs
@@ -235,8 +235,9 @@ impl AccountCode {
 
 impl PartialEq for AccountCode {
     fn eq(&self, other: &Self) -> bool {
-        // TODO: consider checking equality based only on the set of procedures
-        self.mast == other.mast && self.procedures == other.procedures
+        // Equality is defined by the code commitment to ensure consistency with Ord
+        // and with how AccountCode is identified across the codebase.
+        self.commitment == other.commitment
     }
 }
 


### PR DESCRIPTION
- Switch PartialEq/Eq for AccountCode to compare only the code commitment.
- Keeps Ord unchanged (ordering by commitment), restoring Eq/Ord consistency.
- Commitment is the canonical identity across the codebase (used as map keys/indexes), so equality by commitment reflects real-world usage.
- Avoids expensive or brittle structural comparisons (MastForest/procedures) and eliminates the risk of cmp == Equal while eq == false in ordered collections.
- The “set-based” equality implied by the TODO would be inconsistent with the sequential hash used for commitment (order-sensitive), so commitment-based equality is the safe, canonical choice.