### PR TITLE
feat: Rename MockChainBuilder::add_note to add_output_note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - [BREAKING] Remove `MockChain::add_pending_note` to simplify mock chain internals ([#1903](https://github.com/0xMiden/miden-base/pull/1903)).
 - [BREAKING] Move active note procedures from `miden::note` to `miden::active_note` module ([#1901](https://github.com/0xMiden/miden-base/pull/1901)).
 - [BREAKING] Remove account_seed from AccountFile ([#1917](https://github.com/0xMiden/miden-base/pull/1917)).
+- [BREAKING] Rename `MockChainBuilder::add_note` to `add_output_note` ([#1946](https://github.com/0xMiden/miden-base/pull/1946)).
 
 ## 0.11.4 (2025-09-17)
 

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -275,8 +275,8 @@ fn noop_tx_and_state_updating_tx_against_same_account_in_same_block() -> anyhow:
         NoteBuilder::new(ACCOUNT_ID_SENDER.try_into().unwrap(), &mut rand::rng()).build()?;
     let noop_note1 =
         NoteBuilder::new(ACCOUNT_ID_SENDER.try_into().unwrap(), &mut rand::rng()).build()?;
-    builder.add_note(OutputNote::Full(noop_note0.clone()));
-    builder.add_note(OutputNote::Full(noop_note1.clone()));
+    builder.add_output_note(OutputNote::Full(noop_note0.clone()));
+    builder.add_output_note(OutputNote::Full(noop_note1.clone()));
     let mut chain = builder.build()?;
 
     let noop_tx = generate_conditional_tx(&mut chain, account0.id(), noop_note0, false);

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -327,7 +327,7 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
     let fail_epilogue_note = NoteBuilder::new(account.id(), &mut rand::rng())
         .add_assets([Asset::from(note_asset)])
         .build()?;
-    builder.add_note(OutputNote::Full(fail_epilogue_note.clone()));
+    builder.add_output_note(OutputNote::Full(fail_epilogue_note.clone()));
 
     let mock_chain = builder.build()?;
     let notes = vec![

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -168,7 +168,7 @@ fn create_output_notes() -> anyhow::Result<ExecutedTransaction> {
     // This creates a note that adds the given assets to the account vault.
     let asset_note =
         create_public_p2any_note(account.id(), [Asset::from(note_asset0.add(note_asset1)?)]);
-    builder.add_note(OutputNote::Full(asset_note.clone()));
+    builder.add_output_note(OutputNote::Full(asset_note.clone()));
 
     let output_note0 = create_public_p2any_note(account.id(), [note_asset0.into()]);
     let output_note1 = create_public_p2any_note(account.id(), [note_asset1.into()]);

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -481,7 +481,7 @@ pub fn test_timelock() -> anyhow::Result<()> {
         .dynamically_linked_libraries(TransactionKernel::mock_libraries())
         .build()?;
 
-    builder.add_note(OutputNote::Full(timelock_note.clone()));
+    builder.add_output_note(OutputNote::Full(timelock_note.clone()));
 
     let mut mock_chain = builder.build()?;
     mock_chain

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -506,7 +506,7 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let input_note = create_spawn_note(vec![&output_note])?;
 
     let mut builder = MockChain::builder();
-    builder.add_note(OutputNote::Full(input_note.clone()));
+    builder.add_output_note(OutputNote::Full(input_note.clone()));
     let mock_chain = builder.build()?;
 
     let tx_context = mock_chain.build_tx_context(account, &[input_note.id()], &[])?.build()?;

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -400,7 +400,7 @@ impl MockChainBuilder {
     // ----------------------------------------------------------------------------------------
 
     /// Adds the provided note to the initial chain state.
-    pub fn add_note(&mut self, note: impl Into<OutputNote>) {
+    pub fn add_output_note(&mut self, note: impl Into<OutputNote>) {
         self.notes.push(note.into());
     }
 
@@ -415,7 +415,7 @@ impl MockChainBuilder {
         assets: impl IntoIterator<Item = Asset>,
     ) -> anyhow::Result<Note> {
         let note = self.create_p2any_note(sender_account_id, note_type, assets)?;
-        self.add_note(OutputNote::Full(note.clone()));
+        self.add_output_note(OutputNote::Full(note.clone()));
 
         Ok(note)
     }
@@ -438,7 +438,7 @@ impl MockChainBuilder {
             asset.iter().copied(),
             note_type,
         )?;
-        self.add_note(OutputNote::Full(note.clone()));
+        self.add_output_note(OutputNote::Full(note.clone()));
 
         Ok(note)
     }
@@ -468,7 +468,7 @@ impl MockChainBuilder {
             &mut self.rng,
         )?;
 
-        self.add_note(OutputNote::Full(note.clone()));
+        self.add_output_note(OutputNote::Full(note.clone()));
 
         Ok(note)
     }
@@ -492,7 +492,7 @@ impl MockChainBuilder {
             &mut self.rng,
         )?;
 
-        self.add_note(OutputNote::Full(swap_note.clone()));
+        self.add_output_note(OutputNote::Full(swap_note.clone()));
 
         Ok((swap_note, payback_note))
     }
@@ -515,7 +515,7 @@ impl MockChainBuilder {
         I: ExactSizeIterator<Item = &'note Note>,
     {
         let note = create_spawn_note(output_notes)?;
-        self.add_note(OutputNote::Full(note.clone()));
+        self.add_output_note(OutputNote::Full(note.clone()));
 
         Ok(note)
     }

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -271,7 +271,7 @@ impl TransactionContextBuilder {
 
                 let mut builder = MockChain::builder();
                 for i in self.input_notes {
-                    builder.add_note(OutputNote::Full(i));
+                    builder.add_output_note(OutputNote::Full(i));
                 }
                 let mut mock_chain = builder.build()?;
 

--- a/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
+++ b/crates/miden-testing/tests/auth/rpo_falcon_acl.rs
@@ -70,7 +70,7 @@ fn setup_rpo_falcon_acl_test(
     let note = NoteBuilder::new(account.id(), &mut rand::rng())
         .build()
         .expect("failed to create mock note");
-    builder.add_note(OutputNote::Full(note.clone()));
+    builder.add_output_note(OutputNote::Full(note.clone()));
     let mock_chain = builder.build()?;
 
     Ok((account, mock_chain, note))

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -244,7 +244,7 @@ fn prove_burning_fungible_asset_on_existing_faucet_succeeds() -> anyhow::Result<
 
     let note = get_note_with_fungible_asset_and_script(fungible_asset, burn_note_script_code);
 
-    builder.add_note(OutputNote::Full(note.clone()));
+    builder.add_output_note(OutputNote::Full(note.clone()));
     let mock_chain = builder.build()?;
 
     // The Fungible Faucet component is added as the second component after auth, so it's storage

--- a/crates/miden-testing/tests/scripts/swap.rs
+++ b/crates/miden-testing/tests/scripts/swap.rs
@@ -327,7 +327,7 @@ fn setup_swap_test(payback_note_type: NoteType) -> anyhow::Result<SwapTestSetup>
         .add_swap_note(sender_account.id(), offered_asset, requested_asset, payback_note_type)
         .unwrap();
 
-    builder.add_note(OutputNote::Full(swap_note.clone()));
+    builder.add_output_note(OutputNote::Full(swap_note.clone()));
     let mock_chain = builder.build()?;
 
     Ok(SwapTestSetup {


### PR DESCRIPTION
Fixes #1914 