### PR TITLE
feat: Use `FastProcessor` and `TransactionExecutorHost` in code tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [BREAKING] Remove account_seed from AccountFile ([#1917](https://github.com/0xMiden/miden-base/pull/1917)).
 - [BREAKING] Change the signature of TransactionAuthenticator to return the native signature ([#1945](https://github.com/0xMiden/miden-base/pull/1945)).
 - [BREAKING] Rename `MockChainBuilder::add_note` to `add_output_note` ([#1946](https://github.com/0xMiden/miden-base/pull/1946)).
+- [BREAKING] Return `ExecutionOutput` from `TransactionContext::execute_code` ([#1955](https://github.com/0xMiden/miden-base/pull/1955)).
 
 ## 0.11.4 (2025-09-17)
 

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -87,6 +87,11 @@ impl TransactionEvent {
         let is_unprivileged = matches!(self, Self::AuthRequest | Self::Unauthorized);
         !is_unprivileged
     }
+
+    /// TODO
+    pub fn event_id(&self) -> EventId {
+        EventId::from_u64(self.clone() as u64)
+    }
 }
 
 impl fmt::Display for TransactionEvent {

--- a/crates/miden-lib/src/transaction/events.rs
+++ b/crates/miden-lib/src/transaction/events.rs
@@ -88,7 +88,7 @@ impl TransactionEvent {
         !is_unprivileged
     }
 
-    /// TODO
+    /// Returns the [`EventId`] of the transaction event.
     pub fn event_id(&self) -> EventId {
         EventId::from_u64(self.clone() as u64)
     }

--- a/crates/miden-testing/src/executor.rs
+++ b/crates/miden-testing/src/executor.rs
@@ -1,11 +1,7 @@
-use alloc::borrow::ToOwned;
-use alloc::sync::Arc;
-
-use miden_lib::transaction::TransactionKernel;
-use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
-use miden_objects::assembly::{DefaultSourceManager, SourceManagerSync};
+#[cfg(test)]
+use miden_processor::DefaultHost;
 use miden_processor::fast::{ExecutionOutput, FastProcessor};
-use miden_processor::{AdviceInputs, AsyncHost, DefaultHost, ExecutionError, Program, StackInputs};
+use miden_processor::{AdviceInputs, AsyncHost, ExecutionError, Program, StackInputs};
 
 // CODE EXECUTOR
 // ================================================================================================
@@ -42,7 +38,15 @@ impl<H: AsyncHost> CodeExecutor<H> {
     ///
     /// To improve the error message quality, convert the returned [`ExecutionError`] into a
     /// [`Report`](miden_objects::assembly::diagnostics::Report).
+    #[cfg(test)]
     pub fn run(self, code: &str) -> Result<ExecutionOutput, ExecutionError> {
+        use alloc::borrow::ToOwned;
+        use alloc::sync::Arc;
+
+        use miden_lib::transaction::TransactionKernel;
+        use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
+        use miden_objects::assembly::{DefaultSourceManager, SourceManagerSync};
+
         let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
         let assembler = TransactionKernel::with_kernel_library(source_manager.clone());
 
@@ -80,8 +84,11 @@ impl<H: AsyncHost> CodeExecutor<H> {
     }
 }
 
+#[cfg(test)]
 impl CodeExecutor<DefaultHost> {
     pub fn with_default_host() -> Self {
+        use miden_lib::transaction::TransactionKernel;
+
         let mut host = DefaultHost::default();
 
         let test_lib = TransactionKernel::library();

--- a/crates/miden-testing/src/executor.rs
+++ b/crates/miden-testing/src/executor.rs
@@ -81,7 +81,7 @@ impl<H: AsyncHost> CodeExecutor<H> {
 }
 
 impl CodeExecutor<DefaultHost> {
-    pub(crate) fn with_default_host() -> Self {
+    pub fn with_default_host() -> Self {
         let mut host = DefaultHost::default();
 
         let test_lib = TransactionKernel::library();

--- a/crates/miden-testing/src/kernel_tests/tx/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/mod.rs
@@ -43,10 +43,10 @@ mod test_fpi;
 mod test_input_note;
 mod test_lazy_loading;
 mod test_link_map;
-// mod test_note;
-// mod test_output_note;
+mod test_note;
+mod test_output_note;
 mod test_prologue;
-// mod test_tx;
+mod test_tx;
 
 // HELPER FUNCTIONS
 // ================================================================================================
@@ -101,7 +101,7 @@ impl ProcessMemoryExt for ExecutionOutput {
     }
 }
 
-fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
+pub fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
     memory::INPUT_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -183,7 +183,7 @@ pub fn test_account_type() -> miette::Result<()> {
                 "
             );
 
-            let execution_output = CodeExecutor::with_default_host()
+            let exec_output = CodeExecutor::with_default_host()
                 .stack_inputs(
                     StackInputs::new(vec![account_id.prefix().as_felt()]).into_diagnostic()?,
                 )
@@ -194,7 +194,7 @@ pub fn test_account_type() -> miette::Result<()> {
             has_type |= type_matches;
 
             assert_eq!(
-                execution_output.get_stack_element(0),
+                exec_output.get_stack_element(0),
                 expected_result,
                 "Rust and Masm check on account type diverge. proc: {} account_id: {} account_type: {:?} expected_type: {:?}",
                 procedure,
@@ -312,13 +312,13 @@ fn test_is_faucet_procedure() -> miette::Result<()> {
             prefix = account_id.prefix().as_felt(),
         );
 
-        let execution_output = CodeExecutor::with_default_host()
+        let exec_output = CodeExecutor::with_default_host()
             .run(&code)
             .wrap_err("failed to execute is_faucet procedure")?;
 
         let is_faucet = account_id.is_faucet();
         assert_eq!(
-            execution_output.get_stack_element(0),
+            exec_output.get_stack_element(0),
             Felt::new(is_faucet as u64),
             "Rust and MASM is_faucet diverged for account_id {account_id}"
         );
@@ -425,23 +425,23 @@ fn test_get_map_item() -> miette::Result<()> {
 
         let exec_output = &mut tx_context.execute_code(&code)?;
         assert_eq!(
+            exec_output.get_stack_word(0),
             value,
-            exec_output.stack.get_stack_word(0).unwrap(),
             "get_map_item result doesn't match the expected value",
         );
         assert_eq!(
+            exec_output.get_stack_word(4),
             Word::empty(),
-            exec_output.stack.get_stack_word(4).unwrap(),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
+            exec_output.get_stack_word(8),
             Word::empty(),
-            exec_output.stack.get_stack_word(8).unwrap(),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
+            exec_output.get_stack_word(12),
             Word::empty(),
-            exec_output.stack.get_stack_word(12).unwrap(),
             "The rest of the stack must be cleared",
         );
     }
@@ -487,21 +487,9 @@ fn test_get_storage_slot_type() -> miette::Result<()> {
         assert_eq!(exec_output.get_stack_element(1), ZERO, "the rest of the stack is empty");
         assert_eq!(exec_output.get_stack_element(2), ZERO, "the rest of the stack is empty");
         assert_eq!(exec_output.get_stack_element(3), ZERO, "the rest of the stack is empty");
-        assert_eq!(
-            Word::empty(),
-            exec_output.stack.get_stack_word(1).unwrap(),
-            "the rest of the stack is empty"
-        );
-        assert_eq!(
-            Word::empty(),
-            exec_output.stack.get_stack_word(2).unwrap(),
-            "the rest of the stack is empty"
-        );
-        assert_eq!(
-            Word::empty(),
-            exec_output.stack.get_stack_word(3).unwrap(),
-            "the rest of the stack is empty"
-        );
+        assert_eq!(exec_output.get_stack_word(4), Word::empty(), "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_word(8), Word::empty(), "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_word(12), Word::empty(), "the rest of the stack is empty");
     }
 
     Ok(())
@@ -596,12 +584,12 @@ fn test_set_map_item() -> miette::Result<()> {
 
     assert_eq!(
         new_storage_map.root(),
-        exec_output.stack.get_stack_word(0).unwrap(),
+        exec_output.get_stack_word(0),
         "get_item must return the new updated value",
     );
     assert_eq!(
         storage_item.slot.value(),
-        exec_output.stack.get_stack_word(4).unwrap(),
+        exec_output.get_stack_word(4),
         "The original value stored in the map doesn't match the expected value",
     );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -423,25 +423,25 @@ fn test_get_map_item() -> miette::Result<()> {
             map_key = &key,
         );
 
-        let process = &mut tx_context.execute_code(&code)?;
+        let exec_output = &mut tx_context.execute_code(&code)?;
         assert_eq!(
             value,
-            process.stack.get_stack_word(0).unwrap(),
+            exec_output.stack.get_stack_word(0).unwrap(),
             "get_map_item result doesn't match the expected value",
         );
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(4).unwrap(),
+            exec_output.stack.get_stack_word(4).unwrap(),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(8).unwrap(),
+            exec_output.stack.get_stack_word(8).unwrap(),
             "The rest of the stack must be cleared",
         );
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(12).unwrap(),
+            exec_output.stack.get_stack_word(12).unwrap(),
             "The rest of the stack must be cleared",
         );
     }
@@ -479,27 +479,27 @@ fn test_get_storage_slot_type() -> miette::Result<()> {
             item_index = storage_item.index,
         );
 
-        let process = &tx_context.execute_code(&code).unwrap();
+        let exec_output = &tx_context.execute_code(&code).unwrap();
 
         let storage_slot_type = storage_item.slot.slot_type();
 
-        assert_eq!(storage_slot_type, process.get_stack_item(0).try_into().unwrap());
-        assert_eq!(process.get_stack_item(1), ZERO, "the rest of the stack is empty");
-        assert_eq!(process.get_stack_item(2), ZERO, "the rest of the stack is empty");
-        assert_eq!(process.get_stack_item(3), ZERO, "the rest of the stack is empty");
+        assert_eq!(storage_slot_type, exec_output.get_stack_item(0).try_into().unwrap());
+        assert_eq!(exec_output.get_stack_item(1), ZERO, "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_item(2), ZERO, "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_item(3), ZERO, "the rest of the stack is empty");
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(1).unwrap(),
+            exec_output.stack.get_stack_word(1).unwrap(),
             "the rest of the stack is empty"
         );
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(2).unwrap(),
+            exec_output.stack.get_stack_word(2).unwrap(),
             "the rest of the stack is empty"
         );
         assert_eq!(
             Word::empty(),
-            process.stack.get_stack_word(3).unwrap(),
+            exec_output.stack.get_stack_word(3).unwrap(),
             "the rest of the stack is empty"
         );
     }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -49,7 +49,7 @@ use rand_chacha::ChaCha20Rng;
 
 use super::{Felt, StackInputs, ZERO};
 use crate::executor::CodeExecutor;
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::{
     Auth,
     MockChain,
@@ -194,7 +194,7 @@ pub fn test_account_type() -> miette::Result<()> {
             has_type |= type_matches;
 
             assert_eq!(
-                execution_output.get_stack_item(0),
+                execution_output.get_stack_element(0),
                 expected_result,
                 "Rust and Masm check on account type diverge. proc: {} account_id: {} account_type: {:?} expected_type: {:?}",
                 procedure,
@@ -318,7 +318,7 @@ fn test_is_faucet_procedure() -> miette::Result<()> {
 
         let is_faucet = account_id.is_faucet();
         assert_eq!(
-            execution_output.get_stack_item(0),
+            execution_output.get_stack_element(0),
             Felt::new(is_faucet as u64),
             "Rust and MASM is_faucet diverged for account_id {account_id}"
         );
@@ -483,10 +483,10 @@ fn test_get_storage_slot_type() -> miette::Result<()> {
 
         let storage_slot_type = storage_item.slot.slot_type();
 
-        assert_eq!(storage_slot_type, exec_output.get_stack_item(0).try_into().unwrap());
-        assert_eq!(exec_output.get_stack_item(1), ZERO, "the rest of the stack is empty");
-        assert_eq!(exec_output.get_stack_item(2), ZERO, "the rest of the stack is empty");
-        assert_eq!(exec_output.get_stack_item(3), ZERO, "the rest of the stack is empty");
+        assert_eq!(storage_slot_type, exec_output.get_stack_element(0).try_into().unwrap());
+        assert_eq!(exec_output.get_stack_element(1), ZERO, "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_element(2), ZERO, "the rest of the stack is empty");
+        assert_eq!(exec_output.get_stack_element(3), ZERO, "the rest of the stack is empty");
         assert_eq!(
             Word::empty(),
             exec_output.stack.get_stack_word(1).unwrap(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -24,6 +24,7 @@ use miden_objects::testing::account_id::{
 };
 use miden_objects::{EMPTY_WORD, Felt, ONE, WORD_SIZE, Word};
 
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::create_public_p2any_note;
 use crate::{
     Auth,
@@ -269,7 +270,7 @@ fn test_active_note_get_assets() -> anyhow::Result<()> {
             # prepare note 0
             exec.note_internal::prepare_note
 
-            # exec_output note 0
+            # process note 0
             call.process_note_0
 
             # increment active input note pointer
@@ -278,7 +279,7 @@ fn test_active_note_get_assets() -> anyhow::Result<()> {
             # prepare note 1
             exec.note_internal::prepare_note
 
-            # exec_output note 1
+            # process note 1
             call.process_note_1
 
             # truncate the stack
@@ -498,7 +499,7 @@ fn test_active_note_get_serial_number() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code)?;
 
     let serial_number = tx_context.input_notes().get_note(0).note().serial_num();
-    assert_eq!(exec_output.stack.get_stack_word(0).unwrap(), serial_number);
+    assert_eq!(exec_output.get_stack_word(0), serial_number);
     Ok(())
 }
 
@@ -537,6 +538,6 @@ fn test_active_note_get_script_root() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code)?;
 
     let script_root = tx_context.input_notes().get_note(0).note().script().root();
-    assert_eq!(exec_output.stack.get_stack_word(0).unwrap(), script_root);
+    assert_eq!(exec_output.get_stack_word(0), script_root);
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -149,11 +149,12 @@ fn test_active_note_get_sender() -> anyhow::Result<()> {
         end
         ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
     let sender = tx_context.input_notes().get_note(0).note().metadata().sender();
-    assert_eq!(process.stack.get(0), sender.prefix().as_felt());
-    assert_eq!(process.stack.get(1), sender.suffix());
+    assert_eq!(exec_output.stack[0], sender.prefix().as_felt());
+    assert_eq!(exec_output.stack[1], sender.suffix());
+
     Ok(())
 }
 
@@ -497,7 +498,7 @@ fn test_active_note_get_serial_number() -> anyhow::Result<()> {
     let process = tx_context.execute_code(code)?;
 
     let serial_number = tx_context.input_notes().get_note(0).note().serial_num();
-    assert_eq!(process.stack.get_word(0), serial_number);
+    assert_eq!(process.stack.get_stack_word(0).unwrap(), serial_number);
     Ok(())
 }
 
@@ -533,9 +534,9 @@ fn test_active_note_get_script_root() -> anyhow::Result<()> {
     end
     ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
     let script_root = tx_context.input_notes().get_note(0).note().script().root();
-    assert_eq!(process.stack.get_word(0), script_root);
+    assert_eq!(exec_output.stack.get_stack_word(0).unwrap(), script_root);
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -269,7 +269,7 @@ fn test_active_note_get_assets() -> anyhow::Result<()> {
             # prepare note 0
             exec.note_internal::prepare_note
 
-            # process note 0
+            # exec_output note 0
             call.process_note_0
 
             # increment active input note pointer
@@ -278,7 +278,7 @@ fn test_active_note_get_assets() -> anyhow::Result<()> {
             # prepare note 1
             exec.note_internal::prepare_note
 
-            # process note 1
+            # exec_output note 1
             call.process_note_1
 
             # truncate the stack
@@ -495,10 +495,10 @@ fn test_active_note_get_serial_number() -> anyhow::Result<()> {
         end
         ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
     let serial_number = tx_context.input_notes().get_note(0).note().serial_num();
-    assert_eq!(process.stack.get_stack_word(0).unwrap(), serial_number);
+    assert_eq!(exec_output.stack.get_stack_word(0).unwrap(), serial_number);
     Ok(())
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -37,11 +37,11 @@ fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {
         "
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     assert_eq!(
-        process.get_stack_word(0),
+        exec_output.get_stack_word(0),
         Word::from([
             Felt::new(FUNGIBLE_ASSET_AMOUNT),
             Felt::new(0),

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -6,9 +6,10 @@ use miden_objects::testing::constants::{
     FUNGIBLE_FAUCET_INITIAL_BALANCE,
     NON_FUNGIBLE_ASSET_DATA,
 };
+use miden_objects::{Felt, Hasher, Word};
 
-use super::{Felt, Hasher, Word};
 use crate::TransactionContextBuilder;
+use crate::kernel_tests::tx::ProcessMemoryExt;
 
 #[test]
 fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {
@@ -40,7 +41,7 @@ fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {
 
     let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     assert_eq!(
-        process.stack.get_word(0),
+        process.get_stack_word(0),
         Word::from([
             Felt::new(FUNGIBLE_ASSET_AMOUNT),
             Felt::new(0),
@@ -78,9 +79,9 @@ fn test_create_non_fungible_asset_succeeds() -> anyhow::Result<()> {
         non_fungible_asset_data_hash = Hasher::hash(&NON_FUNGIBLE_ASSET_DATA),
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
+    assert_eq!(exec_output.get_stack_word(0), Word::from(non_fungible_asset));
 
-    assert_eq!(process.stack.get_word(0), Word::from(non_fungible_asset));
     Ok(())
 }
 
@@ -106,8 +107,8 @@ fn test_validate_non_fungible_asset() -> anyhow::Result<()> {
         "
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
-    assert_eq!(process.stack.get_word(0), non_fungible_asset);
+    assert_eq!(exec_output.get_stack_word(0), non_fungible_asset);
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -9,7 +9,7 @@ use miden_objects::testing::constants::{
 use miden_objects::{Felt, Hasher, Word};
 
 use crate::TransactionContextBuilder;
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 
 #[test]
 fn test_create_fungible_asset_succeeds() -> anyhow::Result<()> {

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -7,7 +7,6 @@ use miden_lib::errors::tx_kernel_errors::{
     ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND,
 };
 use miden_lib::transaction::memory;
-use miden_objects::AssetVaultError;
 use miden_objects::account::AccountId;
 use miden_objects::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
 use miden_objects::testing::account_id::{
@@ -16,8 +15,8 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
 };
 use miden_objects::testing::constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA};
+use miden_objects::{AssetVaultError, Felt, ONE, Word, ZERO};
 
-use super::{Felt, ONE, Word, ZERO};
 use crate::kernel_tests::tx::ProcessMemoryExt;
 use crate::{TransactionContextBuilder, assert_execution_error};
 
@@ -47,10 +46,10 @@ fn get_balance_returns_correct_amount() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code(&code)?;
+    let exec_output = tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get(0).as_int(),
+        exec_output.get_stack_item(0).as_int(),
         tx_context.account().vault().get_balance(faucet_id).unwrap()
     );
 
@@ -88,10 +87,10 @@ fn peek_balance_returns_correct_amount() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code(&code)?;
+    let exec_output = tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get(0).as_int(),
+        exec_output.get_stack_item(0).as_int(),
         tx_context.account().vault().get_balance(faucet_id).unwrap()
     );
 
@@ -99,6 +98,7 @@ fn peek_balance_returns_correct_amount() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore = "transaction executor host returns error before the tx kernel, making the test less useful"]
 fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
@@ -118,9 +118,13 @@ fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code(&code);
+    // TODO: Consider building a VM host manually that does not do lazy loading.
+    let _exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_GET_BALANCE_CAN_ONLY_BE_CALLED_ON_FUNGIBLE_ASSET);
+    // assert_execution_error!(
+    //     exec_output,
+    //     ERR_VAULT_GET_BALANCE_CAN_ONLY_BE_CALLED_ON_FUNGIBLE_ASSET
+    // );
 
     Ok(())
 }
@@ -148,9 +152,9 @@ fn test_has_non_fungible_asset() -> anyhow::Result<()> {
         non_fungible_asset_key = Word::from(non_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code)?;
+    let exec_output = tx_context.execute_code(&code)?;
 
-    assert_eq!(process.stack.get(0), ONE);
+    assert_eq!(exec_output.get_stack_item(0), ONE);
 
     Ok(())
 }
@@ -186,15 +190,15 @@ fn test_add_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(add_fungible_asset)
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
-        Into::<Word>::into(account_vault.add_asset(add_fungible_asset).unwrap())
+        exec_output.get_stack_word(0),
+        Word::from(account_vault.add_asset(add_fungible_asset).unwrap())
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
         account_vault.root()
     );
 
@@ -230,9 +234,9 @@ fn test_add_non_fungible_asset_fail_overflow() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(add_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_FUNGIBLE_MAX_AMOUNT_EXCEEDED);
+    assert_execution_error!(exec_output, ERR_VAULT_FUNGIBLE_MAX_AMOUNT_EXCEEDED);
     assert!(account_vault.add_asset(add_fungible_asset).is_err());
 
     Ok(())
@@ -264,15 +268,15 @@ fn test_add_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(add_non_fungible_asset)
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
-        Into::<Word>::into(account_vault.add_asset(add_non_fungible_asset)?)
+        exec_output.get_stack_word(0),
+        Word::from(account_vault.add_asset(add_non_fungible_asset)?)
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
         account_vault.root()
     );
 
@@ -303,9 +307,9 @@ fn test_add_non_fungible_asset_fail_duplicate() -> anyhow::Result<()> {
         NON_FUNGIBLE_ASSET = Word::from(non_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
+    assert_execution_error!(exec_output, ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
 
     Ok(())
@@ -343,15 +347,15 @@ fn test_remove_fungible_asset_success_no_balance_remaining() -> anyhow::Result<(
         FUNGIBLE_ASSET = Word::from(remove_fungible_asset)
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
-        Into::<Word>::into(account_vault.remove_asset(remove_fungible_asset).unwrap())
+        exec_output.get_stack_word(0),
+        Word::from(account_vault.remove_asset(remove_fungible_asset).unwrap())
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
         account_vault.root()
     );
 
@@ -385,9 +389,12 @@ fn test_remove_fungible_asset_fail_remove_too_much() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(remove_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW);
+    assert_execution_error!(
+        exec_output,
+        ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW
+    );
 
     Ok(())
 }
@@ -424,15 +431,15 @@ fn test_remove_fungible_asset_success_balance_remaining() -> anyhow::Result<()> 
         FUNGIBLE_ASSET = Word::from(remove_fungible_asset)
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
-        Into::<Word>::into(account_vault.remove_asset(remove_fungible_asset).unwrap())
+        exec_output.get_stack_word(0),
+        Word::from(account_vault.remove_asset(remove_fungible_asset).unwrap())
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
         account_vault.root()
     );
 
@@ -470,9 +477,9 @@ fn test_remove_inexisting_non_fungible_asset_fails() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(non_existent_non_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
+    assert_execution_error!(exec_output, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
     assert_matches!(
         account_vault.remove_asset(non_existent_non_fungible_asset).unwrap_err(),
         AssetVaultError::NonFungibleAssetNotFound(err_asset) if err_asset == nonfungible,
@@ -509,15 +516,15 @@ fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(non_fungible_asset)
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
-        Into::<Word>::into(account_vault.remove_asset(non_fungible_asset).unwrap())
+        exec_output.get_stack_word(0),
+        Word::from(account_vault.remove_asset(non_fungible_asset).unwrap())
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(memory::NATIVE_ACCT_VAULT_ROOT_PTR),
         account_vault.root()
     );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -98,8 +98,6 @@ fn peek_balance_returns_correct_amount() -> anyhow::Result<()> {
 }
 
 #[test]
-// #[ignore = "transaction executor host returns error before the tx kernel, making the test less
-// useful"]
 fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
     // Disable lazy loading otherwise the handler will return an error before the transaction kernel
     // can abort, which is what we want to test.
@@ -123,11 +121,10 @@ fn test_get_balance_non_fungible_fails() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    // TODO: Consider building a VM host manually that does not do lazy loading.
-    let exec_output = tx_context.execute_code(&code);
+    let exec_result = tx_context.execute_code(&code);
 
     assert_execution_error!(
-        exec_output,
+        exec_result,
         ERR_VAULT_GET_BALANCE_CAN_ONLY_BE_CALLED_ON_FUNGIBLE_ASSET
     );
 
@@ -239,9 +236,9 @@ fn test_add_non_fungible_asset_fail_overflow() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(add_fungible_asset)
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let exec_result = tx_context.execute_code(&code);
 
-    assert_execution_error!(exec_output, ERR_VAULT_FUNGIBLE_MAX_AMOUNT_EXCEEDED);
+    assert_execution_error!(exec_result, ERR_VAULT_FUNGIBLE_MAX_AMOUNT_EXCEEDED);
     assert!(account_vault.add_asset(add_fungible_asset).is_err());
 
     Ok(())
@@ -312,9 +309,9 @@ fn test_add_non_fungible_asset_fail_duplicate() -> anyhow::Result<()> {
         NON_FUNGIBLE_ASSET = Word::from(non_fungible_asset)
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let exec_result = tx_context.execute_code(&code);
 
-    assert_execution_error!(exec_output, ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
+    assert_execution_error!(exec_result, ERR_VAULT_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
     assert!(account_vault.add_asset(non_fungible_asset).is_err());
 
     Ok(())
@@ -394,10 +391,10 @@ fn test_remove_fungible_asset_fail_remove_too_much() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(remove_fungible_asset)
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let exec_result = tx_context.execute_code(&code);
 
     assert_execution_error!(
-        exec_output,
+        exec_result,
         ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW
     );
 
@@ -482,9 +479,9 @@ fn test_remove_inexisting_non_fungible_asset_fails() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(non_existent_non_fungible_asset)
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let exec_result = tx_context.execute_code(&code);
 
-    assert_execution_error!(exec_output, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
+    assert_execution_error!(exec_result, ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND);
     assert_matches!(
         account_vault.remove_asset(non_existent_non_fungible_asset).unwrap_err(),
         AssetVaultError::NonFungibleAssetNotFound(err_asset) if err_asset == nonfungible,

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -17,7 +17,7 @@ use miden_objects::testing::account_id::{
 use miden_objects::testing::constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA};
 use miden_objects::{AssetVaultError, Felt, ONE, Word, ZERO};
 
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::{TransactionContextBuilder, assert_execution_error};
 
 /// Tests that account::get_balance returns the correct amount.
@@ -49,7 +49,7 @@ fn get_balance_returns_correct_amount() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(&code)?;
 
     assert_eq!(
-        exec_output.get_stack_item(0).as_int(),
+        exec_output.get_stack_element(0).as_int(),
         tx_context.account().vault().get_balance(faucet_id).unwrap()
     );
 
@@ -90,7 +90,7 @@ fn peek_balance_returns_correct_amount() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(&code)?;
 
     assert_eq!(
-        exec_output.get_stack_item(0).as_int(),
+        exec_output.get_stack_element(0).as_int(),
         tx_context.account().vault().get_balance(faucet_id).unwrap()
     );
 
@@ -159,7 +159,7 @@ fn test_has_non_fungible_asset() -> anyhow::Result<()> {
 
     let exec_output = tx_context.execute_code(&code)?;
 
-    assert_eq!(exec_output.get_stack_item(0), ONE);
+    assert_eq!(exec_output.get_stack_element(0), ONE);
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -7,8 +7,8 @@ use miden_lib::testing::mock_account::MockAccountExt;
 use miden_lib::utils::ScriptBuilder;
 use miden_objects::account::{Account, AccountBuilder};
 use miden_objects::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE;
+use miden_objects::{Felt, ONE};
 
-use super::{Felt, ONE};
 use crate::{Auth, TransactionContextBuilder, assert_transaction_executor_error};
 
 pub const ERR_WRONG_ARGS: MasmError = MasmError::from_static_str(ERR_WRONG_ARGS_MSG);

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -38,7 +38,7 @@ use miden_processor::{Felt, ONE};
 use rand::rng;
 
 use super::{ZERO, create_mock_notes_procedure};
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::{create_public_p2any_note, create_spawn_note};
 use crate::{
     Auth,
@@ -391,7 +391,7 @@ fn test_block_expiration_height_monotonically_decreases() -> anyhow::Result<()> 
         let expected_expiry =
             v1.min(v2) + tx_context.tx_inputs().block_header().block_num().as_u64();
         assert_eq!(
-            exec_output.get_stack_item(EXPIRATION_BLOCK_ELEMENT_IDX).as_int(),
+            exec_output.get_stack_element(EXPIRATION_BLOCK_ELEMENT_IDX).as_int(),
             expected_expiry
         );
     }
@@ -449,7 +449,7 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
 
     // Default value should be equal to u32::MAX, set in the prologue
     assert_eq!(
-        exec_output.get_stack_item(EXPIRATION_BLOCK_ELEMENT_IDX).as_int() as u32,
+        exec_output.get_stack_element(EXPIRATION_BLOCK_ELEMENT_IDX).as_int() as u32,
         u32::MAX
     );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -94,7 +94,7 @@ fn test_epilogue() -> anyhow::Result<()> {
         "
     );
 
-    let process = tx_context.execute_code(&code)?;
+    let exec_output = tx_context.execute_code(&code)?;
 
     // The final account is the initial account with the nonce incremented by one.
     let mut final_account = account.clone();
@@ -138,13 +138,13 @@ fn test_epilogue() -> anyhow::Result<()> {
     expected_stack.extend((13..16).map(|_| ZERO));
 
     assert_eq!(
-        *process.stack.build_stack_outputs()?,
+        exec_output.stack.as_slice(),
         expected_stack.as_slice(),
         "Stack state after finalize_transaction does not contain the expected values"
     );
 
     assert_eq!(
-        process.stack.depth(),
+        exec_output.stack.len(),
         16,
         "The stack must be truncated to 16 elements after finalize_transaction"
     );
@@ -390,7 +390,7 @@ fn test_block_expiration_height_monotonically_decreases() -> anyhow::Result<()> 
         // (which can only decrease, not increase)
         let expected_expiry =
             v1.min(v2) + tx_context.tx_inputs().block_header().block_num().as_u64();
-        assert_eq!(process.stack.get(EXPIRATION_BLOCK_ELEMENT_IDX).as_int(), expected_expiry);
+        assert_eq!(process.get_stack_item(EXPIRATION_BLOCK_ELEMENT_IDX).as_int(), expected_expiry);
     }
 
     Ok(())
@@ -444,8 +444,8 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
 
     let process = &tx_context.execute_code(code_template)?;
 
-    // Default value should be equal to u32::max, set in the prologue
-    assert_eq!(process.stack.get(EXPIRATION_BLOCK_ELEMENT_IDX).as_int() as u32, u32::MAX);
+    // Default value should be equal to u32::MAX, set in the prologue
+    assert_eq!(process.get_stack_item(EXPIRATION_BLOCK_ELEMENT_IDX).as_int() as u32, u32::MAX);
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -39,7 +39,7 @@ use miden_objects::testing::noop_auth_component::NoopAuthComponent;
 use miden_objects::testing::storage::FAUCET_STORAGE_DATA_SLOT;
 use miden_objects::{Felt, Word};
 
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::create_public_p2any_note;
 use crate::{TransactionContextBuilder, assert_execution_error, assert_transaction_executor_error};
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -39,6 +39,7 @@ use miden_objects::testing::noop_auth_component::NoopAuthComponent;
 use miden_objects::testing::storage::FAUCET_STORAGE_DATA_SLOT;
 use miden_objects::{Felt, Word};
 
+use crate::kernel_tests::tx::ProcessMemoryExt;
 use crate::utils::create_public_p2any_note;
 use crate::{TransactionContextBuilder, assert_execution_error, assert_transaction_executor_error};
 
@@ -89,12 +90,8 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         FAUCET_STORAGE_DATA_SLOT as u32 + NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR;
     let faucet_storage_amount_location = faucet_reserved_slot_storage_location + 3;
 
-    let faucet_storage_amount = process
-        .chiplets
-        .memory
-        .get_value(process.system.ctx(), faucet_storage_amount_location)
-        .unwrap()
-        .as_int();
+    let faucet_storage_amount =
+        process.get_kernel_mem_element(faucet_storage_amount_location).as_int();
 
     assert_eq!(faucet_storage_amount, expected_final_storage_amount);
     Ok(())
@@ -383,12 +380,8 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
         FAUCET_STORAGE_DATA_SLOT as u32 + NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR;
     let faucet_storage_amount_location = faucet_reserved_slot_storage_location + 3;
 
-    let faucet_storage_amount = process
-        .chiplets
-        .memory
-        .get_value(process.system.ctx(), faucet_storage_amount_location)
-        .unwrap()
-        .as_int();
+    let faucet_storage_amount =
+        process.get_kernel_mem_element(faucet_storage_amount_location).as_int();
 
     assert_eq!(faucet_storage_amount, expected_final_storage_amount);
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -83,7 +83,7 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = &tx_context.execute_code(&code).unwrap();
+    let exec_output = &tx_context.execute_code(&code).unwrap();
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE + FUNGIBLE_ASSET_AMOUNT;
     let faucet_reserved_slot_storage_location =
@@ -91,7 +91,7 @@ fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
     let faucet_storage_amount_location = faucet_reserved_slot_storage_location + 3;
 
     let faucet_storage_amount =
-        process.get_kernel_mem_element(faucet_storage_amount_location).as_int();
+        exec_output.get_kernel_mem_element(faucet_storage_amount_location).as_int();
 
     assert_eq!(faucet_storage_amount, expected_final_storage_amount);
     Ok(())
@@ -146,9 +146,9 @@ fn test_mint_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
         asset = Word::from(FungibleAsset::mock(5))
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
+    assert_execution_error!(exec_output, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
@@ -261,9 +261,9 @@ fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
         non_fungible_asset = Word::from(non_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
+    assert_execution_error!(exec_output, ERR_NON_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
@@ -316,9 +316,9 @@ fn test_mint_non_fungible_asset_fails_asset_already_exists() -> anyhow::Result<(
         non_fungible_asset = Word::from(non_fungible_asset)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_ALREADY_ISSUED);
+    assert_execution_error!(exec_output, ERR_FAUCET_NON_FUNGIBLE_ASSET_ALREADY_ISSUED);
 
     Ok(())
 }
@@ -373,7 +373,7 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
         final_input_vault_asset_amount = CONSUMED_ASSET_1_AMOUNT - FUNGIBLE_ASSET_AMOUNT,
     );
 
-    let process = &tx_context.execute_code(&code).unwrap();
+    let exec_output = &tx_context.execute_code(&code).unwrap();
 
     let expected_final_storage_amount = FUNGIBLE_FAUCET_INITIAL_BALANCE - FUNGIBLE_ASSET_AMOUNT;
     let faucet_reserved_slot_storage_location =
@@ -381,7 +381,7 @@ fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
     let faucet_storage_amount_location = faucet_reserved_slot_storage_location + 3;
 
     let faucet_storage_amount =
-        process.get_kernel_mem_element(faucet_storage_amount_location).as_int();
+        exec_output.get_kernel_mem_element(faucet_storage_amount_location).as_int();
 
     assert_eq!(faucet_storage_amount, expected_final_storage_amount);
     Ok(())
@@ -439,9 +439,9 @@ fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
         suffix = faucet_id.suffix(),
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
+    assert_execution_error!(exec_output, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
     Ok(())
 }
 
@@ -471,9 +471,12 @@ fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
         saturating_amount = CONSUMED_ASSET_1_AMOUNT + 1
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW);
+    assert_execution_error!(
+        exec_output,
+        ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW
+    );
     Ok(())
 }
 
@@ -572,9 +575,9 @@ fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {
         non_fungible_asset = Word::from(non_fungible_asset_burnt)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
+    assert_execution_error!(exec_output, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
     Ok(())
 }
 
@@ -630,9 +633,9 @@ fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result
         non_fungible_asset = Word::from(non_fungible_asset_burnt)
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
+    assert_execution_error!(exec_output, ERR_FAUCET_NON_FUNGIBLE_ASSET_TO_BURN_NOT_FOUND);
     Ok(())
 }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -160,15 +160,15 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         get_item_foreign_hash = foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let process = tx_context.execute_code(&code)?;
+    let exec_output = tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_stack_word(0),
+        exec_output.get_stack_word(0),
         storage_slots[0].value(),
         "Value at the top of the stack (value in the storage at index 0) should be equal [1, 2, 3, 4]",
     );
 
-    foreign_account_data_memory_assertions(&foreign_account, &process);
+    foreign_account_data_memory_assertions(&foreign_account, &exec_output);
 
     // GET MAP ITEM
     // --------------------------------------------------------------------------------------------
@@ -214,15 +214,15 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         get_map_item_foreign_hash = foreign_account.code().procedures()[2].mast_root(),
     );
 
-    let process = tx_context.execute_code(&code).unwrap();
+    let exec_output = tx_context.execute_code(&code).unwrap();
 
     assert_eq!(
-        process.get_stack_word(0),
+        exec_output.get_stack_word(0),
         STORAGE_LEAVES_2[0].1,
         "Value at the top of the stack should be equal [1, 2, 3, 4]",
     );
 
-    foreign_account_data_memory_assertions(&foreign_account, &process);
+    foreign_account_data_memory_assertions(&foreign_account, &exec_output);
 
     // GET ITEM TWICE
     // --------------------------------------------------------------------------------------------
@@ -284,7 +284,7 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         get_item_foreign_hash = foreign_account.code().procedures()[1].mast_root(),
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     // Check that the second invocation of the foreign procedure from the same account does not load
     // the account data again: already loaded data should be reused.
@@ -293,7 +293,7 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     // Foreign account:   [16384; 24575] <- initialized during first FPI
     // Next account slot: [24576; 32767] <- should not be initialized
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 2),
+        exec_output.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 2),
         Word::empty(),
         "Memory starting from 24576 should stay uninitialized"
     );
@@ -467,7 +467,7 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
         foreign_2_suffix = foreign_account_2.id().suffix(),
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     // Check the correctness of the memory layout after multiple foreign procedure invocations from
     // different foreign accounts
@@ -479,7 +479,7 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
 
     // check that the first word of the first foreign account slot is correct
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32),
+        exec_output.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32),
         Word::new([
             foreign_account_1.id().suffix(),
             foreign_account_1.id().prefix().as_felt(),
@@ -490,7 +490,7 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
 
     // check that the first word of the second foreign account slot is correct
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 2),
+        exec_output.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 2),
         Word::new([
             foreign_account_2.id().suffix(),
             foreign_account_2.id().prefix().as_felt(),
@@ -501,7 +501,7 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
 
     // check that the first word of the third foreign account slot was not initialized
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 3),
+        exec_output.get_kernel_mem_word(NATIVE_ACCOUNT_DATA_PTR + ACCOUNT_DATA_LENGTH as u32 * 3),
         Word::empty(),
         "Memory starting from 32768 should stay uninitialized"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -49,7 +49,7 @@ use miden_tx::LocalTransactionProver;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::{Auth, MockChainBuilder, assert_execution_error, assert_transaction_executor_error};
 
 // SIMPLE FPI TESTS

--- a/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_link_map.rs
@@ -3,10 +3,9 @@ use std::collections::BTreeMap;
 use std::string::String;
 
 use anyhow::Context;
-use miden_objects::{EMPTY_WORD, Felt, LexicographicWord, Word};
-use miden_processor::fast::ExecutionOutput;
-use miden_processor::{ContextId, ONE, ProcessState, ZERO};
-use miden_tx::{LinkMap, MemoryViewer};
+use miden_objects::{EMPTY_WORD, LexicographicWord, Word};
+use miden_processor::{ONE, ZERO};
+use miden_tx::LinkMap;
 use rand::seq::IteratorRandom;
 use winter_rand_utils::rand_value;
 
@@ -542,7 +541,7 @@ fn execute_link_map_test(operations: Vec<TestOperation>) -> anyhow::Result<()> {
     );
 
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
-    let mut exec_output = tx_context.execute_code(&code).context("failed to execute code")?;
+    let exec_output = tx_context.execute_code(&code).context("failed to execute code")?;
 
     for (map_ptr, control_map) in control_maps {
         let map = LinkMap::new(map_ptr.into(), &exec_output);

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -82,10 +82,10 @@ fn test_note_setup() -> anyhow::Result<()> {
         end
         ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
-    note_setup_stack_assertions(&process, &tx_context);
-    note_setup_memory_assertions(&process);
+    note_setup_stack_assertions(&exec_output, &tx_context);
+    note_setup_memory_assertions(&exec_output);
     Ok(())
 }
 
@@ -163,10 +163,10 @@ fn test_note_script_and_note_args() -> miette::Result<()> {
     .with_note_args(note_args_map);
 
     tx_context.set_tx_args(tx_args);
-    let process = tx_context.execute_code(code).unwrap();
+    let exec_output = tx_context.execute_code(code).unwrap();
 
-    assert_eq!(process.get_stack_word(0), note_args[0]);
-    assert_eq!(process.get_stack_word(4), note_args[1]);
+    assert_eq!(exec_output.get_stack_word(0), note_args[0]);
+    assert_eq!(exec_output.get_stack_word(4), note_args[1]);
 
     Ok(())
 }
@@ -256,7 +256,7 @@ fn test_build_recipient() -> anyhow::Result<()> {
         serial_num = serial_num,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     // Create expected recipients and get their digests
     let note_inputs_4 = NoteInputs::new(word_1.to_vec())?;
@@ -280,7 +280,7 @@ fn test_build_recipient() -> anyhow::Result<()> {
     expected_stack.extend_from_slice(recipient_13.digest().as_elements());
     expected_stack.reverse();
 
-    assert_eq!(process.stack[0..12], expected_stack);
+    assert_eq!(exec_output.stack[0..12], expected_stack);
     Ok(())
 }
 
@@ -344,7 +344,7 @@ fn test_compute_inputs_commitment() -> anyhow::Result<()> {
         addr_3 = BASE_ADDR + 12,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     let mut inputs_5 = word_1.to_vec();
     inputs_5.push(word_2[0]);
@@ -368,7 +368,7 @@ fn test_compute_inputs_commitment() -> anyhow::Result<()> {
     expected_stack.extend_from_slice(Word::empty().as_elements());
     expected_stack.reverse();
 
-    assert_eq!(process.stack[0..16], expected_stack);
+    assert_eq!(exec_output.stack[0..16], expected_stack);
     Ok(())
 }
 
@@ -421,9 +421,9 @@ fn test_build_metadata() -> miette::Result<()> {
             tag = test_metadata.tag(),
         );
 
-        let process = tx_context.execute_code(&code).unwrap();
+        let exec_output = tx_context.execute_code(&code).unwrap();
 
-        let metadata_word = process.get_stack_word(0);
+        let metadata_word = exec_output.get_stack_word(0);
 
         assert_eq!(Word::from(test_metadata), metadata_word, "failed in iteration {iteration}");
     }

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -37,7 +37,7 @@ use miden_processor::fast::ExecutionOutput;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 
-use crate::kernel_tests::tx::{ProcessMemoryExt, input_note_data_ptr};
+use crate::kernel_tests::tx::{ExecutionOutputExt, input_note_data_ptr};
 use crate::{
     Auth,
     MockChain,

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -47,7 +47,7 @@ use miden_objects::transaction::{OutputNote, OutputNotes};
 use miden_objects::{Felt, Word, ZERO};
 
 use super::{TestSetup, setup_test};
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::create_public_p2any_note;
 use crate::{Auth, MockChain, TransactionContextBuilder, assert_execution_error};
 
@@ -117,7 +117,7 @@ fn test_create_note() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        exec_output.get_stack_item(0),
+        exec_output.get_stack_element(0),
         ZERO,
         "top item on the stack is the index of the output note"
     );
@@ -447,7 +447,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        exec_output.get_stack_item(0),
+        exec_output.get_stack_element(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );
@@ -541,7 +541,7 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        exec_output.get_stack_item(0),
+        exec_output.get_stack_element(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -371,7 +371,8 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
     );
     assert_eq!(
         NoteMetadata::try_from(
-            exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET)
+            exec_output
+                .get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET)
         )
         .unwrap(),
         *output_note_1.metadata(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -117,7 +117,7 @@ fn test_create_note() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        process.stack.get(0),
+        process.get_stack_item(0),
         ZERO,
         "top item on the stack is the index of the output note"
     );
@@ -386,7 +386,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
         "Validate the output note 1 metadata",
     );
 
-    assert_eq!(process.stack.get_word(0), expected_output_notes_commitment);
+    assert_eq!(process.get_stack_word(0), expected_output_notes_commitment);
     Ok(())
 }
 
@@ -446,7 +446,7 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        process.stack.get(0),
+        process.get_stack_item(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );
@@ -540,7 +540,7 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        process.stack.get(0),
+        process.get_stack_item(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -87,16 +87,16 @@ fn test_create_note() -> anyhow::Result<()> {
         tag = tag,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
+        exec_output.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
         Word::from([1, 0, 0, 0u32]),
         "number of output notes must increment by 1",
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
         recipient,
         "recipient must be stored at the correct memory location",
     );
@@ -111,13 +111,13 @@ fn test_create_note() -> anyhow::Result<()> {
     .into();
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET),
         expected_note_metadata,
         "metadata must be stored at the correct memory location",
     );
 
     assert_eq!(
-        process.get_stack_item(0),
+        exec_output.get_stack_item(0),
         ZERO,
         "top item on the stack is the index of the output note"
     );
@@ -200,9 +200,9 @@ fn test_create_note_too_many_notes() -> anyhow::Result<()> {
         aux = ZERO,
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT);
+    assert_execution_error!(exec_output, ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT);
     Ok(())
 }
 
@@ -362,23 +362,23 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
         ),
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
+        exec_output.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
         Word::from([2u32, 0, 0, 0]),
         "The test creates two notes",
     );
     assert_eq!(
         NoteMetadata::try_from(
-            process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET)
+            exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET)
         )
         .unwrap(),
         *output_note_1.metadata(),
         "Validate the output note 1 metadata",
     );
     assert_eq!(
-        NoteMetadata::try_from(process.get_kernel_mem_word(
+        NoteMetadata::try_from(exec_output.get_kernel_mem_word(
             OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_METADATA_OFFSET + NOTE_MEM_SIZE
         ))
         .unwrap(),
@@ -386,7 +386,7 @@ fn test_get_output_notes_commitment() -> anyhow::Result<()> {
         "Validate the output note 1 metadata",
     );
 
-    assert_eq!(process.get_stack_word(0), expected_output_notes_commitment);
+    assert_eq!(exec_output.get_stack_word(0), expected_output_notes_commitment);
     Ok(())
 }
 
@@ -437,16 +437,16 @@ fn test_create_note_and_add_asset() -> anyhow::Result<()> {
         asset = asset,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
         asset,
         "asset must be stored at the correct memory location",
     );
 
     assert_eq!(
-        process.get_stack_item(0),
+        exec_output.get_stack_item(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );
@@ -519,28 +519,28 @@ fn test_create_note_and_add_multiple_assets() -> anyhow::Result<()> {
         nft = non_fungible_asset_encoded,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET),
         asset,
         "asset must be stored at the correct memory location",
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 4),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 4),
         asset_2_and_3,
         "asset_2 and asset_3 must be stored at the same correct memory location",
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 8),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_ASSETS_OFFSET + 8),
         non_fungible_asset_encoded,
         "non_fungible_asset must be stored at the correct memory location",
     );
 
     assert_eq!(
-        process.get_stack_item(0),
+        exec_output.get_stack_item(0),
         ZERO,
         "top item on the stack is the index to the output note"
     );
@@ -595,9 +595,9 @@ fn test_create_note_and_add_same_nft_twice() -> anyhow::Result<()> {
         nft = encoded,
     );
 
-    let process = tx_context.execute_code(&code);
+    let exec_output = tx_context.execute_code(&code);
 
-    assert_execution_error!(process, ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
+    assert_execution_error!(exec_output, ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS);
     Ok(())
 }
 
@@ -692,10 +692,10 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
         aux = aux,
     );
 
-    let process = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code(&code)?;
 
     assert_eq!(
-        process.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
+        exec_output.get_kernel_mem_word(NUM_OUTPUT_NOTES_PTR),
         Word::from([1, 0, 0, 0u32]),
         "number of output notes must increment by 1",
     );
@@ -703,7 +703,7 @@ fn test_build_recipient_hash() -> anyhow::Result<()> {
     let recipient_digest = recipient.clone().digest();
 
     assert_eq!(
-        process.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
+        exec_output.get_kernel_mem_word(OUTPUT_NOTE_SECTION_OFFSET + OUTPUT_NOTE_RECIPIENT_OFFSET),
         recipient_digest,
         "recipient hash not correct",
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -37,7 +37,6 @@ use miden_lib::transaction::memory::{
     INPUT_NOTE_SERIAL_NUM_OFFSET,
     INPUT_NOTES_COMMITMENT_PTR,
     KERNEL_PROCEDURES_PTR,
-    MemoryOffset,
     NATIVE_ACCT_CODE_COMMITMENT_PTR,
     NATIVE_ACCT_ID_AND_NONCE_PTR,
     NATIVE_ACCT_ID_PTR,
@@ -88,14 +87,15 @@ use miden_objects::transaction::{
     TransactionScript,
 };
 use miden_objects::{EMPTY_WORD, ONE, WORD_SIZE};
-use miden_processor::{AdviceInputs, Process, Word};
+use miden_processor::fast::ExecutionOutput;
+use miden_processor::{AdviceInputs, Word};
 use miden_tx::TransactionExecutorError;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{Felt, ZERO};
 use crate::kernel_tests::tx::ProcessMemoryExt;
-use crate::utils::{create_public_p2any_note, input_note_data_ptr};
+use crate::utils::create_public_p2any_note;
 use crate::{
     Auth,
     MockChain,
@@ -163,148 +163,148 @@ fn test_transaction_prologue() -> anyhow::Result<()> {
     .with_note_args(note_args_map);
 
     tx_context.set_tx_args(tx_args);
-    let process = &tx_context.execute_code(code)?;
+    let exec_output = &tx_context.execute_code(code)?;
 
-    global_input_memory_assertions(process, &tx_context);
-    block_data_memory_assertions(process, &tx_context);
-    partial_blockchain_memory_assertions(process, &tx_context);
-    kernel_data_memory_assertions(process);
-    account_data_memory_assertions(process, &tx_context);
-    input_notes_memory_assertions(process, &tx_context, &note_args);
+    global_input_memory_assertions(exec_output, &tx_context);
+    block_data_memory_assertions(exec_output, &tx_context);
+    partial_blockchain_memory_assertions(exec_output, &tx_context);
+    kernel_data_memory_assertions(exec_output);
+    account_data_memory_assertions(exec_output, &tx_context);
+    input_notes_memory_assertions(exec_output, &tx_context, &note_args);
 
     Ok(())
 }
 
-fn global_input_memory_assertions(process: &Process, inputs: &TransactionContext) {
+fn global_input_memory_assertions(exec_output: &ExecutionOutput, inputs: &TransactionContext) {
     assert_eq!(
-        process.get_kernel_mem_word(BLOCK_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(BLOCK_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().commitment(),
         "The block commitment should be stored at the BLOCK_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_ID_PTR)[0],
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_ID_PTR)[0],
         inputs.account().id().suffix(),
         "The account ID prefix should be stored at the ACCT_ID_PTR[0]"
     );
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_ID_PTR)[1],
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_ID_PTR)[1],
         inputs.account().id().prefix().as_felt(),
         "The account ID suffix should be stored at the ACCT_ID_PTR[1]"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(INIT_ACCT_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(INIT_ACCT_COMMITMENT_PTR),
         inputs.account().commitment(),
         "The account commitment should be stored at the INIT_ACCT_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(INIT_NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(INIT_NATIVE_ACCT_VAULT_ROOT_PTR),
         inputs.account().vault().root(),
         "The initial native account vault root should be stored at the INIT_ACCT_VAULT_ROOT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(INIT_NATIVE_ACCT_STORAGE_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(INIT_NATIVE_ACCT_STORAGE_COMMITMENT_PTR),
         inputs.account().storage().commitment(),
         "The initial native account storage commitment should be stored at the INIT_ACCT_STORAGE_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(INPUT_NOTES_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(INPUT_NOTES_COMMITMENT_PTR),
         inputs.input_notes().commitment(),
         "The nullifier commitment should be stored at the INPUT_NOTES_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(INIT_NONCE_PTR)[0],
+        exec_output.get_kernel_mem_word(INIT_NONCE_PTR)[0],
         inputs.account().nonce(),
         "The initial nonce should be stored at the INIT_NONCE_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(TX_SCRIPT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(TX_SCRIPT_ROOT_PTR),
         inputs.tx_args().tx_script().as_ref().unwrap().root(),
         "The transaction script root should be stored at the TX_SCRIPT_ROOT_PTR"
     );
 }
 
-fn block_data_memory_assertions(process: &Process, inputs: &TransactionContext) {
+fn block_data_memory_assertions(exec_output: &ExecutionOutput, inputs: &TransactionContext) {
     assert_eq!(
-        process.get_kernel_mem_word(BLOCK_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(BLOCK_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().commitment(),
         "The block commitment should be stored at the BLOCK_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(PREV_BLOCK_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(PREV_BLOCK_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().prev_block_commitment(),
         "The previous block commitment should be stored at the PARENT_BLOCK_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(CHAIN_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(CHAIN_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().chain_commitment(),
         "The chain commitment should be stored at the CHAIN_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(ACCT_DB_ROOT_PTR),
+        exec_output.get_kernel_mem_word(ACCT_DB_ROOT_PTR),
         inputs.tx_inputs().block_header().account_root(),
         "The account db root should be stored at the ACCT_DB_ROOT_PRT"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NULLIFIER_DB_ROOT_PTR),
+        exec_output.get_kernel_mem_word(NULLIFIER_DB_ROOT_PTR),
         inputs.tx_inputs().block_header().nullifier_root(),
         "The nullifier db root should be stored at the NULLIFIER_DB_ROOT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(TX_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(TX_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().tx_commitment(),
         "The TX commitment should be stored at the TX_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(TX_KERNEL_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(TX_KERNEL_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().tx_kernel_commitment(),
         "The kernel commitment should be stored at the TX_KERNEL_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(PROOF_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(PROOF_COMMITMENT_PTR),
         inputs.tx_inputs().block_header().proof_commitment(),
         "The proof commitment should be stored at the PROOF_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(BLOCK_METADATA_PTR)[BLOCK_NUMBER_IDX],
+        exec_output.get_kernel_mem_word(BLOCK_METADATA_PTR)[BLOCK_NUMBER_IDX],
         inputs.tx_inputs().block_header().block_num().into(),
         "The block number should be stored at BLOCK_METADATA_PTR[BLOCK_NUMBER_IDX]"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(BLOCK_METADATA_PTR)[PROTOCOL_VERSION_IDX],
+        exec_output.get_kernel_mem_word(BLOCK_METADATA_PTR)[PROTOCOL_VERSION_IDX],
         inputs.tx_inputs().block_header().version().into(),
         "The protocol version should be stored at BLOCK_METADATA_PTR[PROTOCOL_VERSION_IDX]"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(BLOCK_METADATA_PTR)[TIMESTAMP_IDX],
+        exec_output.get_kernel_mem_word(BLOCK_METADATA_PTR)[TIMESTAMP_IDX],
         inputs.tx_inputs().block_header().timestamp().into(),
         "The timestamp should be stored at BLOCK_METADATA_PTR[TIMESTAMP_IDX]"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(FEE_PARAMETERS_PTR)[NATIVE_ASSET_ID_SUFFIX_IDX],
+        exec_output.get_kernel_mem_word(FEE_PARAMETERS_PTR)[NATIVE_ASSET_ID_SUFFIX_IDX],
         inputs.tx_inputs().block_header().fee_parameters().native_asset_id().suffix(),
         "The native asset ID suffix should be stored at FEE_PARAMETERS_PTR[NATIVE_ASSET_ID_SUFFIX_IDX]"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(FEE_PARAMETERS_PTR)[NATIVE_ASSET_ID_PREFIX_IDX],
+        exec_output.get_kernel_mem_word(FEE_PARAMETERS_PTR)[NATIVE_ASSET_ID_PREFIX_IDX],
         inputs
             .tx_inputs()
             .block_header()
@@ -316,7 +316,7 @@ fn block_data_memory_assertions(process: &Process, inputs: &TransactionContext) 
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(FEE_PARAMETERS_PTR)[VERIFICATION_BASE_FEE_IDX],
+        exec_output.get_kernel_mem_word(FEE_PARAMETERS_PTR)[VERIFICATION_BASE_FEE_IDX],
         inputs
             .tx_inputs()
             .block_header()
@@ -327,20 +327,23 @@ fn block_data_memory_assertions(process: &Process, inputs: &TransactionContext) 
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NOTE_ROOT_PTR),
+        exec_output.get_kernel_mem_word(NOTE_ROOT_PTR),
         inputs.tx_inputs().block_header().note_root(),
         "The note root should be stored at the NOTE_ROOT_PTR"
     );
 }
 
-fn partial_blockchain_memory_assertions(process: &Process, prepared_tx: &TransactionContext) {
+fn partial_blockchain_memory_assertions(
+    exec_output: &ExecutionOutput,
+    prepared_tx: &TransactionContext,
+) {
     // update the partial blockchain to point to the block against which this transaction is being
     // executed
     let mut partial_blockchain = prepared_tx.tx_inputs().blockchain().clone();
     partial_blockchain.add_block(prepared_tx.tx_inputs().block_header().clone(), true);
 
     assert_eq!(
-        process.get_kernel_mem_word(PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR)[0],
+        exec_output.get_kernel_mem_word(PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR)[0],
         Felt::new(partial_blockchain.chain_length().as_u64()),
         "The number of leaves should be stored at the PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR"
     );
@@ -352,17 +355,17 @@ fn partial_blockchain_memory_assertions(process: &Process, prepared_tx: &Transac
         );
         let word_aligned_peak_idx = peak_idx * WORD_SIZE as u32;
         assert_eq!(
-            process.get_kernel_mem_word(PARTIAL_BLOCKCHAIN_PEAKS_PTR + word_aligned_peak_idx),
+            exec_output.get_kernel_mem_word(PARTIAL_BLOCKCHAIN_PEAKS_PTR + word_aligned_peak_idx),
             *peak
         );
     }
 }
 
-fn kernel_data_memory_assertions(process: &Process) {
+fn kernel_data_memory_assertions(exec_output: &ExecutionOutput) {
     // check that the number of kernel procedures stored in the memory is equal to the number of
     // procedures in the `TransactionKernel::PROCEDURES` array
     assert_eq!(
-        process.get_kernel_mem_word(NUM_KERNEL_PROCEDURES_PTR)[0].as_int(),
+        exec_output.get_kernel_mem_word(NUM_KERNEL_PROCEDURES_PTR)[0].as_int(),
         TransactionKernel::PROCEDURES.len() as u64,
         "Number of the kernel procedures should be stored at the NUM_KERNEL_PROCEDURES_PTR"
     );
@@ -371,16 +374,16 @@ fn kernel_data_memory_assertions(process: &Process) {
     // `TransactionKernel::PROCEDURES` array
     for (i, &proc_hash) in TransactionKernel::PROCEDURES.iter().enumerate() {
         assert_eq!(
-            process.get_kernel_mem_word(KERNEL_PROCEDURES_PTR + (i * WORD_SIZE) as u32),
+            exec_output.get_kernel_mem_word(KERNEL_PROCEDURES_PTR + (i * WORD_SIZE) as u32),
             proc_hash,
             "hash of kernel procedure at index `{i}` does not match the hash stored in memory"
         );
     }
 }
 
-fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext) {
+fn account_data_memory_assertions(exec_output: &ExecutionOutput, inputs: &TransactionContext) {
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_ID_AND_NONCE_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_ID_AND_NONCE_PTR),
         Word::new([
             inputs.account().id().suffix(),
             inputs.account().id().prefix().as_felt(),
@@ -391,25 +394,25 @@ fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_VAULT_ROOT_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_VAULT_ROOT_PTR),
         inputs.account().vault().root(),
         "The account vault root should be stored at NATIVE_ACCT_VAULT_ROOT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_STORAGE_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_STORAGE_COMMITMENT_PTR),
         inputs.account().storage().commitment(),
         "The account storage commitment should be stored at NATIVE_ACCT_STORAGE_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_ACCT_CODE_COMMITMENT_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_ACCT_CODE_COMMITMENT_PTR),
         inputs.account().code().commitment(),
         "account code commitment should be stored at NATIVE_ACCT_CODE_COMMITMENT_PTR"
     );
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR),
         Word::from([u16::try_from(inputs.account().storage().slots().len()).unwrap(), 0, 0, 0]),
         "The number of initialised storage slots should be stored at NATIVE_NUM_ACCT_STORAGE_SLOTS_PTR"
     );
@@ -422,7 +425,7 @@ fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext
         .enumerate()
     {
         assert_eq!(
-            process.get_kernel_mem_word(
+            exec_output.get_kernel_mem_word(
                 NATIVE_ACCT_STORAGE_SLOTS_SECTION_PTR + (i * WORD_SIZE) as u32
             ),
             Word::try_from(elements).unwrap(),
@@ -431,7 +434,7 @@ fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext
     }
 
     assert_eq!(
-        process.get_kernel_mem_word(NATIVE_NUM_ACCT_PROCEDURES_PTR),
+        exec_output.get_kernel_mem_word(NATIVE_NUM_ACCT_PROCEDURES_PTR),
         Word::from([u16::try_from(inputs.account().code().procedures().len()).unwrap(), 0, 0, 0]),
         "The number of procedures should be stored at NATIVE_NUM_ACCT_PROCEDURES_PTR"
     );
@@ -444,7 +447,7 @@ fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext
         .enumerate()
     {
         assert_eq!(
-            process
+            exec_output
                 .get_kernel_mem_word(NATIVE_ACCT_PROCEDURES_SECTION_PTR + (i * WORD_SIZE) as u32),
             Word::try_from(elements).unwrap(),
             "The account procedures and storage offsets should be stored starting at NATIVE_ACCT_PROCEDURES_SECTION_PTR"
@@ -453,12 +456,12 @@ fn account_data_memory_assertions(process: &Process, inputs: &TransactionContext
 }
 
 fn input_notes_memory_assertions(
-    process: &Process,
+    exec_output: &ExecutionOutput,
     inputs: &TransactionContext,
     note_args: &[Word],
 ) {
     assert_eq!(
-        process.get_kernel_mem_word(INPUT_NOTE_SECTION_PTR),
+        exec_output.get_kernel_mem_word(INPUT_NOTE_SECTION_PTR),
         Word::from([inputs.input_notes().num_notes(), 0, 0, 0]),
         "number of input notes should be stored at the INPUT_NOTES_OFFSET"
     );
@@ -467,7 +470,7 @@ fn input_notes_memory_assertions(
         let note = input_note.note();
 
         assert_eq!(
-            process.get_kernel_mem_word(
+            exec_output.get_kernel_mem_word(
                 INPUT_NOTE_NULLIFIER_SECTION_PTR + note_idx * WORD_SIZE as u32
             ),
             note.nullifier().as_word(),
@@ -475,55 +478,55 @@ fn input_notes_memory_assertions(
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_ID_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_ID_OFFSET),
             note.id().as_word(),
             "ID hash should be computed and stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_SERIAL_NUM_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_SERIAL_NUM_OFFSET),
             note.serial_num(),
             "note serial num should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_SCRIPT_ROOT_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_SCRIPT_ROOT_OFFSET),
             note.script().root(),
             "note script root should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_INPUTS_COMMITMENT_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_INPUTS_COMMITMENT_OFFSET),
             note.inputs().commitment(),
             "note input commitment should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_RECIPIENT_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_RECIPIENT_OFFSET),
             note.recipient().digest(),
             "note recipient should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_ASSETS_COMMITMENT_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_ASSETS_COMMITMENT_OFFSET),
             note.assets().commitment(),
             "note asset commitment should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_METADATA_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_METADATA_OFFSET),
             Word::from(note.metadata()),
             "note metadata should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_ARGS_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_ARGS_OFFSET),
             note_args[note_idx as usize],
             "note args should be stored at the correct offset"
         );
 
         assert_eq!(
-            read_note_element(process, note_idx, INPUT_NOTE_NUM_ASSETS_OFFSET),
+            exec_output.get_note_mem_word(note_idx, INPUT_NOTE_NUM_ASSETS_OFFSET),
             Word::from([<u32>::try_from(note.assets().num_assets()).unwrap(), 0, 0, 0]),
             "number of assets should be stored at the correct offset"
         );
@@ -531,8 +534,7 @@ fn input_notes_memory_assertions(
         for (asset, asset_idx) in note.assets().iter().cloned().zip(0_u32..) {
             let word: Word = asset.into();
             assert_eq!(
-                read_note_element(
-                    process,
+                exec_output.get_note_mem_word(
                     note_idx,
                     INPUT_NOTE_ASSETS_OFFSET + asset_idx * WORD_SIZE as u32
                 ),
@@ -772,9 +774,12 @@ fn test_get_blk_version() -> anyhow::Result<()> {
     end
     ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
-    assert_eq!(process.stack.get(0), tx_context.tx_inputs().block_header().version().into());
+    assert_eq!(
+        exec_output.get_stack_item(0),
+        tx_context.tx_inputs().block_header().version().into()
+    );
 
     Ok(())
 }
@@ -795,16 +800,12 @@ fn test_get_blk_timestamp() -> anyhow::Result<()> {
     end
     ";
 
-    let process = tx_context.execute_code(code)?;
+    let exec_output = tx_context.execute_code(code)?;
 
-    assert_eq!(process.stack.get(0), tx_context.tx_inputs().block_header().timestamp().into());
+    assert_eq!(
+        exec_output.get_stack_item(0),
+        tx_context.tx_inputs().block_header().timestamp().into()
+    );
 
     Ok(())
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-fn read_note_element(process: &Process, note_idx: u32, offset: MemoryOffset) -> Word {
-    process.get_kernel_mem_word(input_note_data_ptr(note_idx) + offset)
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -94,7 +94,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{Felt, ZERO};
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::create_public_p2any_note;
 use crate::{
     Auth,
@@ -777,7 +777,7 @@ fn test_get_blk_version() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code)?;
 
     assert_eq!(
-        exec_output.get_stack_item(0),
+        exec_output.get_stack_element(0),
         tx_context.tx_inputs().block_header().version().into()
     );
 
@@ -803,7 +803,7 @@ fn test_get_blk_timestamp() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code)?;
 
     assert_eq!(
-        exec_output.get_stack_item(0),
+        exec_output.get_stack_element(0),
         tx_context.tx_inputs().block_header().timestamp().into()
     );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -54,12 +54,12 @@ use miden_objects::transaction::{
     TransactionArgs,
     TransactionSummary,
 };
-use miden_objects::{FieldElement, Hasher, Word};
+use miden_objects::{Felt, FieldElement, Hasher, ONE, Word};
 use miden_processor::crypto::RpoRandomCoin;
 use miden_tx::auth::UnreachableAuth;
 use miden_tx::{TransactionExecutor, TransactionExecutorError};
 
-use super::{Felt, ONE};
+use crate::kernel_tests::tx::ProcessMemoryExt;
 use crate::utils::{create_public_p2any_note, create_spawn_note};
 use crate::{Auth, MockChain, TransactionContextBuilder};
 
@@ -191,19 +191,19 @@ fn test_block_procedures() -> anyhow::Result<()> {
     let process = &tx_context.execute_code(code)?;
 
     assert_eq!(
-        process.stack.get_word(0),
+        process.get_stack_word(0),
         tx_context.tx_inputs().block_header().commitment(),
         "top word on the stack should be equal to the block header commitment"
     );
 
     assert_eq!(
-        process.stack.get(4).as_int(),
+        process.get_stack_item(4).as_int(),
         tx_context.tx_inputs().block_header().timestamp() as u64,
         "fifth element on the stack should be equal to the timestamp of the last block creation"
     );
 
     assert_eq!(
-        process.stack.get(5).as_int(),
+        process.get_stack_item(5).as_int(),
         tx_context.tx_inputs().block_header().block_num().as_u64(),
         "sixth element on the stack should be equal to the block number"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -59,7 +59,7 @@ use miden_processor::crypto::RpoRandomCoin;
 use miden_tx::auth::UnreachableAuth;
 use miden_tx::{TransactionExecutor, TransactionExecutorError};
 
-use crate::kernel_tests::tx::ProcessMemoryExt;
+use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::{create_public_p2any_note, create_spawn_note};
 use crate::{Auth, MockChain, TransactionContextBuilder};
 
@@ -197,13 +197,13 @@ fn test_block_procedures() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        exec_output.get_stack_item(4).as_int(),
+        exec_output.get_stack_element(4).as_int(),
         tx_context.tx_inputs().block_header().timestamp() as u64,
         "fifth element on the stack should be equal to the timestamp of the last block creation"
     );
 
     assert_eq!(
-        exec_output.get_stack_item(5).as_int(),
+        exec_output.get_stack_element(5).as_int(),
         tx_context.tx_inputs().block_header().block_num().as_u64(),
         "sixth element on the stack should be equal to the block number"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -188,22 +188,22 @@ fn test_block_procedures() -> anyhow::Result<()> {
         end
         ";
 
-    let process = &tx_context.execute_code(code)?;
+    let exec_output = &tx_context.execute_code(code)?;
 
     assert_eq!(
-        process.get_stack_word(0),
+        exec_output.get_stack_word(0),
         tx_context.tx_inputs().block_header().commitment(),
         "top word on the stack should be equal to the block header commitment"
     );
 
     assert_eq!(
-        process.get_stack_item(4).as_int(),
+        exec_output.get_stack_item(4).as_int(),
         tx_context.tx_inputs().block_header().timestamp() as u64,
         "fifth element on the stack should be equal to the timestamp of the last block creation"
     );
 
     assert_eq!(
-        process.get_stack_item(5).as_int(),
+        exec_output.get_stack_item(5).as_int(),
         tx_context.tx_inputs().block_header().block_num().as_u64(),
         "sixth element on the stack should be equal to the block number"
     );

--- a/crates/miden-testing/src/lib.rs
+++ b/crates/miden-testing/src/lib.rs
@@ -21,7 +21,6 @@ pub use tx_context::{TransactionContext, TransactionContextBuilder};
 
 pub mod executor;
 
-pub use mock_host::MockHost;
 mod mock_host;
 
 pub mod utils;

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -3,7 +3,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use miden_lib::StdLibrary;
-use miden_lib::transaction::{EventId, TransactionEvent, TransactionEventError};
+use miden_lib::transaction::{EventId, TransactionEvent};
 use miden_objects::Word;
 use miden_processor::{
     AdviceMutation,
@@ -27,7 +27,13 @@ use crate::TransactionContext;
 /// - There is special handling of EMPTY_DIGEST in account procedure index map.
 /// - This host uses `MemAdviceProvider` which is instantiated from the passed in advice inputs.
 pub(crate) struct MockHost<'store> {
+    /// The underlying [`TransactionExecutorHost`] that the mock host will forward requests to.
     exec_host: TransactionExecutorHost<'store, 'static, TransactionContext, UnreachableAuth>,
+
+    /// The set of event IDs that the mock host will forward to the [`TransactionExecutorHost`].
+    ///
+    /// Event IDs that are not in this set are not handled. This can be useful in certain test
+    /// scenarios.
     handled_events: BTreeSet<EventId>,
 }
 

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -220,7 +220,9 @@ impl TransactionContextBuilder {
         self
     }
 
-    /// TODO
+    /// Disables lazy loading.
+    ///
+    /// This is the opposite of [`Self::enable_lazy_loading`] - see its docs for details.
     pub fn disable_lazy_loading(mut self) -> Self {
         self.is_lazy_loading_enabled = false;
         self

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -220,6 +220,12 @@ impl TransactionContextBuilder {
         self
     }
 
+    /// TODO
+    pub fn disable_lazy_loading(mut self) -> Self {
+        self.is_lazy_loading_enabled = false;
+        self
+    }
+
     /// Extend the note arguments map with the provided one.
     pub fn extend_note_args(mut self, note_args: BTreeMap<NoteId, Word>) -> Self {
         self.note_args.extend(note_args);
@@ -346,6 +352,7 @@ impl TransactionContextBuilder {
             authenticator: self.authenticator,
             advice_inputs: self.advice_inputs,
             source_manager: self.source_manager,
+            is_lazy_loading_enabled: self.is_lazy_loading_enabled,
         })
     }
 }

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -59,9 +59,9 @@ pub struct TransactionContext {
     pub(super) tx_args: TransactionArgs,
     pub(super) tx_inputs: TransactionInputs,
     pub(super) mast_store: TransactionMastStore,
-    pub(super) advice_inputs: AdviceInputs,
     pub(super) authenticator: Option<MockAuthenticator>,
     pub(super) source_manager: Arc<dyn SourceManagerSync>,
+    pub(super) advice_inputs: AdviceInputs,
     pub(super) is_lazy_loading_enabled: bool,
 }
 
@@ -146,7 +146,9 @@ impl TransactionContext {
             .extend_advice_inputs(advice_inputs)
             .execute_program(program)
     }
+}
 
+impl TransactionContext {
     /// Executes the transaction through a [TransactionExecutor]
     pub async fn execute(self) -> Result<ExecutedTransaction, TransactionExecutorError> {
         let account_id = self.account().id();

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -1,6 +1,5 @@
 use alloc::borrow::ToOwned;
 use alloc::collections::{BTreeMap, BTreeSet};
-use alloc::rc::Rc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
@@ -20,26 +19,28 @@ use miden_objects::transaction::{
     TransactionArgs,
     TransactionInputs,
 };
+use miden_processor::fast::ExecutionOutput;
 use miden_processor::{
     AdviceInputs,
     ExecutionError,
     FutureMaybeSend,
     MastForest,
     MastForestStore,
-    Process,
     Word,
 };
-use miden_tx::auth::BasicAuthenticator;
+use miden_tx::auth::{BasicAuthenticator, UnreachableAuth};
 use miden_tx::{
+    AccountProcedureIndexMap,
     DataStore,
     DataStoreError,
+    ScriptMastForestStore,
     TransactionExecutor,
     TransactionExecutorError,
+    TransactionExecutorHost,
     TransactionMastStore,
 };
 use rand_chacha::ChaCha20Rng;
 
-use crate::MockHost;
 use crate::executor::CodeExecutor;
 use crate::tx_context::builder::MockAuthenticator;
 
@@ -82,7 +83,7 @@ impl TransactionContext {
     /// # Panics
     ///
     /// - If the provided `code` is not a valid program.
-    pub fn execute_code(&self, code: &str) -> Result<Process, ExecutionError> {
+    pub fn execute_code(&self, code: &str) -> Result<ExecutionOutput, ExecutionError> {
         let (stack_inputs, advice_inputs) = TransactionKernel::prepare_inputs(
             &self.tx_inputs,
             &self.tx_args,
@@ -104,27 +105,38 @@ impl TransactionContext {
             .assemble_program(virtual_source_file)
             .expect("code was not well formed");
 
-        let mast_store = Rc::new(TransactionMastStore::new());
+        // Load transaction kernel and the program into the mast forest in self.
+        // Note that native and foreign account's code are already loaded by the
+        // TransactionContextBuilder.
+        self.mast_store.insert(TransactionKernel::library().mast_forest().clone());
+        self.mast_store.insert(program.mast_forest().clone());
 
-        mast_store.insert(program.mast_forest().clone());
-        mast_store.insert(TransactionKernel::library().mast_forest().clone());
-        mast_store.load_account_code(self.account().code());
-        for acc_inputs in self.tx_args.foreign_account_inputs() {
-            mast_store.load_account_code(acc_inputs.code());
-        }
+        let account_procedure_idx_map = AccountProcedureIndexMap::new(
+            [self.tx_inputs().account().code()]
+                .into_iter()
+                .chain(self.tx_args().foreign_account_inputs().iter().map(|inputs| inputs.code())),
+        )
+        .expect("TODO");
+
+        // The ref block is unimportant when using execute_code so we can set it to any value.
+        let ref_block = self.tx_inputs().block_header().block_num();
+
+        let host = TransactionExecutorHost::<'_, '_, _, UnreachableAuth>::new(
+            &PartialAccount::from(self.account()),
+            self.tx_inputs().input_notes().clone(),
+            self,
+            ScriptMastForestStore::default(),
+            account_procedure_idx_map,
+            None,
+            ref_block,
+            self.source_manager(),
+        );
 
         let advice_inputs = advice_inputs.into_advice_inputs();
-        CodeExecutor::new(
-            MockHost::new(
-                self.tx_inputs().account().code(),
-                mast_store,
-                self.tx_args.foreign_account_inputs(),
-            )
-            .with_source_manager(self.source_manager()),
-        )
-        .stack_inputs(stack_inputs)
-        .extend_advice_inputs(advice_inputs)
-        .execute_program(program)
+        CodeExecutor::new(host)
+            .stack_inputs(stack_inputs)
+            .extend_advice_inputs(advice_inputs)
+            .execute_program(program)
     }
 
     /// Executes the transaction through a [TransactionExecutor]

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -118,7 +118,7 @@ impl TransactionContext {
                 .into_iter()
                 .chain(self.tx_args().foreign_account_inputs().iter().map(|inputs| inputs.code())),
         )
-        .expect("TODO");
+        .expect("constructing account procedure index map should work");
 
         // The ref block is unimportant when using execute_code so we can set it to any value.
         let ref_block = self.tx_inputs().block_header().block_num();

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -146,9 +146,7 @@ impl TransactionContext {
             .extend_advice_inputs(advice_inputs)
             .execute_program(program)
     }
-}
 
-impl TransactionContext {
     /// Executes the transaction through a [TransactionExecutor]
     pub async fn execute(self) -> Result<ExecutedTransaction, TransactionExecutorError> {
         let account_id = self.account().id();

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use miden_lib::testing::note::NoteBuilder;
-use miden_lib::transaction::{TransactionKernel, memory};
+use miden_lib::transaction::TransactionKernel;
 use miden_objects::Word;
 use miden_objects::account::AccountId;
 use miden_objects::asset::Asset;
@@ -62,13 +62,6 @@ macro_rules! assert_transaction_executor_error {
             Err(err) => panic!("Execution error was not as expected: {err}"),
         }
     };
-}
-
-// TEST UTILITIES
-// ================================================================================================
-
-pub fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
-    memory::INPUT_NOTE_DATA_SECTION_OFFSET + note_idx * memory::NOTE_MEM_SIZE
 }
 
 // HELPER NOTES

--- a/crates/miden-tx/src/host/link_map.rs
+++ b/crates/miden-tx/src/host/link_map.rs
@@ -294,7 +294,7 @@ enum SetOperation {
     InsertAfterEntry = 2,
 }
 
-// PROCESS MEMORY ABSTRACTION
+// MEMORY VIEWER
 // ================================================================================================
 
 mod private {
@@ -309,6 +309,8 @@ mod private {
 ///
 /// This should all go away again once we change a LinkMap's implementation to be based on an actual
 /// map type instead of viewing a process' memory directly.
+///
+/// This trait is sealed and should not be implemented by users.
 pub trait MemoryViewer: private::MemoryViewerSeal {
     fn get_kernel_mem_element(&self, addr: u32) -> Option<Felt>;
     fn get_kernel_mem_word(&self, addr: u32) -> Option<Word>;
@@ -331,12 +333,10 @@ impl MemoryViewer for ExecutionOutput {
     fn get_kernel_mem_element(&self, addr: u32) -> Option<Felt> {
         // TODO: Use Memory::read_element once it no longer requires &mut self.
         // https://github.com/0xMiden/miden-vm/issues/2237
-        // Copy of the function in Miden VM.
-        fn split_addr(addr: u32) -> (u32, u32) {
-            let idx = addr % miden_objects::WORD_SIZE as u32;
-            (addr - idx, idx)
-        }
-        let (word_addr, idx) = split_addr(addr);
+
+        // Copy of how Memory::read_element is implemented in Miden VM.
+        let idx = addr % miden_objects::WORD_SIZE as u32;
+        let word_addr = addr - idx;
 
         Some(self.get_kernel_mem_word(word_addr)?[idx as usize])
     }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -5,7 +5,7 @@ use account_delta_tracker::AccountDeltaTracker;
 mod storage_delta_tracker;
 
 mod link_map;
-pub use link_map::LinkMap;
+pub use link_map::{LinkMap, MemoryViewer};
 
 mod account_procedures;
 pub use account_procedures::AccountProcedureIndexMap;

--- a/crates/miden-tx/src/lib.rs
+++ b/crates/miden-tx/src/lib.rs
@@ -22,7 +22,7 @@ pub use executor::{
 };
 
 mod host;
-pub use host::{AccountProcedureIndexMap, LinkMap, ScriptMastForestStore};
+pub use host::{AccountProcedureIndexMap, LinkMap, MemoryViewer, ScriptMastForestStore};
 
 mod prover;
 pub use prover::{


### PR DESCRIPTION

Change the implementation of `TransactionContext::execute_code` to use the `FastProcessor`.

This affected mainly:
- The way we access the stack and memory after executing some arbitrary code. This relies more heavily on an extension trait now to make test code succinct and convenient to write/read.
- The `MockHost` was originally intended to be removed and fully replaced by `TransactionExecutorHost`. That almost worked, but for some tests, the executor host actually does too much. For instance, it handles delta tracking and output note creation which is unnecessary for testing and produces unimportant errors in some tests, so it is standing in the way of testing. For that reason, the `MockHost` is kept but is just a very thin wrapper around the executor host with the only difference being that it handles a small subset of `TransactionEvent`s. This seems fine because the code is fairly simple and shouldn't be hard to maintain.
- The `LinkMap` implementation. It was previously relying on a `ProcessState` directly but now it needs to work both on a `ProcessState` and an `ExecutionOutput`. An abstraction over both was added for that, but long-term this should ideally go away once we change a `LinkMap` to be a copy of the in-kernel link map, e.g. using a `BTreeMap` or something similar. See `MemoryViewer` docs for more details.

Related to the second point, the intention of the issue was to remove everything related to `TransactionContextBuilder::enable_lazy_loading`, but:
- `enable_lazy_loading` specifically will be removed with the PR that closes #1473.
- The internal flag still will need to continue to exist because we now need the negative version of it, i.e. `disable_lazy_loading`. There is just one test (`test_get_balance_non_fungible_fails`) that needs it, but I couldn't think of a better way to work around this. For now, lazy loading is disabled by default, but that will change with another PR and if lazy loading is enabled, the test fails with 

```
Error: error during processing of event with id EventId(3463669078242126216) in on_event handler

Caused by:
    0: provided faucet ID is not valid for fungible assets
    1: faucet id 0xbc0000000000ca300000dd000000ef of type NonFungibleFaucet must be of type FungibleFaucet for fungible assets
```

Also note that if we do https://github.com/0xMiden/miden-base/issues/1919 then no public API would have any enable/disable lazy loading, because only the internal tool would allow for `execute_code` and only it needs the disable functionality.

**Follow-up**

I'll make a follow-up PR to make `TransactionContext::execute_code` async.

**Random note**

Long-term I'd like to make `CodeExecutor`, `MockHost` and `TransactionContext::execute_code` completely internal to `miden-testing`, i.e. only use them as testing tools for miden-base. This makes it easier to evolve them in the future, because currently, we technically always have to keep in mind that we're changing the public API. This should also be fine because they are primarily used to test the transaction kernel, which is something that should not be necessary outside of miden-base.
There is an argument that `CodeExecutor` might be useful for external users to write unit test for their code, but using Miden VM directly for this is pretty easy as well, as evident by the few lines of code with which `CodeExecutor` is implemented.
For this reason, some APIs were already made `#[cfg(test)]`.

