### PR TITLE
post vm 0.18 migration cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Simplify `MockChain` internals and rework its documentation ([#1942]https://github.com/0xMiden/miden-base/pull/1942).
 - [BREAKING] Change the signature of TransactionAuthenticator to return the native signature ([#1945](https://github.com/0xMiden/miden-base/pull/1945)).
 - [BREAKING] Rename `MockChainBuilder::add_note` to `add_output_note` ([#1946](https://github.com/0xMiden/miden-base/pull/1946)).
+- Dynamically lookup all masm `EventId`s from source ([#1954](https://github.com/0xMiden/miden-base/pull/1954)).
 
 ## 0.11.5 (2025-10-02)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1472,7 @@ dependencies = [
 name = "miden-lib"
 version = "0.12.0"
 dependencies = [
+ "Inflector",
  "anyhow",
  "assert_matches",
  "fs-err",

--- a/crates/miden-lib/Cargo.toml
+++ b/crates/miden-lib/Cargo.toml
@@ -32,6 +32,7 @@ rand      = { optional = true, workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]
+Inflector      = { version = "0.11" }
 fs-err         = { version = "3" }
 miden-assembly = { workspace = true }
 miden-core     = { workspace = true }

--- a/crates/miden-lib/asm/account_components/multisig_rpo_falcon_512.masm
+++ b/crates/miden-lib/asm/account_components/multisig_rpo_falcon_512.masm
@@ -9,7 +9,7 @@ use.miden::auth
 # Auth Request Constants
 
 # The event emitted when a signature is not found for a required signer.
-const.UNAUTHORIZED_EVENT=event("miden::auth::unauthorized")
+const.AUTH_UNAUTHORIZED_EVENT=event("miden::auth::unauthorized")
 
 # Storage Layout Constants
 #
@@ -298,7 +298,7 @@ export.auth_tx_rpo_falcon512_multisig
 
     # If signatures are non-existent the tx will fail here.
     if.true
-        emit.UNAUTHORIZED_EVENT
+        emit.AUTH_UNAUTHORIZED_EVENT
         push.0 assert.err="insufficient number of signatures"
     end
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -29,7 +29,10 @@ const.ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND="failed to remove non-exi
 # EVENTS
 # =================================================================================================
 
-const.SMT_PEEK=event("stdlib::collections::smt::smt_peek")
+# The event is from `stdlib`, visible through the prefix and is _not_ a `TransactionEvent`.
+# Care must be taken it stays in sync with the `miden-stdlib` definition. Note that generally speaking
+# we should not emit `"stdlib"` events, consider this "hijacking", tread carefully.
+const.SMT_PEEK_EVENT=event("stdlib::collections::smt::smt_peek")
 
 # CONSTANTS
 # =================================================================================================
@@ -111,7 +114,7 @@ export.peek_balance
     # => [ASSET_KEY, ASSET_VAULT_ROOT]
 
     # lookup asset
-    emit.SMT_PEEK
+    emit.SMT_PEEK_EVENT
     # OS => [ASSET_KEY, ASSET_VAULT_ROOT]
     # AS => [ASSET]
 
@@ -204,7 +207,7 @@ export.add_fungible_asset
     mem_loadw swapw
     # => [ASSET_KEY, VAULT_ROOT, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
 
-    emit.SMT_PEEK adv_loadw
+    emit.SMT_PEEK_EVENT adv_loadw
     # => [CUR_VAULT_VALUE, VAULT_ROOT, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
     swapw
     # => [VAULT_ROOT, CUR_VAULT_VALUE, faucet_id_prefix, faucet_id_suffix, amount, vault_root_ptr]
@@ -536,7 +539,7 @@ proc.peek_asset
     # => [ASSET_KEY, ASSET_VAULT_ROOT]
 
     # lookup asset
-    emit.SMT_PEEK
+    emit.SMT_PEEK_EVENT
     # OS => [ASSET_KEY, ASSET_VAULT_ROOT]
     # AS => [ASSET]
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/epilogue.masm
@@ -22,16 +22,16 @@ const.ERR_AUTH_PROCEDURE_CALLED_FROM_WRONG_CONTEXT="auth procedure had been call
 # =================================================================================================
 
 # Event emitted to signal that the compute_fee procedure has obtained the current number of cycles.
-const.EPILOGUE_AFTER_TX_CYCLES_OBTAINED=event("miden::epilogue::after_tx_cycles_obtained")
+const.EPILOGUE_AFTER_TX_CYCLES_OBTAINED_EVENT=event("miden::epilogue::after_tx_cycles_obtained")
 
 # Event emitted to signal that the fee was computed.
-const.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT=event("miden::epilogue::before_tx_fee_removed_from_account")
+const.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_EVENT=event("miden::epilogue::before_tx_fee_removed_from_account")
 
 # Event emitted to signal that an execution of the authentication procedure has started.
-const.EPILOGUE_AUTH_PROC_START=event("miden::epilogue::auth_proc_start")
+const.EPILOGUE_AUTH_PROC_START_EVENT=event("miden::epilogue::auth_proc_start")
 
 # Event emitted to signal that an execution of the authentication procedure has ended.
-const.EPILOGUE_AUTH_PROC_END=event("miden::epilogue::auth_proc_end")
+const.EPILOGUE_AUTH_PROC_END_EVENT=event("miden::epilogue::auth_proc_end")
 
 # An additional number of cyclces to account for the number of cycles that smt::set will take when
 # removing the computed fee from the asset vault.
@@ -204,7 +204,7 @@ end
 #! Inputs:  []
 #! Outputs: []
 proc.execute_auth_procedure
-    emit.EPILOGUE_AUTH_PROC_START
+    emit.EPILOGUE_AUTH_PROC_START_EVENT
 
     padw padw padw
     # get the auth procedure arguments
@@ -230,7 +230,7 @@ proc.execute_auth_procedure
     # clean up auth procedure outputs
     dropw dropw dropw dropw
 
-    emit.EPILOGUE_AUTH_PROC_END
+    emit.EPILOGUE_AUTH_PROC_END_EVENT
 end
 
 # FEE PROCEDURES
@@ -252,7 +252,7 @@ proc.compute_fee
     clk
     # => [num_current_cycles]
 
-    emit.EPILOGUE_AFTER_TX_CYCLES_OBTAINED
+    emit.EPILOGUE_AFTER_TX_CYCLES_OBTAINED_EVENT
 
     # estimate the number of cycles the transaction will take
     add.ESTIMATED_AFTER_COMPUTE_FEE_CYCLES
@@ -317,7 +317,7 @@ proc.compute_and_remove_fee
     exec.build_native_fee_asset
     # => [FEE_ASSET]
 
-    emit.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT
+    emit.EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT_EVENT
     # => [FEE_ASSET]
 
     # remove the fee from the native account's vault

--- a/crates/miden-lib/asm/kernels/transaction/main.masm
+++ b/crates/miden-lib/asm/kernels/transaction/main.masm
@@ -9,29 +9,29 @@ use.$kernel::prologue
 # =================================================================================================
 
 # Event emitted to signal that an execution of the transaction prologue has started.
-const.PROLOGUE_START=event("miden::tx::prologue_start")
+const.PROLOGUE_START_EVENT=event("miden::tx::prologue_start")
 # Event emitted to signal that an execution of the transaction prologue has ended.
-const.PROLOGUE_END=event("miden::tx::prologue_end")
+const.PROLOGUE_END_EVENT=event("miden::tx::prologue_end")
 
 # Event emitted to signal that the notes processing has started.
-const.NOTES_PROCESSING_START=event("miden::tx::notes_processing_start")
+const.NOTES_PROCESSING_START_EVENT=event("miden::tx::notes_processing_start")
 # Event emitted to signal that the notes processing has ended.
-const.NOTES_PROCESSING_END=event("miden::tx::notes_processing_end")
+const.NOTES_PROCESSING_END_EVENT=event("miden::tx::notes_processing_end")
 
 # Event emitted to signal that the note consuming has started.
-const.NOTE_EXECUTION_START=event("miden::tx::note_execution_start")
+const.NOTE_EXECUTION_START_EVENT=event("miden::tx::note_execution_start")
 # Event emitted to signal that the note consuming has ended.
-const.NOTE_EXECUTION_END=event("miden::tx::note_execution_end")
+const.NOTE_EXECUTION_END_EVENT=event("miden::tx::note_execution_end")
 
 # Event emitted to signal that the transaction script processing has started.
-const.TX_SCRIPT_PROCESSING_START=event("miden::tx::tx_script_processing_start")
+const.TX_SCRIPT_PROCESSING_START_EVENT=event("miden::tx::tx_script_processing_start")
 # Event emitted to signal that the transaction script processing has ended.
-const.TX_SCRIPT_PROCESSING_END=event("miden::tx::tx_script_processing_end")
+const.TX_SCRIPT_PROCESSING_END_EVENT=event("miden::tx::tx_script_processing_end")
 
 # Event emitted to signal that an execution of the transaction epilogue has started.
-const.EPILOGUE_START=event("miden::tx::epilogue_start")
+const.EPILOGUE_START_EVENT=event("miden::tx::epilogue_start")
 # Event emitted to signal that an execution of the transaction epilogue has ended.
-const.EPILOGUE_END=event("miden::tx::epilogue_end")
+const.EPILOGUE_END_EVENT=event("miden::tx::epilogue_end")
 
 # MAIN
 # =================================================================================================
@@ -70,17 +70,17 @@ proc.main.1
     # Prologue
     # ---------------------------------------------------------------------------------------------
 
-    emit.PROLOGUE_START
+    emit.PROLOGUE_START_EVENT
 
     exec.prologue::prepare_transaction
     # => [pad(16)]
 
-    emit.PROLOGUE_END
+    emit.PROLOGUE_END_EVENT
 
     # Note Processing
     # ---------------------------------------------------------------------------------------------
 
-    emit.NOTES_PROCESSING_START
+    emit.NOTES_PROCESSING_START_EVENT
 
     exec.memory::get_num_input_notes
     # => [num_input_notes, pad(16)]
@@ -93,7 +93,7 @@ proc.main.1
     # => [should_loop, pad(16)]
 
     while.true
-        emit.NOTE_EXECUTION_START
+        emit.NOTE_EXECUTION_START_EVENT
         # => []
 
         exec.note::prepare_note
@@ -114,18 +114,18 @@ proc.main.1
         loc_load.0 neq
         # => [should_loop, pad(16)]
 
-        emit.NOTE_EXECUTION_END
+        emit.NOTE_EXECUTION_END_EVENT
     end
 
     exec.note::note_processing_teardown
     # => [pad(16)]
 
-    emit.NOTES_PROCESSING_END
+    emit.NOTES_PROCESSING_END_EVENT
 
     # Transaction Script Processing
     # ---------------------------------------------------------------------------------------------
 
-    emit.TX_SCRIPT_PROCESSING_START
+    emit.TX_SCRIPT_PROCESSING_START_EVENT
 
     # get the memory address of the transaction script root and load it to the stack
     exec.memory::get_tx_script_root_ptr
@@ -157,12 +157,12 @@ proc.main.1
         # => [pad(16)]
     end
 
-    emit.TX_SCRIPT_PROCESSING_END
+    emit.TX_SCRIPT_PROCESSING_END_EVENT
 
     # Epilogue
     # ---------------------------------------------------------------------------------------------
 
-    emit.EPILOGUE_START
+    emit.EPILOGUE_START_EVENT
 
     # execute the transaction epilogue
     exec.epilogue::finalize_transaction
@@ -172,7 +172,7 @@ proc.main.1
     repeat.13 movup.13 drop end
     # => [OUTPUT_NOTES_COMMITMENT, ACCOUNT_UPDATE_COMMITMENT, FEE_ASSET, tx_expiration_block_num, pad(3)]
 
-    emit.EPILOGUE_END
+    emit.EPILOGUE_END_EVENT
 end
 
 begin

--- a/crates/miden-lib/asm/miden/auth/rpo_falcon512.masm
+++ b/crates/miden-lib/asm/miden/auth/rpo_falcon512.masm
@@ -7,7 +7,7 @@ use.std::crypto::dsa::rpo_falcon512
 # =================================================================================================
 
 # The event to request an authentication signature.
-const.AUTH_REQUEST=event("miden::auth::request")
+const.AUTH_REQUEST_EVENT=event("miden::auth::request")
 
 # The slot in this component's storage layout where the public key is stored.
 const.PUBLIC_KEY_SLOT=0
@@ -56,7 +56,7 @@ export.authenticate_transaction
     # Fetch signature from advice provider and verify.
     # ---------------------------------------------------------------------------------------------
     # Emit the authentication request event that pushes a signature for the message to the advice stack
-    emit.AUTH_REQUEST
+    emit.AUTH_REQUEST_EVENT
     swapw
     # OS => [PUB_KEY, MESSAGE]
     # AS => [SIGNATURE]
@@ -148,7 +148,7 @@ export.verify_signatures.16
             # => [MSG, PK, MSG, i-1]
 
             # Emit the authentication request event that pushes a signature for the message to the advice stack.
-            emit.AUTH_REQUEST
+            emit.AUTH_REQUEST_EVENT
 
             swapw
             # OS => [PUB_KEY, MSG, MSG, i-1]

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -28,9 +28,9 @@ pub enum TransactionEvent {
     AccountVaultBeforeRemoveAsset = ACCOUNT_VAULT_BEFORE_REMOVE_ASSET,
     AccountVaultAfterRemoveAsset = ACCOUNT_VAULT_AFTER_REMOVE_ASSET,
 
-    AccountVaultBeforeGetBalanceEvent = ACCOUNT_VAULT_BEFORE_GET_BALANCE,
+    AccountVaultBeforeGetBalance = ACCOUNT_VAULT_BEFORE_GET_BALANCE,
 
-    AccountVaultBeforeHasNonFungibleAssetEvent = ACCOUNT_VAULT_BEFORE_HAS_NON_FUNGIBLE_ASSET,
+    AccountVaultBeforeHasNonFungibleAsset = ACCOUNT_VAULT_BEFORE_HAS_NON_FUNGIBLE_ASSET,
 
     AccountStorageBeforeSetItem = ACCOUNT_STORAGE_BEFORE_SET_ITEM,
     AccountStorageAfterSetItem = ACCOUNT_STORAGE_AFTER_SET_ITEM,
@@ -74,10 +74,10 @@ pub enum TransactionEvent {
     EpilogueAfterTxCyclesObtained = EPILOGUE_AFTER_TX_CYCLES_OBTAINED,
     EpilogueBeforeTxFeeRemovedFromAccount = EPILOGUE_BEFORE_TX_FEE_REMOVED_FROM_ACCOUNT,
 
-    LinkMapSetEvent = LINK_MAP_SET_EVENT,
-    LinkMapGetEvent = LINK_MAP_GET_EVENT,
+    LinkMapSet = LINK_MAP_SET,
+    LinkMapGet = LINK_MAP_GET,
 
-    Unauthorized = UNAUTHORIZED_EVENT,
+    Unauthorized = AUTH_UNAUTHORIZED,
 }
 
 impl TransactionEvent {
@@ -101,10 +101,7 @@ impl TryFrom<EventId> for TransactionEvent {
     fn try_from(value: EventId) -> Result<Self, Self::Error> {
         let raw = value.as_felt().as_int();
 
-        #[cfg(feature = "std")]
         let name = EVENT_NAME_LUT.get(&raw).copied();
-        #[cfg(not(feature = "std"))]
-        let name = Some("<EventId name resolution requires feature \"std\">");
 
         if value.is_reserved() {
             return Err(TransactionEventError::ReservedSystemEvent(value));
@@ -121,12 +118,10 @@ impl TryFrom<EventId> for TransactionEvent {
             },
             ACCOUNT_VAULT_AFTER_REMOVE_ASSET => Ok(TransactionEvent::AccountVaultAfterRemoveAsset),
 
-            ACCOUNT_VAULT_BEFORE_GET_BALANCE => {
-                Ok(TransactionEvent::AccountVaultBeforeGetBalanceEvent)
-            },
+            ACCOUNT_VAULT_BEFORE_GET_BALANCE => Ok(TransactionEvent::AccountVaultBeforeGetBalance),
 
             ACCOUNT_VAULT_BEFORE_HAS_NON_FUNGIBLE_ASSET => {
-                Ok(TransactionEvent::AccountVaultBeforeHasNonFungibleAssetEvent)
+                Ok(TransactionEvent::AccountVaultBeforeHasNonFungibleAsset)
             },
 
             ACCOUNT_STORAGE_BEFORE_SET_ITEM => Ok(TransactionEvent::AccountStorageBeforeSetItem),
@@ -179,10 +174,10 @@ impl TryFrom<EventId> for TransactionEvent {
             },
             EPILOGUE_END => Ok(TransactionEvent::EpilogueEnd),
 
-            LINK_MAP_SET_EVENT => Ok(TransactionEvent::LinkMapSetEvent),
-            LINK_MAP_GET_EVENT => Ok(TransactionEvent::LinkMapGetEvent),
+            LINK_MAP_SET => Ok(TransactionEvent::LinkMapSet),
+            LINK_MAP_GET => Ok(TransactionEvent::LinkMapGet),
 
-            UNAUTHORIZED_EVENT => Ok(TransactionEvent::Unauthorized),
+            AUTH_UNAUTHORIZED => Ok(TransactionEvent::Unauthorized),
 
             _ => Err(TransactionEventError::InvalidTransactionEvent(value, name)),
         }

--- a/crates/miden-objects/src/block/account_witness.rs
+++ b/crates/miden-objects/src/block/account_witness.rs
@@ -3,7 +3,6 @@ use alloc::string::ToString;
 use miden_crypto::merkle::{
     InnerNodeInfo,
     LeafIndex,
-    MerklePath,
     SMT_DEPTH,
     SmtLeaf,
     SmtProof,
@@ -40,7 +39,7 @@ pub struct AccountWitness {
     /// The state commitment of the account ID.
     commitment: Word,
     /// The merkle path of the account witness.
-    path: MerklePath,
+    path: SparseMerklePath,
 }
 
 impl AccountWitness {
@@ -53,11 +52,11 @@ impl AccountWitness {
     pub fn new(
         account_id: AccountId,
         commitment: Word,
-        path: MerklePath,
+        path: SparseMerklePath,
     ) -> Result<Self, AccountTreeError> {
-        if path.len() != SMT_DEPTH as usize {
+        if path.depth() != SMT_DEPTH {
             return Err(AccountTreeError::WitnessMerklePathDepthDoesNotMatchAccountTreeDepth(
-                path.len(),
+                path.depth() as usize,
             ));
         }
 
@@ -105,7 +104,7 @@ impl AccountWitness {
         // the account trees.
         debug_assert_eq!(proof.path().depth(), AccountTree::DEPTH);
 
-        AccountWitness::new_unchecked(witness_id, commitment, proof.into_parts().0.into())
+        AccountWitness::new_unchecked(witness_id, commitment, proof.into_parts().0)
     }
 
     /// Constructs a new [`AccountWitness`] from the provided parts.
@@ -113,7 +112,11 @@ impl AccountWitness {
     /// # Warning
     ///
     /// This does not validate any of the guarantees of this type.
-    pub(super) fn new_unchecked(account_id: AccountId, commitment: Word, path: MerklePath) -> Self {
+    pub(super) fn new_unchecked(
+        account_id: AccountId,
+        commitment: Word,
+        path: SparseMerklePath,
+    ) -> Self {
         Self { id: account_id, commitment, path }
     }
 
@@ -127,8 +130,8 @@ impl AccountWitness {
         self.commitment
     }
 
-    /// Returns the [`MerklePath`] of the account witness.
-    pub fn path(&self) -> &MerklePath {
+    /// Returns the [`SparseMerklePath`] of the account witness.
+    pub fn path(&self) -> &SparseMerklePath {
         &self.path
     }
 
@@ -147,13 +150,8 @@ impl AccountWitness {
     pub fn into_proof(self) -> SmtProof {
         let leaf = self.leaf();
         debug_assert_eq!(self.path.depth(), AccountTree::DEPTH);
-        SmtProof::new(
-            SparseMerklePath::try_from(self.path).expect(
-                "only ever exists for merkle paths that match the SMT depth by construction",
-            ),
-            leaf,
-        )
-        .expect("merkle path depth should be the SMT depth by construction")
+        SmtProof::new(self.path, leaf)
+            .expect("merkle path depth should be the SMT depth by construction")
     }
 
     /// Returns an iterator over every inner node of this witness' merkle path.
@@ -186,11 +184,11 @@ impl Deserializable for AccountWitness {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let id = AccountId::read_from(source)?;
         let commitment = Word::read_from(source)?;
-        let path = MerklePath::read_from(source)?;
+        let path = SparseMerklePath::read_from(source)?;
 
-        if path.len() != SMT_DEPTH as usize {
+        if path.depth() != SMT_DEPTH {
             return Err(DeserializationError::InvalidValue(
-                SmtProofError::InvalidMerklePathLength(path.len()).to_string(),
+                SmtProofError::InvalidMerklePathLength(path.depth() as usize).to_string(),
             ));
         }
 

--- a/crates/miden-objects/src/block/partial_account_tree.rs
+++ b/crates/miden-objects/src/block/partial_account_tree.rs
@@ -270,16 +270,10 @@ mod tests {
         let proof1 = full_tree.open(&key1);
         assert_eq!(proof0.leaf(), proof1.leaf());
 
-        let witness0 = AccountWitness::new_unchecked(
-            id0,
-            proof0.get(&key0).unwrap(),
-            proof0.into_parts().0.into(),
-        );
-        let witness1 = AccountWitness::new_unchecked(
-            id1,
-            proof1.get(&key1).unwrap(),
-            proof1.into_parts().0.into(),
-        );
+        let witness0 =
+            AccountWitness::new_unchecked(id0, proof0.get(&key0).unwrap(), proof0.into_parts().0);
+        let witness1 =
+            AccountWitness::new_unchecked(id1, proof1.get(&key1).unwrap(), proof1.into_parts().0);
 
         let mut partial_tree = PartialAccountTree::new();
         partial_tree.track_account(witness0).unwrap();

--- a/crates/miden-objects/src/transaction/inputs/account.rs
+++ b/crates/miden-objects/src/transaction/inputs/account.rs
@@ -1,5 +1,3 @@
-use miden_crypto::merkle::SparseMerklePath;
-
 use crate::Word;
 use crate::account::{AccountCode, AccountId, PartialAccount, PartialStorage};
 use crate::asset::PartialVault;
@@ -68,8 +66,6 @@ impl AccountInputs {
     /// This root should be equal to the account root in the reference block header.
     pub fn compute_account_root(&self) -> Result<Word, SmtProofError> {
         let smt_merkle_path = self.witness.path().clone();
-        let smt_merkle_path = SparseMerklePath::try_from(smt_merkle_path)
-            .expect("Only ever exists for merkle paths that match the SMT depth by construction");
         let smt_leaf = self.witness.leaf();
         let root = SmtProof::new(smt_merkle_path, smt_leaf)?.compute_root();
 
@@ -102,7 +98,7 @@ mod tests {
 
     use miden_core::Felt;
     use miden_core::utils::{Deserializable, Serializable};
-    use miden_crypto::merkle::MerklePath;
+    use miden_crypto::merkle::SparseMerklePath;
     use miden_processor::SMT_DEPTH;
 
     use crate::account::{Account, AccountCode, AccountId, AccountStorage, PartialAccount};
@@ -125,7 +121,8 @@ mod tests {
         for _ in 0..(SMT_DEPTH as usize) {
             merkle_nodes.push(commitment);
         }
-        let merkle_path = MerklePath::new(merkle_nodes);
+        let merkle_path = SparseMerklePath::from_sized_iter(merkle_nodes)
+            .expect("The nodes given are of SMT_DEPTH count");
 
         let fpi_inputs = AccountInputs::new(
             PartialAccount::from(&account),

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -455,7 +455,7 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let source_code = r#"
       use.miden::auth
       use.miden::tx
-      const.ABORT_EVENT=event("miden::auth::unauthorized")
+      const.AUTH_UNAUTHORIZED_EVENT=event("miden::auth::unauthorized")
       #! Inputs:  [AUTH_ARGS, pad(12)]
       #! Outputs: [pad(16)]
       export.auth_abort_tx
@@ -475,7 +475,7 @@ fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
           exec.auth::hash_tx_summary
           # => [MESSAGE, pad(16)]
 
-          emit.ABORT_EVENT
+          emit.AUTH_UNAUTHORIZED_EVENT
       end
     "#;
 

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -130,8 +130,8 @@ impl SyncHost for MockHost {
             TransactionEvent::AccountPushProcedureIndex => {
                 self.on_push_account_procedure_index(process)
             },
-            TransactionEvent::LinkMapSetEvent => LinkMap::handle_set_event(process),
-            TransactionEvent::LinkMapGetEvent => LinkMap::handle_get_event(process),
+            TransactionEvent::LinkMapSet => LinkMap::handle_set_event(process),
+            TransactionEvent::LinkMapGet => LinkMap::handle_get_event(process),
             _ => Ok(Vec::new()),
         }?;
 

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -270,11 +270,11 @@ where
                 self.on_account_vault_after_remove_asset(process).map(|_| TransactionEventHandling::Handled(Vec::new()))
             },
 
-            TransactionEvent::AccountVaultBeforeGetBalanceEvent => {
+            TransactionEvent::AccountVaultBeforeGetBalance => {
                 self.on_account_vault_before_get_balance(process)
             },
 
-            TransactionEvent::AccountVaultBeforeHasNonFungibleAssetEvent => {
+            TransactionEvent::AccountVaultBeforeHasNonFungibleAsset => {
                 self.on_account_vault_before_has_non_fungible_asset(process)
             }
 
@@ -373,10 +373,10 @@ where
                 self.tx_progress.end_epilogue(process.clk());
                 Ok(TransactionEventHandling::Handled(Vec::new()))
             }
-            TransactionEvent::LinkMapSetEvent => {
+            TransactionEvent::LinkMapSet => {
                 return LinkMap::handle_set_event(process).map(TransactionEventHandling::Handled);
             },
-            TransactionEvent::LinkMapGetEvent => {
+            TransactionEvent::LinkMapGet => {
                 return LinkMap::handle_get_event(process).map(TransactionEventHandling::Handled);
             },
             TransactionEvent::Unauthorized => {


### PR DESCRIPTION
Closes #1950

* Dynamically constructs the constants for the `TransactionEvent` based on masm file `const.X=event("foo::bar")"` definitions
* `AccountWitness` uses the `SparseMerklePath` impl
* unify MASM event const names to have an `_EVENT` suffix, the rust constants don't since they're scoped.