### PR TITLE
feat: Track minimal data in partial account and always enable lazy loading in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added `Address` serialization and deserialization ([#1937](https://github.com/0xMiden/miden-base/issues/1937))
 - Added `StorageMap::{num_entries, num_leaves}` to retrieve the number of entries in a storage map ([#1935]https://github.com/0xMiden/miden-base/pull/1935).
 - Added `AssetVault::{num_assets, num_leaves, inner_nodes}` ([#1939]https://github.com/0xMiden/miden-base/pull/1939).
+- [BREAKING] Change `Account` to `PartialAccount` conversion to generally track only minimal data ([#1963]https://github.com/0xMiden/miden-base/pull/1963).
 
 ### Changes
 

--- a/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
+++ b/crates/miden-lib/asm/kernels/transaction/lib/asset_vault.masm
@@ -82,6 +82,10 @@ end
 #! manipulation from a malicious host. Therefore this should only be used when the inclusion of the
 #! peeked balance is verified at a later point.
 #!
+#! WARNING: This is a generic vault procedure and so it cannot emit an event to lazy load asset
+#! merkle paths from the merkle store, since this is only possible for the account vault. Ensure
+#! that the merkle paths are present prior to calling.
+#!
 #! To get the verified balance, use get_balance.
 #!
 #! Inputs:  [faucet_id_prefix, faucet_id_suffix, vault_root_ptr]

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -68,10 +68,6 @@ impl TransactionAdviceInputs {
             inputs.add_map_entry(account_id_key, seed.to_vec());
         }
 
-        // --- foreign account injection --------------------------------------
-        // TODO: Remove?
-        // inputs.add_foreign_accounts(tx_args.foreign_account_inputs())?;
-
         // any extra user-supplied advice
         inputs.extend(tx_args.advice_inputs().clone());
 

--- a/crates/miden-lib/src/transaction/inputs.rs
+++ b/crates/miden-lib/src/transaction/inputs.rs
@@ -69,7 +69,8 @@ impl TransactionAdviceInputs {
         }
 
         // --- foreign account injection --------------------------------------
-        inputs.add_foreign_accounts(tx_args.foreign_account_inputs())?;
+        // TODO: Remove?
+        // inputs.add_foreign_accounts(tx_args.foreign_account_inputs())?;
 
         // any extra user-supplied advice
         inputs.extend(tx_args.advice_inputs().clone());

--- a/crates/miden-objects/src/account/partial.rs
+++ b/crates/miden-objects/src/account/partial.rs
@@ -3,8 +3,8 @@ use alloc::string::ToString;
 use miden_core::utils::{Deserializable, Serializable};
 use miden_core::{Felt, ZERO};
 
-use super::{Account, AccountCode, AccountId, PartialStorage};
-use crate::account::{hash_account, validate_account_seed};
+use super::{Account, AccountCode, AccountId, PartialStorage, StorageSlot};
+use crate::account::{PartialStorageMap, hash_account, validate_account_seed};
 use crate::asset::PartialVault;
 use crate::utils::serde::DeserializationError;
 use crate::{AccountError, Word};
@@ -170,12 +170,32 @@ impl From<&Account> for PartialAccount {
     /// Constructs a [`PartialAccount`] from the provided account with an empty seed, assuming it is
     /// an existing account.
     fn from(account: &Account) -> Self {
+        let partial_storage = if account.is_new() {
+            PartialStorage::from(account.storage())
+        } else {
+            let storage_maps = account.storage().slots().iter().filter_map(|slot| match slot {
+                StorageSlot::Value(_) => None,
+                StorageSlot::Map(storage_map) => {
+                    let mut partial_storage_map = PartialStorageMap::default();
+                    let key = Word::empty();
+                    let witness = storage_map.open(&key);
+                    partial_storage_map
+                        .add(witness)
+                        .expect("adding the first proof should never error");
+                    Some(partial_storage_map)
+                },
+            });
+
+            PartialStorage::new(account.storage().to_header(), storage_maps)
+                .expect("partial storage should be internally consistent")
+        };
+
         Self::new(
             account.id(),
             account.nonce(),
             account.code().clone(),
-            account.storage().into(),
-            account.vault().into(),
+            partial_storage,
+            PartialVault::from(account.vault()),
             account.seed(),
         )
         .expect("account should ensure that seed is valid for account")

--- a/crates/miden-objects/src/account/partial.rs
+++ b/crates/miden-objects/src/account/partial.rs
@@ -3,8 +3,8 @@ use alloc::string::ToString;
 use miden_core::utils::{Deserializable, Serializable};
 use miden_core::{Felt, ZERO};
 
-use super::{Account, AccountCode, AccountId, PartialStorage, StorageSlot};
-use crate::account::{PartialStorageMap, hash_account, validate_account_seed};
+use super::{Account, AccountCode, AccountId, PartialStorage};
+use crate::account::{hash_account, validate_account_seed};
 use crate::asset::PartialVault;
 use crate::utils::serde::DeserializationError;
 use crate::{AccountError, Word};
@@ -167,27 +167,25 @@ impl PartialAccount {
 }
 
 impl From<&Account> for PartialAccount {
-    /// Constructs a [`PartialAccount`] from the provided account with an empty seed, assuming it is
-    /// an existing account.
+    /// Constructs a [`PartialAccount`] from the provided account.
+    ///
+    /// The behavior is different whether the [`Account::is_new`] or not:
+    /// - For new accounts, the storage is tracked in full. This is because transactions that create
+    ///   accounts need the full state.
+    /// - For existing accounts, the storage is tracked minimally, i.e. the minimal necessary data
+    ///   is included.
+    ///
+    /// In both cases, the asset vault is minimally tracked.
+    ///
+    /// For precise control over how an account is converted to a partial account, use
+    /// [`PartialAccount::new`].
     fn from(account: &Account) -> Self {
         let partial_storage = if account.is_new() {
-            PartialStorage::from(account.storage())
+            // This is somewhat expensive, but it allows us to do this conversion from &Account and
+            // it penalizes only the rare case (new accounts).
+            PartialStorage::new_full(account.storage.clone())
         } else {
-            let storage_maps = account.storage().slots().iter().filter_map(|slot| match slot {
-                StorageSlot::Value(_) => None,
-                StorageSlot::Map(storage_map) => {
-                    let mut partial_storage_map = PartialStorageMap::default();
-                    let key = Word::empty();
-                    let witness = storage_map.open(&key);
-                    partial_storage_map
-                        .add(witness)
-                        .expect("adding the first proof should never error");
-                    Some(partial_storage_map)
-                },
-            });
-
-            PartialStorage::new(account.storage().to_header(), storage_maps)
-                .expect("partial storage should be internally consistent")
+            PartialStorage::new_minimal(account.storage())
         };
 
         Self::new(

--- a/crates/miden-objects/src/account/partial.rs
+++ b/crates/miden-objects/src/account/partial.rs
@@ -175,7 +175,8 @@ impl From<&Account> for PartialAccount {
     /// - For existing accounts, the storage is tracked minimally, i.e. the minimal necessary data
     ///   is included.
     ///
-    /// In both cases, the asset vault is minimally tracked.
+    /// Because new accounts always have empty vaults, in both cases, the asset vault is a minimal
+    /// representation.
     ///
     /// For precise control over how an account is converted to a partial account, use
     /// [`PartialAccount::new`].

--- a/crates/miden-objects/src/account/storage/map/partial.rs
+++ b/crates/miden-objects/src/account/storage/map/partial.rs
@@ -60,6 +60,35 @@ impl PartialStorageMap {
         Ok(PartialStorageMap { partial_smt, entries: map })
     }
 
+    /// Converts a [`StorageMap`] into a partial storage representation.
+    ///
+    /// The resulting [`PartialStorageMap`] will contain the _full_ entries and merkle paths of the
+    /// original storage map.
+    pub fn new_full(storage_map: StorageMap) -> Self {
+        let partial_smt = PartialSmt::from(storage_map.smt);
+        let entries = storage_map.entries;
+
+        PartialStorageMap { partial_smt, entries }
+    }
+
+    /// Converts a [`StorageMap`] into a partial storage representation.
+    ///
+    /// The resulting [`PartialStorageMap`] will contain only a single, unspecified key-value pair
+    /// in order to have the same root as the original storage map. Is it otherwise the most
+    /// _minimal_ representation of the storage map.
+    pub fn new_minimal(storage_map: &StorageMap) -> Self {
+        let mut partial_map = PartialStorageMap::default();
+
+        // Construct a partial storage map that tracks the empty word, but none of the assets that
+        // are actually in the asset tree. That way, the partial map has the same root as the full
+        // map. This is the most minimal and correct partial map we can build.
+        partial_map
+            .add(storage_map.open(&Word::empty()))
+            .expect("adding the first proof should never fail");
+
+        partial_map
+    }
+
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -128,15 +157,6 @@ impl PartialStorageMap {
     pub fn add(&mut self, witness: StorageMapWitness) -> Result<(), MerkleError> {
         self.entries.extend(witness.entries().map(|(key, value)| (*key, *value)));
         self.partial_smt.add_proof(SmtProof::from(witness))
-    }
-}
-
-impl From<StorageMap> for PartialStorageMap {
-    fn from(value: StorageMap) -> Self {
-        let smt = value.smt;
-        let map = value.entries;
-
-        PartialStorageMap { partial_smt: smt.into(), entries: map }
     }
 }
 

--- a/crates/miden-objects/src/asset/vault/partial.rs
+++ b/crates/miden-objects/src/asset/vault/partial.rs
@@ -142,10 +142,17 @@ impl PartialVault {
 }
 
 impl From<&AssetVault> for PartialVault {
-    fn from(value: &AssetVault) -> Self {
-        let vault_partial_smt = value.asset_tree.clone().into();
+    fn from(vault: &AssetVault) -> Self {
+        // Construct a partial vault that tracks the empty word, but none of the assets
+        // that are actually in the asset tree. That way, the partial vault has the same
+        // root as the full vault, but will not add any relevant merkle paths to the
+        // merkle store, which will test lazy loading of assets.
+        let mut partial_vault = PartialVault::default();
+        partial_vault
+            .add(vault.open(Word::empty()))
+            .expect("adding the first proof should never fail");
 
-        PartialVault { partial_smt: vault_partial_smt }
+        partial_vault
     }
 }
 

--- a/crates/miden-objects/src/asset/vault/partial.rs
+++ b/crates/miden-objects/src/asset/vault/partial.rs
@@ -143,11 +143,11 @@ impl PartialVault {
 
 impl From<&AssetVault> for PartialVault {
     fn from(vault: &AssetVault) -> Self {
-        // Construct a partial vault that tracks the empty word, but none of the assets
-        // that are actually in the asset tree. That way, the partial vault has the same
-        // root as the full vault, but will not add any relevant merkle paths to the
-        // merkle store, which will test lazy loading of assets.
         let mut partial_vault = PartialVault::default();
+
+        // Construct a partial vault that tracks the empty word, but none of the assets that are
+        // actually in the asset tree. That way, the partial vault has the same root as the full
+        // vault. This is the most minimal and correct partial vault we can build.
         partial_vault
             .add(vault.open(Word::empty()))
             .expect("adding the first proof should never fail");

--- a/crates/miden-objects/src/transaction/tx_args.rs
+++ b/crates/miden-objects/src/transaction/tx_args.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
@@ -6,7 +6,7 @@ use miden_crypto::dsa::rpo_falcon512::PublicKey;
 use miden_crypto::merkle::InnerNodeInfo;
 use miden_processor::MastNodeExt;
 
-use super::{AccountInputs, Felt, Hasher, Word};
+use super::{Felt, Hasher, Word};
 use crate::account::Signature;
 use crate::note::{NoteId, NoteRecipient};
 use crate::utils::serde::{
@@ -40,13 +40,12 @@ use crate::{EMPTY_WORD, MastForest, MastNodeId};
 ///   this argument is not specified, the [`EMPTY_WORD`] would be used as a default value. If the
 ///   [AdviceInputs] are propagated with some user defined map entries, this argument could be used
 ///   as a key to access the corresponding value.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionArgs {
     tx_script: Option<TransactionScript>,
     tx_script_args: Word,
     note_args: BTreeMap<NoteId, Word>,
     advice_inputs: AdviceInputs,
-    foreign_account_inputs: Vec<AccountInputs>,
     auth_args: Word,
 }
 
@@ -56,7 +55,7 @@ impl TransactionArgs {
 
     /// Returns new [TransactionArgs] instantiated with the provided transaction script, advice
     /// map and foreign account inputs.
-    pub fn new(advice_map: AdviceMap, foreign_account_inputs: Vec<AccountInputs>) -> Self {
+    pub fn new(advice_map: AdviceMap) -> Self {
         let advice_inputs = AdviceInputs { map: advice_map, ..Default::default() };
 
         Self {
@@ -64,7 +63,6 @@ impl TransactionArgs {
             tx_script_args: EMPTY_WORD,
             note_args: Default::default(),
             advice_inputs,
-            foreign_account_inputs,
             auth_args: EMPTY_WORD,
         }
     }
@@ -139,19 +137,6 @@ impl TransactionArgs {
     /// Returns a reference to the internal [AdviceInputs].
     pub fn advice_inputs(&self) -> &AdviceInputs {
         &self.advice_inputs
-    }
-
-    /// Returns a reference to the foreign account inputs in the transaction arguments.
-    pub fn foreign_account_inputs(&self) -> &[AccountInputs] {
-        &self.foreign_account_inputs
-    }
-
-    /// Collects and returns a set containing all code commitments from foreign accounts.
-    pub fn to_foreign_account_code_commitments(&self) -> BTreeSet<Word> {
-        self.foreign_account_inputs()
-            .iter()
-            .map(|acc| acc.code().commitment())
-            .collect()
     }
 
     /// Returns a reference to the authentication procedure argument, or [`EMPTY_WORD`] if the
@@ -236,13 +221,18 @@ impl TransactionArgs {
     }
 }
 
+impl Default for TransactionArgs {
+    fn default() -> Self {
+        Self::new(AdviceMap::default())
+    }
+}
+
 impl Serializable for TransactionArgs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.tx_script.write_into(target);
         self.tx_script_args.write_into(target);
         self.note_args.write_into(target);
         self.advice_inputs.write_into(target);
-        self.foreign_account_inputs.write_into(target);
         self.auth_args.write_into(target);
     }
 }
@@ -253,7 +243,6 @@ impl Deserializable for TransactionArgs {
         let tx_script_args = Word::read_from(source)?;
         let note_args = BTreeMap::<NoteId, Word>::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
-        let foreign_account_inputs = Vec::<AccountInputs>::read_from(source)?;
         let auth_args = Word::read_from(source)?;
 
         Ok(Self {
@@ -261,7 +250,6 @@ impl Deserializable for TransactionArgs {
             tx_script_args,
             note_args,
             advice_inputs,
-            foreign_account_inputs,
             auth_args,
         })
     }
@@ -344,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_tx_args_serialization() {
-        let tx_args = TransactionArgs::new(AdviceMap::default(), std::vec::Vec::default());
+        let tx_args = TransactionArgs::new(AdviceMap::default());
         let bytes: std::vec::Vec<u8> = tx_args.to_bytes();
         let decoded = TransactionArgs::read_from_bytes(&bytes).unwrap();
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -1,3 +1,5 @@
+use std::string::ToString;
+
 use assert_matches::assert_matches;
 use miden_lib::errors::tx_kernel_errors::{
     ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW,
@@ -8,6 +10,7 @@ use miden_lib::errors::tx_kernel_errors::{
 };
 use miden_lib::transaction::memory;
 use miden_objects::account::AccountId;
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
 use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
@@ -523,7 +526,9 @@ fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(non_fungible_asset)
     );
 
-    let exec_output = &tx_context.execute_code2(&code)?;
+    let exec_output = &tx_context
+        .execute_code(&code)
+        .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))?;
 
     assert_eq!(
         exec_output.get_stack_word(0),

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -76,6 +76,11 @@ fn peek_balance_returns_correct_amount() -> anyhow::Result<()> {
             push.{suffix} push.{prefix}
             # => [prefix, suffix, account_vault_root_ptr, balance]
 
+            # emit an event to fetch the merkle path for the asset since peek_balance does not do
+            # that
+            emit.event("miden::account::vault_before_get_balance")
+            # => [prefix, suffix, account_vault_root_ptr, balance]
+
             exec.asset_vault::peek_balance
             # => [peeked_balance]
 
@@ -518,7 +523,7 @@ fn test_remove_non_fungible_asset_success() -> anyhow::Result<()> {
         FUNGIBLE_ASSET = Word::from(non_fungible_asset)
     );
 
-    let exec_output = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context.execute_code2(&code)?;
 
     assert_eq!(
         exec_output.get_stack_word(0),

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -16,8 +16,10 @@ use miden_lib::transaction::memory::{
 };
 use miden_lib::transaction::{EXPIRATION_BLOCK_ELEMENT_IDX, TransactionKernel};
 use miden_lib::utils::ScriptBuilder;
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::Word;
 use miden_objects::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
+use miden_objects::assembly::diagnostics::miette;
 use miden_objects::asset::{Asset, AssetVault, FungibleAsset};
 use miden_objects::note::{NoteTag, NoteType};
 use miden_objects::testing::account_id::{
@@ -445,7 +447,9 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
     end
     ";
 
-    let exec_output = &tx_context.execute_code(code_template)?;
+    let exec_output = &tx_context
+        .execute_code(code_template)
+        .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))?;
 
     // Default value should be equal to u32::MAX, set in the prologue
     assert_eq!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -9,35 +9,25 @@ use miden_lib::errors::tx_kernel_errors::{
 };
 use miden_lib::testing::mock_account::MockAccountExt;
 use miden_lib::testing::note::NoteBuilder;
+use miden_lib::transaction::EXPIRATION_BLOCK_ELEMENT_IDX;
 use miden_lib::transaction::memory::{
     NOTE_MEM_SIZE,
     OUTPUT_NOTE_ASSET_COMMITMENT_OFFSET,
     OUTPUT_NOTE_SECTION_OFFSET,
 };
-use miden_lib::transaction::{EXPIRATION_BLOCK_ELEMENT_IDX, TransactionKernel};
 use miden_lib::utils::ScriptBuilder;
-use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::Word;
 use miden_objects::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
-use miden_objects::assembly::diagnostics::miette;
-use miden_objects::asset::{Asset, AssetVault, FungibleAsset};
+use miden_objects::asset::{Asset, FungibleAsset};
 use miden_objects::note::{NoteTag, NoteType};
 use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
-    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
-    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_3,
     ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_SENDER,
 };
-use miden_objects::testing::constants::{
-    CONSUMED_ASSET_1_AMOUNT,
-    CONSUMED_ASSET_2_AMOUNT,
-    CONSUMED_ASSET_3_AMOUNT,
-};
 use miden_objects::transaction::{OutputNote, OutputNotes};
 use miden_processor::{Felt, ONE};
-use rand::rng;
 
 use super::{ZERO, create_mock_notes_procedure};
 use crate::kernel_tests::tx::ExecutionOutputExt;
@@ -214,142 +204,109 @@ fn test_compute_output_note_id() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_epilogue_asset_preservation_violation_too_few_input() -> anyhow::Result<()> {
+/// Tests that a transaction fails due to the asset preservation rules when the input note has an
+/// asset with amount 100 and the output note has the same asset with amount 200.
+#[tokio::test]
+async fn epilogue_fails_when_num_output_assets_exceed_num_input_assets() -> anyhow::Result<()> {
+    // Create an input asset with amount 100 and an output asset with amount 200.
+    let input_asset = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?, 100)?;
+    let output_asset = input_asset.add(input_asset)?;
+
     let mut builder = MockChain::builder();
-    let account = builder
-        .add_existing_mock_account_with_assets(Auth::IncrNonce, AssetVault::mock().assets())?;
+    let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
+    // Add an input note that (automatically) adds its assets to the transaction's input vault, but
+    // _does not_ add the asset to the account. This is just to keep the test conceptually simple -
+    // there is no account involved.
+    let input_note = NoteBuilder::new(account.id(), *builder.rng_mut())
+        .add_assets([Asset::from(input_asset)])
+        .build()?;
+    builder.add_output_note(OutputNote::Full(input_note.clone()));
     let mock_chain = builder.build()?;
-
-    let fungible_asset_1: Asset = FungibleAsset::new(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?,
-        CONSUMED_ASSET_1_AMOUNT,
-    )?
-    .into();
-    let fungible_asset_2: Asset = FungibleAsset::new(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?,
-        CONSUMED_ASSET_2_AMOUNT,
-    )?
-    .into();
-
-    let output_note_1 = NoteBuilder::new(account.id(), rng())
-        .add_assets([fungible_asset_1])
-        .dynamically_linked_libraries(TransactionKernel::mock_libraries())
-        .build()?;
-    let output_note_2 = NoteBuilder::new(account.id(), rng())
-        .add_assets([fungible_asset_2])
-        .dynamically_linked_libraries(TransactionKernel::mock_libraries())
-        .build()?;
-
-    let input_note = create_spawn_note([&output_note_1, &output_note_2])?;
-
-    let tx_context = mock_chain
-        .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[input_note])?
-        .extend_expected_output_notes(vec![
-            OutputNote::Full(output_note_1),
-            OutputNote::Full(output_note_2),
-        ])
-        .build()?;
-
-    let output_notes_data_procedure =
-        create_mock_notes_procedure(tx_context.expected_output_notes());
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
-        use.$kernel::epilogue
+      use.mock::account
+      use.mock::util
 
-        {output_notes_data_procedure}
-
-        begin
-            exec.prologue::prepare_transaction
-            exec.create_mock_notes
-            exec.epilogue::finalize_transaction
-
-            # truncate the stack
-            movupw.3 dropw movupw.3 dropw movup.9 drop
-        end
-        "
+      begin
+          # create a note with the output asset
+          push.{OUTPUT_ASSET}
+          exec.util::create_random_note_with_asset drop
+          # => []
+      end
+      ",
+        OUTPUT_ASSET = Word::from(output_asset),
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let builder = ScriptBuilder::with_mock_libraries()?;
+    let source_manager = builder.source_manager();
+    let tx_script = builder.compile_tx_script(code)?;
 
-    assert_execution_error!(exec_output, ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME);
+    let tx_context = mock_chain
+        .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[input_note])?
+        .tx_script(tx_script)
+        .with_source_manager(source_manager)
+        .build()?;
+
+    let exec_output = tx_context.execute().await;
+    assert_transaction_executor_error!(
+        exec_output,
+        ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME
+    );
+
     Ok(())
 }
 
-#[test]
-fn test_epilogue_asset_preservation_violation_too_many_fungible_input() -> anyhow::Result<()> {
+/// Tests that a transaction fails due to the asset preservation rules when the input note has an
+/// asset with amount 200 and the output note has the same asset with amount 100.
+#[tokio::test]
+async fn epilogue_fails_when_num_input_assets_exceed_num_output_assets() -> anyhow::Result<()> {
+    // Create an input asset with amount 200 and an output asset with amount 100.
+    let output_asset = FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?, 100)?;
+    let input_asset = output_asset.add(output_asset)?;
+
     let mut builder = MockChain::builder();
-    let account = builder
-        .add_existing_mock_account_with_assets(Auth::IncrNonce, AssetVault::mock().assets())?;
+    let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
+    // Add an input note that (automatically) adds its assets to the transaction's input vault, but
+    // _does not_ add the asset to the account. This is just to keep the test conceptually simple -
+    // there is no account involved.
+    let input_note = NoteBuilder::new(account.id(), *builder.rng_mut())
+        .add_assets([Asset::from(output_asset)])
+        .build()?;
+    builder.add_output_note(OutputNote::Full(input_note.clone()));
     let mock_chain = builder.build()?;
-
-    let fungible_asset_1: Asset = FungibleAsset::new(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into()?,
-        CONSUMED_ASSET_1_AMOUNT,
-    )?
-    .into();
-    let fungible_asset_2: Asset = FungibleAsset::new(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?,
-        CONSUMED_ASSET_2_AMOUNT,
-    )?
-    .into();
-    let fungible_asset_3: Asset = FungibleAsset::new(
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_3.try_into()?,
-        CONSUMED_ASSET_3_AMOUNT,
-    )?
-    .into();
-
-    let output_note_1 = NoteBuilder::new(account.id(), rng())
-        .add_assets([fungible_asset_1])
-        .dynamically_linked_libraries(TransactionKernel::mock_libraries())
-        .build()?;
-    let output_note_2 = NoteBuilder::new(account.id(), rng())
-        .add_assets([fungible_asset_2])
-        .dynamically_linked_libraries(TransactionKernel::mock_libraries())
-        .build()?;
-    let output_note_3 = NoteBuilder::new(account.id(), rng())
-        .add_assets([fungible_asset_3])
-        .dynamically_linked_libraries(TransactionKernel::mock_libraries())
-        .build()?;
-
-    let input_note = create_spawn_note([&output_note_1, &output_note_2, &output_note_3])?;
-
-    let tx_context = mock_chain
-        .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[input_note])?
-        .extend_expected_output_notes(vec![
-            OutputNote::Full(output_note_1),
-            OutputNote::Full(output_note_2),
-        ])
-        .build()?;
-
-    let output_notes_data_procedure =
-        create_mock_notes_procedure(tx_context.expected_output_notes());
 
     let code = format!(
         "
-        use.$kernel::prologue
-        use.mock::account
-        use.$kernel::epilogue
+      use.mock::account
+      use.mock::util
 
-        {output_notes_data_procedure}
-
-        begin
-            exec.prologue::prepare_transaction
-            exec.create_mock_notes
-            exec.epilogue::finalize_transaction
-
-            # truncate the stack
-            movupw.3 dropw movupw.3 dropw movup.9 drop
-        end
-        "
+      begin
+          # create a note with the output asset
+          push.{OUTPUT_ASSET}
+          exec.util::create_random_note_with_asset drop
+          # => []
+      end
+      ",
+        OUTPUT_ASSET = Word::from(input_asset),
     );
 
-    let exec_output = tx_context.execute_code(&code);
+    let builder = ScriptBuilder::with_mock_libraries()?;
+    let source_manager = builder.source_manager();
+    let tx_script = builder.compile_tx_script(code)?;
 
-    assert_execution_error!(exec_output, ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME);
+    let tx_context = mock_chain
+        .build_tx_context(TxContextInput::AccountId(account.id()), &[], &[input_note])?
+        .tx_script(tx_script)
+        .with_source_manager(source_manager)
+        .build()?;
+
+    let exec_output = tx_context.execute().await;
+    assert_transaction_executor_error!(
+        exec_output,
+        ERR_EPILOGUE_TOTAL_NUMBER_OF_ASSETS_MUST_STAY_THE_SAME
+    );
+
     Ok(())
 }
 
@@ -447,9 +404,7 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
     end
     ";
 
-    let exec_output = &tx_context
-        .execute_code(code_template)
-        .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))?;
+    let exec_output = &tx_context.execute_code2(code_template)?;
 
     // Default value should be equal to u32::MAX, set in the prologue
     assert_eq!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -18,6 +18,7 @@ use miden_lib::transaction::memory::{
 use miden_lib::utils::ScriptBuilder;
 use miden_objects::Word;
 use miden_objects::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::asset::{Asset, FungibleAsset};
 use miden_objects::note::{NoteTag, NoteType};
 use miden_objects::testing::account_id::{
@@ -404,7 +405,9 @@ fn test_no_expiration_delta_set() -> anyhow::Result<()> {
     end
     ";
 
-    let exec_output = &tx_context.execute_code2(code_template)?;
+    let exec_output = &tx_context
+        .execute_code(code_template)
+        .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))?;
 
     // Default value should be equal to u32::MAX, set in the prologue
     assert_eq!(

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -109,7 +109,7 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let fpi_inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     let tx_context = mock_chain
@@ -371,11 +371,11 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
     .build()?;
     mock_chain.prove_next_block()?;
     let foreign_account_inputs_1 = mock_chain
-        .get_full_foreign_account_inputs(foreign_account_1.id())
+        .get_foreign_account_inputs(foreign_account_1.id())
         .expect("failed to get foreign account inputs");
 
     let foreign_account_inputs_2 = mock_chain
-        .get_full_foreign_account_inputs(foreign_account_2.id())
+        .get_foreign_account_inputs(foreign_account_2.id())
         .expect("failed to get foreign account inputs");
 
     let tx_context = mock_chain
@@ -635,7 +635,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -757,8 +757,7 @@ fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Result<()>
         .with_dynamically_linked_library(foreign_account_component.library())?
         .compile_tx_script(code)?;
 
-    let foreign_account_inputs =
-        mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
 
     mock_chain
         .build_tx_context(native_account.id(), &[], &[])?
@@ -913,10 +912,10 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
     let foreign_account_inputs = vec![
         mock_chain
-            .get_full_foreign_account_inputs(first_foreign_account.id())
+            .get_foreign_account_inputs(first_foreign_account.id())
             .expect("failed to get foreign account inputs"),
         mock_chain
-            .get_full_foreign_account_inputs(second_foreign_account.id())
+            .get_foreign_account_inputs(second_foreign_account.id())
             .expect("failed to get foreign account inputs"),
     ];
 
@@ -1112,7 +1111,7 @@ fn test_nested_fpi_stack_overflow() {
 
             let foreign_accounts: Vec<_> = foreign_accounts
                 .iter()
-                .map(|acc| mock_chain.get_full_foreign_account_inputs(acc.id())
+                .map(|acc| mock_chain.get_foreign_account_inputs(acc.id())
                     .expect("failed to get foreign account inputs"))
                 .collect();
 
@@ -1251,7 +1250,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     // push the hash of the native procedure and native account IDs to the advice stack to be able
@@ -1326,7 +1325,7 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
     // means the foreign account's commitment does not match the commitment that the account witness
     // proves inclusion for.
     let (_foreign_account, foreign_account_witness) = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     // The account tree from which the transaction inputs are fetched here has the state from the
@@ -1473,7 +1472,7 @@ fn test_fpi_get_account_id() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -1584,7 +1583,7 @@ fn test_fpi_get_account_nonce() -> anyhow::Result<()> {
     let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -1719,8 +1718,7 @@ fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> anyhow::Re
             .build()?;
     mock_chain.prove_next_block()?;
 
-    let foreign_account_inputs =
-        mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
 
     let code = format!(
         "

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -5,7 +5,6 @@ use std::string::ToString;
 
 use miden_lib::errors::tx_kernel_errors::{
     ERR_FOREIGN_ACCOUNT_CONTEXT_AGAINST_NATIVE_ACCOUNT,
-    ERR_FOREIGN_ACCOUNT_INVALID_COMMITMENT,
     ERR_FOREIGN_ACCOUNT_MAX_NUMBER_EXCEEDED,
 };
 use miden_lib::testing::account_component::MockAccountComponent;
@@ -31,7 +30,6 @@ use miden_objects::account::{
     AccountProcedureInfo,
     AccountStorage,
     AccountStorageMode,
-    PartialAccount,
     StorageSlot,
 };
 use miden_objects::assembly::DefaultSourceManager;
@@ -43,8 +41,7 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET,
 };
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
-use miden_objects::transaction::AccountInputs;
-use miden_objects::{FieldElement, Word, ZERO};
+use miden_objects::{Word, ZERO};
 use miden_processor::fast::ExecutionOutput;
 use miden_processor::{AdviceInputs, Felt};
 use miden_tx::LocalTransactionProver;
@@ -52,7 +49,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::kernel_tests::tx::ExecutionOutputExt;
-use crate::{Auth, MockChainBuilder, assert_execution_error, assert_transaction_executor_error};
+use crate::{Auth, MockChainBuilder, assert_transaction_executor_error};
 
 // SIMPLE FPI TESTS
 // ================================================================================================
@@ -759,7 +756,8 @@ fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Result<()>
         .with_dynamically_linked_library(foreign_account_component.library())?
         .compile_tx_script(code)?;
 
-    let foreign_account_inputs = mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs =
+        mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
 
     mock_chain
         .build_tx_context(native_account.id(), &[], &[])?
@@ -1735,7 +1733,8 @@ fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> anyhow::Re
             .build()?;
     mock_chain.prove_next_block()?;
 
-    let foreign_account_inputs = mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs =
+        mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
 
     let code = format!(
         "

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -380,7 +380,6 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
 
     let tx_context = mock_chain
         .build_tx_context(native_account.id(), &[], &[])?
-        .enable_lazy_loading()
         .foreign_accounts(vec![foreign_account_inputs_1, foreign_account_inputs_2])
         .build()?;
 
@@ -642,7 +641,6 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts([foreign_account_inputs])
-        .enable_lazy_loading()
         .tx_script(tx_script)
         .with_source_manager(source_manager)
         .build()?
@@ -762,7 +760,6 @@ fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Result<()>
     mock_chain
         .build_tx_context(native_account.id(), &[], &[])?
         .foreign_accounts([foreign_account_inputs])
-        .enable_lazy_loading()
         .tx_script(tx_script)
         .with_source_manager(source_manager)
         .build()?
@@ -982,7 +979,6 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(foreign_account_inputs)
-        .enable_lazy_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
         .with_source_manager(source_manager)
@@ -1151,7 +1147,6 @@ fn test_nested_fpi_stack_overflow() {
                 .build_tx_context(native_account.id(), &[], &[])
                 .expect("failed to build tx context")
                 .foreign_accounts(foreign_accounts)
-                .enable_lazy_loading()
                 .tx_script(tx_script)
                 .build().unwrap();
 
@@ -1265,7 +1260,6 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_lazy_loading()
         .extend_advice_inputs(advice_inputs)
         .tx_script(tx_script)
         .build()?
@@ -1479,7 +1473,6 @@ fn test_fpi_get_account_id() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_lazy_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;
@@ -1590,7 +1583,6 @@ fn test_fpi_get_account_nonce() -> anyhow::Result<()> {
         .build_tx_context(native_account.id(), &[], &[])
         .expect("failed to build tx context")
         .foreign_accounts(vec![foreign_account_inputs])
-        .enable_lazy_loading()
         .tx_script(tx_script)
         .build()?
         .execute_blocking()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -5,6 +5,7 @@ use std::string::ToString;
 
 use miden_lib::errors::tx_kernel_errors::{
     ERR_FOREIGN_ACCOUNT_CONTEXT_AGAINST_NATIVE_ACCOUNT,
+    ERR_FOREIGN_ACCOUNT_INVALID_COMMITMENT,
     ERR_FOREIGN_ACCOUNT_MAX_NUMBER_EXCEEDED,
 };
 use miden_lib::testing::account_component::MockAccountComponent;
@@ -30,6 +31,7 @@ use miden_objects::account::{
     AccountProcedureInfo,
     AccountStorage,
     AccountStorageMode,
+    PartialAccount,
     StorageSlot,
 };
 use miden_objects::assembly::DefaultSourceManager;
@@ -41,7 +43,8 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET,
 };
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
-use miden_objects::{Word, ZERO};
+use miden_objects::transaction::AccountInputs;
+use miden_objects::{FieldElement, Word, ZERO};
 use miden_processor::fast::ExecutionOutput;
 use miden_processor::{AdviceInputs, Felt};
 use miden_tx::LocalTransactionProver;
@@ -49,7 +52,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::kernel_tests::tx::ExecutionOutputExt;
-use crate::{Auth, MockChainBuilder, assert_transaction_executor_error};
+use crate::{Auth, MockChainBuilder, assert_execution_error, assert_transaction_executor_error};
 
 // SIMPLE FPI TESTS
 // ================================================================================================
@@ -1275,7 +1278,6 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
     Ok(())
 }
 
-/*
 /// Test that providing an account whose commitment does not match the one in the account tree
 /// results in an error.
 #[test]
@@ -1322,33 +1324,19 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
         .storage_mut()
         .set_item(0, Word::from([Felt::ONE, Felt::ONE, Felt::ONE, Felt::ONE]))?;
 
-    // Place the modified account in the advice provider, which will cause the commitment mismatch.
-    let foreign_account_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+    // We pass the modified foreign account with a witness that is valid against the ref block. This
+    // means the foreign account's commitment does not match the commitment that the account witness
+    // proves inclusion for.
+    let (_foreign_account, foreign_account_witness) = mock_chain
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
-
-    // We want to create a mixed ForeignAccountInputs because we want to have a valid account
-    // witness against the ref block, but have newer account data (ie, a new state). Otherwise,
-    // any non-validity of the account witness is caught in
-    // TransactionExecutor::execute_transaction() (see `test_fpi_anchoring_validations()` for
-    // context on this check)
-    let overridden_partial_accounts = PartialAccount::new(
-        foreign_account.id(),
-        foreign_account.nonce(),
-        foreign_account.code().clone(),
-        foreign_account.storage().into(),
-        foreign_account.vault().into(),
-        None,
-    )?;
-    let overridden_foreign_account_inputs =
-        AccountInputs::new(overridden_partial_accounts, foreign_account_inputs.witness().clone());
 
     // The account tree from which the transaction inputs are fetched here has the state from the
     // original unmodified foreign account. This should result in the foreign account's proof to be
     // invalid for this account tree root.
     let tx_context = mock_chain
         .build_tx_context(native_account, &[], &[])?
-        .foreign_accounts(vec![overridden_foreign_account_inputs])
+        .foreign_accounts(vec![(foreign_account.clone(), foreign_account_witness)])
         .build()?;
 
     // Attempt to run FPI.
@@ -1369,7 +1357,7 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
           # => [pad(16)]
 
           # push some hash onto the stack - for this test it does not matter
-          padw
+          push.[1,2,3,4]
           # => [FOREIGN_PROC_ROOT, pad(16)]
 
           # push the foreign account ID
@@ -1385,9 +1373,9 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
 
     let result = tx_context.execute_code(&code).map(|_| ());
     assert_execution_error!(result, ERR_FOREIGN_ACCOUNT_INVALID_COMMITMENT);
+
     Ok(())
 }
-*/
 
 /// This test checks that our `miden::get_id` and `miden::get_native_id` procedures return IDs of
 /// the current and native account respectively while being called from the foreign account.

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -31,7 +31,6 @@ use miden_objects::account::{
     AccountProcedureInfo,
     AccountStorage,
     AccountStorageMode,
-    PartialAccount,
     StorageSlot,
 };
 use miden_objects::assembly::DefaultSourceManager;
@@ -43,7 +42,6 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET,
 };
 use miden_objects::testing::storage::STORAGE_LEAVES_2;
-use miden_objects::transaction::AccountInputs;
 use miden_objects::{FieldElement, Word, ZERO};
 use miden_processor::fast::ExecutionOutput;
 use miden_processor::{AdviceInputs, Felt};

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -1,6 +1,7 @@
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+use std::string::ToString;
 
 use miden_lib::errors::tx_kernel_errors::{
     ERR_FOREIGN_ACCOUNT_CONTEXT_AGAINST_NATIVE_ACCOUNT,
@@ -35,6 +36,7 @@ use miden_objects::account::{
 };
 use miden_objects::assembly::DefaultSourceManager;
 use miden_objects::assembly::diagnostics::NamedSource;
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
 use miden_objects::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
@@ -109,7 +111,7 @@ fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let fpi_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     let tx_context = mock_chain
@@ -371,16 +373,16 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
     .build()?;
     mock_chain.prove_next_block()?;
     let foreign_account_inputs_1 = mock_chain
-        .get_foreign_account_inputs(foreign_account_1.id())
+        .get_full_foreign_account_inputs(foreign_account_1.id())
         .expect("failed to get foreign account inputs");
 
     let foreign_account_inputs_2 = mock_chain
-        .get_foreign_account_inputs(foreign_account_2.id())
+        .get_full_foreign_account_inputs(foreign_account_2.id())
         .expect("failed to get foreign account inputs");
 
     let tx_context = mock_chain
-        .build_tx_context(native_account.id(), &[], &[])
-        .expect("failed to build tx context")
+        .build_tx_context(native_account.id(), &[], &[])?
+        .enable_lazy_loading()
         .foreign_accounts(vec![foreign_account_inputs_1, foreign_account_inputs_2])
         .build()?;
 
@@ -467,7 +469,9 @@ fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
         foreign_2_suffix = foreign_account_2.id().suffix(),
     );
 
-    let exec_output = &tx_context.execute_code(&code)?;
+    let exec_output = &tx_context
+        .execute_code(&code)
+        .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))?;
 
     // Check the correctness of the memory layout after multiple foreign procedure invocations from
     // different foreign accounts
@@ -633,7 +637,7 @@ fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -755,7 +759,7 @@ fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Result<()>
         .with_dynamically_linked_library(foreign_account_component.library())?
         .compile_tx_script(code)?;
 
-    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs = mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
 
     mock_chain
         .build_tx_context(native_account.id(), &[], &[])?
@@ -910,10 +914,10 @@ fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
     let foreign_account_inputs = vec![
         mock_chain
-            .get_foreign_account_inputs(first_foreign_account.id())
+            .get_full_foreign_account_inputs(first_foreign_account.id())
             .expect("failed to get foreign account inputs"),
         mock_chain
-            .get_foreign_account_inputs(second_foreign_account.id())
+            .get_full_foreign_account_inputs(second_foreign_account.id())
             .expect("failed to get foreign account inputs"),
     ];
 
@@ -1107,9 +1111,9 @@ fn test_nested_fpi_stack_overflow() {
 
             mock_chain.prove_next_block().unwrap();
 
-            let foreign_accounts: Vec<AccountInputs> = foreign_accounts
+            let foreign_accounts: Vec<_> = foreign_accounts
                 .iter()
-                .map(|acc| mock_chain.get_foreign_account_inputs(acc.id())
+                .map(|acc| mock_chain.get_full_foreign_account_inputs(acc.id())
                     .expect("failed to get foreign account inputs"))
                 .collect();
 
@@ -1138,9 +1142,9 @@ fn test_nested_fpi_stack_overflow() {
             end
             ",
                 foreign_account_proc_hash =
-                    foreign_accounts.last().unwrap().code().procedures()[1].mast_root(),
-                foreign_prefix = foreign_accounts.last().unwrap().id().prefix().as_felt(),
-                foreign_suffix = foreign_accounts.last().unwrap().id().suffix(),
+                    foreign_accounts.last().unwrap().0.code().procedures()[1].mast_root(),
+                foreign_prefix = foreign_accounts.last().unwrap().0.id().prefix().as_felt(),
+                foreign_suffix = foreign_accounts.last().unwrap().0.id().suffix(),
             );
 
             let tx_script = ScriptBuilder::default().compile_tx_script(code).unwrap();
@@ -1248,7 +1252,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     // push the hash of the native procedure and native account IDs to the advice stack to be able
@@ -1273,6 +1277,7 @@ fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
     Ok(())
 }
 
+/*
 /// Test that providing an account whose commitment does not match the one in the account tree
 /// results in an error.
 #[test]
@@ -1384,6 +1389,7 @@ fn test_fpi_stale_account() -> anyhow::Result<()> {
     assert_execution_error!(result, ERR_FOREIGN_ACCOUNT_INVALID_COMMITMENT);
     Ok(())
 }
+*/
 
 /// This test checks that our `miden::get_id` and `miden::get_native_id` procedures return IDs of
 /// the current and native account respectively while being called from the foreign account.
@@ -1483,7 +1489,7 @@ fn test_fpi_get_account_id() -> anyhow::Result<()> {
         .compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -1594,7 +1600,7 @@ fn test_fpi_get_account_nonce() -> anyhow::Result<()> {
     let tx_script = ScriptBuilder::default().compile_tx_script(code)?;
 
     let foreign_account_inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     mock_chain
@@ -1729,7 +1735,7 @@ fn test_get_item_init_and_get_map_item_init_with_foreign_account() -> anyhow::Re
             .build()?;
     mock_chain.prove_next_block()?;
 
-    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
+    let foreign_account_inputs = mock_chain.get_full_foreign_account_inputs(foreign_account.id())?;
 
     let code = format!(
         "

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -59,7 +59,6 @@ fn adding_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
         .extend_input_notes(vec![asset_note])
-        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?;
     let account = tx_context.account().clone();
@@ -125,7 +124,6 @@ fn removing_fungible_assets_with_lazy_loading_succeeds() -> anyhow::Result<()> {
         .build()?
         .build_tx_context(account, &[], &[])?
         .tx_script(tx_script)
-        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?;
     let account = tx_context.account().clone();
@@ -159,7 +157,6 @@ fn loading_fee_asset_succeeds() -> anyhow::Result<()> {
     builder
         .build()?
         .build_tx_context(account, &[], &[])?
-        .enable_lazy_loading()
         .build()?
         .execute_blocking()?;
 
@@ -219,7 +216,6 @@ fn setting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
 
     let tx = TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
-        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;
@@ -281,7 +277,6 @@ fn getting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
 
     TransactionContextBuilder::with_existing_mock_account()
         .tx_script(tx_script)
-        .enable_lazy_loading()
         .with_source_manager(source_manager)
         .build()?
         .execute_blocking()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -1,6 +1,5 @@
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 
 use anyhow::Context;
 use miden_lib::account::auth::PublicKeyCommitment;
@@ -31,7 +30,7 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_SENDER,
 };
-use miden_objects::transaction::{AccountInputs, OutputNote, TransactionArgs};
+use miden_objects::transaction::{OutputNote, TransactionArgs};
 use miden_objects::{Felt, Word, ZERO};
 use miden_processor::fast::ExecutionOutput;
 use rand::SeedableRng;
@@ -156,11 +155,8 @@ fn test_note_script_and_note_args() -> miette::Result<()> {
         (tx_context.input_notes().get_note(1).note().id(), note_args[0]),
     ]);
 
-    let tx_args = TransactionArgs::new(
-        tx_context.tx_args().advice_inputs().clone().map,
-        Vec::<AccountInputs>::new(),
-    )
-    .with_note_args(note_args_map);
+    let tx_args = TransactionArgs::new(tx_context.tx_args().advice_inputs().clone().map)
+        .with_note_args(note_args_map);
 
     tx_context.set_tx_args(tx_args);
     let exec_output = tx_context.execute_code(code).unwrap();

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -80,12 +80,7 @@ use miden_objects::testing::account_id::{
     ACCOUNT_ID_SENDER,
 };
 use miden_objects::testing::noop_auth_component::NoopAuthComponent;
-use miden_objects::transaction::{
-    AccountInputs,
-    ExecutedTransaction,
-    TransactionArgs,
-    TransactionScript,
-};
+use miden_objects::transaction::{ExecutedTransaction, TransactionArgs, TransactionScript};
 use miden_objects::{EMPTY_WORD, ONE, WORD_SIZE};
 use miden_processor::fast::ExecutionOutput;
 use miden_processor::{AdviceInputs, Word};
@@ -155,12 +150,9 @@ fn test_transaction_prologue() -> anyhow::Result<()> {
         (tx_context.input_notes().get_note(1).note().id(), note_args[1]),
     ]);
 
-    let tx_args = TransactionArgs::new(
-        tx_context.tx_args().advice_inputs().clone().map,
-        Vec::<AccountInputs>::new(),
-    )
-    .with_tx_script(tx_script)
-    .with_note_args(note_args_map);
+    let tx_args = TransactionArgs::new(tx_context.tx_args().advice_inputs().clone().map)
+        .with_tx_script(tx_script)
+        .with_note_args(note_args_map);
 
     tx_context.set_tx_args(tx_args);
     let exec_output = &tx_context.execute_code(code)?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -65,6 +65,7 @@ use crate::{Auth, MockChain, TransactionContextBuilder};
 
 /// Tests that executing a transaction with a foreign account whose inputs are stale fails.
 #[test]
+#[ignore = "TODO: this is hard to test with lazy loading"]
 fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
     // Create a chain with an account
     let mut builder = MockChain::builder();

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -65,7 +65,7 @@ use crate::{Auth, MockChain, TransactionContextBuilder};
 
 /// Tests that executing a transaction with a foreign account whose inputs are stale fails.
 #[test]
-#[ignore = "TODO: this is hard to test with lazy loading"]
+#[ignore = "TODO: should we reenable the check that this tests?"]
 fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
     // Create a chain with an account
     let mut builder = MockChain::builder();

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -76,7 +76,7 @@ fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
 
     // Retrieve inputs which will become stale
     let inputs = mock_chain
-        .get_full_foreign_account_inputs(foreign_account.id())
+        .get_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     // Create a new unrelated account to modify the account tree.

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -62,46 +62,6 @@ use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::{create_public_p2any_note, create_spawn_note};
 use crate::{Auth, MockChain, TransactionContextBuilder};
 
-/// Tests that executing a transaction with a foreign account whose inputs are stale fails.
-#[test]
-#[ignore = "TODO: should we reenable the check that this tests?"]
-fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
-    // Create a chain with an account
-    let mut builder = MockChain::builder();
-    let native_account = builder.add_existing_wallet(Auth::IncrNonce)?;
-    let foreign_account = builder.add_existing_wallet(Auth::IncrNonce)?;
-    let new_account = builder.create_new_wallet(Auth::IncrNonce)?;
-
-    let mut mock_chain = builder.build()?;
-
-    // Retrieve inputs which will become stale
-    let inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
-        .expect("failed to get foreign account inputs");
-
-    // Create a new unrelated account to modify the account tree.
-    let tx = mock_chain
-        .build_tx_context(new_account, &[], &[])?
-        .build()?
-        .execute_blocking()?;
-    mock_chain.add_pending_executed_transaction(&tx)?;
-    mock_chain.prove_next_block()?;
-
-    // Attempt to execute with older foreign account inputs. The AccountWitness in the foreign
-    // account's inputs have become stale and so this should fail.
-    let transaction = mock_chain
-        .build_tx_context(native_account.id(), &[], &[])?
-        .foreign_accounts(vec![inputs])
-        .build()?
-        .execute_blocking();
-
-    assert_matches::assert_matches!(
-        transaction,
-        Err(TransactionExecutorError::ForeignAccountNotAnchoredInReference(_))
-    );
-    Ok(())
-}
-
 /// Tests that consuming a note created in a block that is newer than the reference block of the
 /// transaction fails.
 #[tokio::test]

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -1,5 +1,4 @@
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 
 use anyhow::Context;
 use assert_matches::assert_matches;
@@ -630,7 +629,7 @@ async fn execute_tx_view_script() -> anyhow::Result<()> {
         .with_source_manager(source_manager);
 
     let stack_outputs = executor
-        .execute_tx_view_script(account_id, block_ref, tx_script, advice_inputs, Vec::default())
+        .execute_tx_view_script(account_id, block_ref, tx_script, advice_inputs)
         .await?;
 
     assert_eq!(stack_outputs[..3], [Felt::new(7), Felt::new(2), ONE]);

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -76,7 +76,7 @@ fn transaction_with_stale_foreign_account_inputs_fails() -> anyhow::Result<()> {
 
     // Retrieve inputs which will become stale
     let inputs = mock_chain
-        .get_foreign_account_inputs(foreign_account.id())
+        .get_full_foreign_account_inputs(foreign_account.id())
         .expect("failed to get foreign account inputs");
 
     // Create a new unrelated account to modify the account tree.

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -20,7 +20,6 @@ use miden_objects::block::{
 };
 use miden_objects::note::{Note, NoteHeader, NoteId, NoteInclusionProof, Nullifier};
 use miden_objects::transaction::{
-    AccountInputs,
     ExecutedTransaction,
     InputNote,
     InputNotes,
@@ -712,7 +711,10 @@ impl MockChain {
     }
 
     /// Gets foreign account inputs to execute FPI transactions.
-    pub fn get_full_foreign_account_inputs(
+    ///
+    /// Only used internally and so does not need to be public.
+    #[cfg(test)]
+    pub(crate) fn get_foreign_account_inputs(
         &self,
         account_id: AccountId,
     ) -> anyhow::Result<(Account, AccountWitness)> {
@@ -722,21 +724,6 @@ impl MockChain {
         assert_eq!(account_witness.state_commitment(), account.commitment());
 
         Ok((account, account_witness))
-    }
-
-    /// Gets foreign account inputs to execute FPI transactions.
-    pub fn get_foreign_account_inputs(
-        &self,
-        account_id: AccountId,
-    ) -> anyhow::Result<AccountInputs> {
-        let account = self.committed_account(account_id)?;
-
-        let account_witness = self.account_tree().open(account_id);
-        assert_eq!(account_witness.state_commitment(), account.commitment());
-
-        let partial_account = PartialAccount::from(account);
-
-        Ok(AccountInputs::new(partial_account, account_witness))
     }
 
     /// Gets the inputs for a block for the provided batches.

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -712,6 +712,19 @@ impl MockChain {
     }
 
     /// Gets foreign account inputs to execute FPI transactions.
+    pub fn get_full_foreign_account_inputs(
+        &self,
+        account_id: AccountId,
+    ) -> anyhow::Result<(Account, AccountWitness)> {
+        let account = self.committed_account(account_id)?.clone();
+
+        let account_witness = self.account_tree().open(account_id);
+        assert_eq!(account_witness.state_commitment(), account.commitment());
+
+        Ok((account, account_witness))
+    }
+
+    /// Gets foreign account inputs to execute FPI transactions.
     pub fn get_foreign_account_inputs(
         &self,
         account_id: AccountId,

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -637,6 +637,13 @@ impl MockChainBuilder {
     // HELPER FUNCTIONS
     // ----------------------------------------------------------------------------------------
 
+    /// Returns a mutable reference to the builder's RNG.
+    ///
+    /// This can be used when creating accounts or notes and randomness is required.
+    pub fn rng_mut(&mut self) -> &mut RpoRandomCoin {
+        &mut self.rng
+    }
+
     /// Constructs a fungible asset based on the native asset ID and the provided amount.
     fn native_fee_asset(&self, amount: u64) -> anyhow::Result<FungibleAsset> {
         FungibleAsset::new(self.native_asset_id, amount).context("failed to create fee asset")

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -65,7 +65,7 @@ impl<'store> MockHost<'store> {
                 &TransactionEvent::LinkMapGetEvent,
                 // TODO: It should be possible to remove this after implementing
                 // https://github.com/0xMiden/miden-base/issues/1852.
-                &TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount
+                &TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount,
             ]
             .map(TransactionEvent::event_id),
         );
@@ -115,8 +115,10 @@ impl<'store> AsyncHost for MockHost<'store> {
         async move {
             // If the host should handle the event, delegate to the tx executor host.
             if self.handled_events.contains(&event_id) {
+                std::println!("mock host handles event {event_id}",);
                 self.exec_host.on_event(process).await
             } else {
+                std::println!("mock host skipping event {event_id}",);
                 Ok(Vec::new())
             }
         }

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -81,6 +81,7 @@ impl<'store> MockHost<'store> {
                 &TransactionEvent::AccountVaultBeforeGetBalanceEvent,
                 &TransactionEvent::AccountVaultBeforeHasNonFungibleAssetEvent,
                 &TransactionEvent::AccountVaultBeforeAddAsset,
+                &TransactionEvent::AccountVaultBeforeRemoveAsset,
                 &TransactionEvent::AccountStorageBeforeSetMapItem,
                 &TransactionEvent::AccountStorageBeforeGetMapItem,
             ]
@@ -115,10 +116,8 @@ impl<'store> AsyncHost for MockHost<'store> {
         async move {
             // If the host should handle the event, delegate to the tx executor host.
             if self.handled_events.contains(&event_id) {
-                std::println!("mock host handles event {event_id}",);
                 self.exec_host.on_event(process).await
             } else {
-                std::println!("mock host skipping event {event_id}",);
                 Ok(Vec::new())
             }
         }

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -63,6 +63,9 @@ impl<'store> MockHost<'store> {
                 &TransactionEvent::AccountPushProcedureIndex,
                 &TransactionEvent::LinkMapSetEvent,
                 &TransactionEvent::LinkMapGetEvent,
+                // TODO: It should be possible to remove this after implementing
+                // https://github.com/0xMiden/miden-base/issues/1852.
+                &TransactionEvent::EpilogueBeforeTxFeeRemovedFromAccount
             ]
             .map(TransactionEvent::event_id),
         );

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -22,12 +22,12 @@ use miden_objects::account::{
 use miden_objects::assembly::DefaultSourceManager;
 use miden_objects::assembly::debuginfo::SourceManagerSync;
 use miden_objects::asset::PartialVault;
+use miden_objects::block::AccountWitness;
 use miden_objects::crypto::dsa::rpo_falcon512::PublicKey;
 use miden_objects::note::{Note, NoteId};
 use miden_objects::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE;
 use miden_objects::testing::noop_auth_component::NoopAuthComponent;
 use miden_objects::transaction::{
-    AccountInputs,
     OutputNote,
     TransactionArgs,
     TransactionInputs,
@@ -80,7 +80,7 @@ pub struct TransactionContextBuilder {
     advice_inputs: AdviceInputs,
     authenticator: Option<MockAuthenticator>,
     expected_output_notes: Vec<Note>,
-    foreign_account_inputs: BTreeMap<AccountId, AccountInputs>,
+    foreign_account_inputs: BTreeMap<AccountId, (Account, AccountWitness)>,
     input_notes: Vec<Note>,
     tx_script: Option<TransactionScript>,
     tx_script_args: Word,
@@ -107,7 +107,7 @@ impl TransactionContextBuilder {
             foreign_account_inputs: BTreeMap::new(),
             auth_args: EMPTY_WORD,
             signatures: Vec::new(),
-            is_lazy_loading_enabled: false,
+            is_lazy_loading_enabled: true,
         }
     }
 
@@ -169,9 +169,13 @@ impl TransactionContextBuilder {
     }
 
     /// Set foreign account codes that are used by the transaction
-    pub fn foreign_accounts(mut self, inputs: impl IntoIterator<Item = AccountInputs>) -> Self {
-        self.foreign_account_inputs
-            .extend(inputs.into_iter().map(|account_inputs| (account_inputs.id(), account_inputs)));
+    pub fn foreign_accounts(
+        mut self,
+        inputs: impl IntoIterator<Item = (Account, AccountWitness)>,
+    ) -> Self {
+        self.foreign_account_inputs.extend(
+            inputs.into_iter().map(|account_inputs| (account_inputs.0.id(), account_inputs)),
+        );
         self
     }
 
@@ -299,16 +303,16 @@ impl TransactionContextBuilder {
         // If partial loading is enabled, construct an account that doesn't contain all
         // merkle paths of assets and storage maps, in order to test lazy loading.
         // Otherwise, load the full account.
-        let tx_inputs = if self.is_lazy_loading_enabled {
-            let (_account, block_header, partial_blockchain, input_notes) = tx_inputs.into_parts();
-            // Note that we use self.account instead of account, because we cannot do the same
-            // operation on a partial vault.
-            let account = minimal_partial_account(&self.account)?;
+        // let tx_inputs = if self.is_lazy_loading_enabled {
+        //     let (_account, block_header, partial_blockchain, input_notes) =
+        // tx_inputs.into_parts();     // Note that we use self.account instead of account,
+        // because we cannot do the same     // operation on a partial vault.
+        //     let account = minimal_partial_account(&self.account)?;
 
-            TransactionInputs::new(account, block_header, partial_blockchain, input_notes)?
-        } else {
-            tx_inputs
-        };
+        //     TransactionInputs::new(account, block_header, partial_blockchain, input_notes)?
+        // } else {
+        //     tx_inputs
+        // };
 
         let foreign_account_inputs = if self.is_lazy_loading_enabled {
             Vec::new()
@@ -316,8 +320,8 @@ impl TransactionContextBuilder {
             self.foreign_account_inputs.values().cloned().collect()
         };
 
-        let tx_args = TransactionArgs::new(AdviceMap::default(), foreign_account_inputs)
-            .with_note_args(self.note_args);
+        let tx_args =
+            TransactionArgs::new(AdviceMap::default(), Vec::new()).with_note_args(self.note_args);
 
         let mut tx_args = if let Some(tx_script) = self.tx_script {
             tx_args.with_tx_script_and_args(tx_script, self.tx_script_args)
@@ -338,8 +342,8 @@ impl TransactionContextBuilder {
             let mast_forest_store = TransactionMastStore::new();
             mast_forest_store.load_account_code(tx_inputs.account().code());
 
-            for acc_inputs in self.foreign_account_inputs.values() {
-                mast_forest_store.insert(acc_inputs.code().mast());
+            for (account, _) in self.foreign_account_inputs.values() {
+                mast_forest_store.insert(account.code().mast());
             }
 
             mast_forest_store
@@ -381,13 +385,17 @@ fn minimal_partial_account(account: &Account) -> anyhow::Result<PartialAccount> 
     let storage_maps =
         account.storage().slots().iter().filter_map(|storage_slot| match storage_slot {
             StorageSlot::Map(storage_map) => {
-                let mut partial_storage_map = PartialStorageMap::default();
-                let key = Word::empty();
-                let witness = storage_map.open(&key);
-                partial_storage_map
-                    .add(witness)
-                    .expect("adding the first proof should never error");
-                Some(partial_storage_map)
+                if account.is_new() {
+                    Some(PartialStorageMap::from(storage_map.clone()))
+                } else {
+                    let mut partial_storage_map = PartialStorageMap::default();
+                    let key = Word::empty();
+                    let witness = storage_map.open(&key);
+                    partial_storage_map
+                        .add(witness)
+                        .expect("adding the first proof should never error");
+                    Some(partial_storage_map)
+                }
             },
             _ => None,
         });
@@ -400,7 +408,7 @@ fn minimal_partial_account(account: &Account) -> anyhow::Result<PartialAccount> 
         account.code().clone(),
         partial_storage,
         partial_vault,
-        None,
+        account.seed(),
     )?;
 
     Ok(account)

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -163,7 +163,7 @@ impl TransactionContextBuilder {
         inputs: impl IntoIterator<Item = (Account, AccountWitness)>,
     ) -> Self {
         self.foreign_account_inputs.extend(
-            inputs.into_iter().map(|account_inputs| (account_inputs.0.id(), account_inputs)),
+            inputs.into_iter().map(|(account, witness)| (account.id(), (account, witness))),
         );
         self
     }

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -203,20 +203,10 @@ impl TransactionContextBuilder {
         self
     }
 
-    /// Causes the transaction to only construct a minimal partial account as the transaction
-    /// input, causing lazy loading of assets and storage map items throughout transaction
-    /// execution. Additionally, foreign accounts aren't provided via the transaction args but are
-    /// lazy loaded as well.
-    ///
-    /// This exists to test lazy loading selectively and should go away in the future.
-    pub fn enable_lazy_loading(mut self) -> Self {
-        self.is_lazy_loading_enabled = true;
-        self
-    }
-
     /// Disables lazy loading.
     ///
-    /// This is the opposite of [`Self::enable_lazy_loading`] - see its docs for details.
+    /// Only affects [`TransactionContext::execute_code`] and causes the host to _not_ handle lazy
+    /// loading events.
     pub fn disable_lazy_loading(mut self) -> Self {
         self.is_lazy_loading_enabled = false;
         self

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -9,19 +9,9 @@ use anyhow::Context;
 use miden_lib::testing::account_component::IncrNonceAuthComponent;
 use miden_lib::testing::mock_account::MockAccountExt;
 use miden_objects::EMPTY_WORD;
-use miden_objects::account::{
-    Account,
-    AccountHeader,
-    AccountId,
-    PartialAccount,
-    PartialStorage,
-    PartialStorageMap,
-    Signature,
-    StorageSlot,
-};
+use miden_objects::account::{Account, AccountHeader, AccountId, Signature};
 use miden_objects::assembly::DefaultSourceManager;
 use miden_objects::assembly::debuginfo::SourceManagerSync;
-use miden_objects::asset::PartialVault;
 use miden_objects::block::AccountWitness;
 use miden_objects::crypto::dsa::rpo_falcon512::PublicKey;
 use miden_objects::note::{Note, NoteId};
@@ -33,7 +23,6 @@ use miden_objects::transaction::{
     TransactionInputs,
     TransactionScript,
 };
-use miden_objects::vm::AdviceMap;
 use miden_processor::{AdviceInputs, Felt, Word};
 use miden_tx::TransactionMastStore;
 use miden_tx::auth::BasicAuthenticator;
@@ -300,28 +289,7 @@ impl TransactionContextBuilder {
             },
         };
 
-        // If partial loading is enabled, construct an account that doesn't contain all
-        // merkle paths of assets and storage maps, in order to test lazy loading.
-        // Otherwise, load the full account.
-        // let tx_inputs = if self.is_lazy_loading_enabled {
-        //     let (_account, block_header, partial_blockchain, input_notes) =
-        // tx_inputs.into_parts();     // Note that we use self.account instead of account,
-        // because we cannot do the same     // operation on a partial vault.
-        //     let account = minimal_partial_account(&self.account)?;
-
-        //     TransactionInputs::new(account, block_header, partial_blockchain, input_notes)?
-        // } else {
-        //     tx_inputs
-        // };
-
-        let foreign_account_inputs = if self.is_lazy_loading_enabled {
-            Vec::new()
-        } else {
-            self.foreign_account_inputs.values().cloned().collect()
-        };
-
-        let tx_args =
-            TransactionArgs::new(AdviceMap::default(), Vec::new()).with_note_args(self.note_args);
+        let tx_args = TransactionArgs::default().with_note_args(self.note_args);
 
         let mut tx_args = if let Some(tx_script) = self.tx_script {
             tx_args.with_tx_script_and_args(tx_script, self.tx_script_args)
@@ -368,48 +336,4 @@ impl Default for TransactionContextBuilder {
     fn default() -> Self {
         Self::with_existing_mock_account()
     }
-}
-
-/// Creates a minimal [`PartialAccount`] from the provided full [`Account`].
-fn minimal_partial_account(account: &Account) -> anyhow::Result<PartialAccount> {
-    // Construct a partial vault that tracks the empty word, but none of the assets
-    // that are actually in the asset tree. That way, the partial vault has the same
-    // root as the full vault, but will not add any relevant merkle paths to the
-    // merkle store, which will test lazy loading of assets.
-    let mut partial_vault = PartialVault::default();
-    partial_vault.add(account.vault().open(Word::empty()))?;
-
-    // Construct a partial storage that tracks the empty word in all storage maps, but none
-    // of the other keys, following the same rationale as the partial vault above.
-    let storage_header = account.storage().to_header();
-    let storage_maps =
-        account.storage().slots().iter().filter_map(|storage_slot| match storage_slot {
-            StorageSlot::Map(storage_map) => {
-                if account.is_new() {
-                    Some(PartialStorageMap::from(storage_map.clone()))
-                } else {
-                    let mut partial_storage_map = PartialStorageMap::default();
-                    let key = Word::empty();
-                    let witness = storage_map.open(&key);
-                    partial_storage_map
-                        .add(witness)
-                        .expect("adding the first proof should never error");
-                    Some(partial_storage_map)
-                }
-            },
-            _ => None,
-        });
-    let partial_storage = PartialStorage::new(storage_header, storage_maps)
-        .expect("provided storage maps should match storage header");
-
-    let account = PartialAccount::new(
-        account.id(),
-        account.nonce(),
-        account.code().clone(),
-        partial_storage,
-        partial_vault,
-        account.seed(),
-    )?;
-
-    Ok(account)
 }

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -1,11 +1,13 @@
 use alloc::borrow::ToOwned;
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::{Account, AccountId, PartialAccount, StorageMapWitness, StorageSlot};
 use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
+use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::assembly::{SourceManager, SourceManagerSync};
 use miden_objects::asset::AssetWitness;
 use miden_objects::block::{AccountWitness, BlockHeader, BlockNumber};
@@ -66,6 +68,11 @@ pub struct TransactionContext {
 }
 
 impl TransactionContext {
+    pub fn execute_code2(&self, code: &str) -> anyhow::Result<ExecutionOutput> {
+        self.execute_code(code)
+            .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))
+    }
+
     /// Executes arbitrary code within the context of a mocked transaction environment and returns
     /// the resulting [`ExecutionOutput`].
     ///
@@ -334,9 +341,10 @@ impl DataStore for TransactionContext {
                     })?;
 
                 let map = foreign_account
-                    .storage().slots()
-                    
-                    .iter().find_map(|slot| match slot {
+                    .storage()
+                    .slots()
+                    .iter()
+                    .find_map(|slot| match slot {
                       StorageSlot::Map(storage_map) if  storage_map.root() == map_root => {Some(storage_map)},
                       _ => None,
                     })

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -8,7 +8,7 @@ use miden_objects::account::{Account, AccountId, PartialAccount, StorageMapWitne
 use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
 use miden_objects::assembly::{SourceManager, SourceManagerSync};
 use miden_objects::asset::AssetWitness;
-use miden_objects::block::{BlockHeader, BlockNumber};
+use miden_objects::block::{AccountWitness, BlockHeader, BlockNumber};
 use miden_objects::note::Note;
 use miden_objects::transaction::{
     AccountInputs,
@@ -55,7 +55,7 @@ use crate::tx_context::builder::MockAuthenticator;
 pub struct TransactionContext {
     pub(super) account: Account,
     pub(super) expected_output_notes: Vec<Note>,
-    pub(super) foreign_account_inputs: BTreeMap<AccountId, AccountInputs>,
+    pub(super) foreign_account_inputs: BTreeMap<AccountId, (Account, AccountWitness)>,
     pub(super) tx_args: TransactionArgs,
     pub(super) tx_inputs: TransactionInputs,
     pub(super) mast_store: TransactionMastStore,
@@ -117,7 +117,7 @@ impl TransactionContext {
         let account_procedure_idx_map = AccountProcedureIndexMap::new(
             [self.tx_inputs().account().code()]
                 .into_iter()
-                .chain(self.tx_args().foreign_account_inputs().iter().map(|inputs| inputs.code())),
+                .chain(self.foreign_account_inputs.values().map(|(account, _)| account.code())),
         )
         .expect("constructing account procedure index map should work");
 
@@ -234,11 +234,17 @@ impl DataStore for TransactionContext {
         // Note that we cannot validate that the foreign account inputs are valid for the
         // transaction's reference block.
         async move {
-            self.foreign_account_inputs.get(&foreign_account_id).cloned().ok_or_else(|| {
-                DataStoreError::other(format!(
-                    "failed to find foreign account {foreign_account_id}"
-                ))
-            })
+            let (foreign_account, account_witness) =
+                self.foreign_account_inputs.get(&foreign_account_id).ok_or_else(|| {
+                    DataStoreError::other(format!(
+                        "failed to find foreign account {foreign_account_id}"
+                    ))
+                })?;
+
+            Ok(AccountInputs::new(
+                PartialAccount::from(foreign_account),
+                account_witness.clone(),
+            ))
         }
     }
 
@@ -259,7 +265,7 @@ impl DataStore for TransactionContext {
 
                 Ok(self.account().vault().open(vault_key))
             } else {
-                let foreign_account_inputs = self
+                let (foreign_account, _witness) = self
                     .foreign_account_inputs
                     .iter()
                     .find_map(
@@ -273,21 +279,14 @@ impl DataStore for TransactionContext {
                         ))
                     })?;
 
-                if foreign_account_inputs.account().vault().root() != vault_root {
+                if foreign_account.vault().root() != vault_root {
                     return Err(DataStoreError::other(format!(
                         "foreign account {account_id} has vault root {} but {vault_root} was requested",
-                        foreign_account_inputs.account().vault().root()
+                        foreign_account.vault().root()
                     )));
                 }
 
-                foreign_account_inputs.account().vault().open(vault_key).map_err(|err| {
-                    DataStoreError::other_with_source(
-                        format!(
-                            "failed to open vault_key {vault_key} in foreign account {account_id}"
-                        ),
-                        err,
-                    )
-                })
+                Ok(foreign_account.vault().open(vault_key))
             }
         }
     }
@@ -320,7 +319,7 @@ impl DataStore for TransactionContext {
 
                 Ok(storage_map.open(&map_key))
             } else {
-                let foreign_account_inputs = self
+                let (foreign_account, _witness) = self
                     .foreign_account_inputs
                     .iter()
                     .find_map(
@@ -334,22 +333,20 @@ impl DataStore for TransactionContext {
                         ))
                     })?;
 
-                let map = foreign_account_inputs
-                    .account()
-                    .storage()
-                    .maps()
-                    .find(|map| map.root() == map_root)
+                let map = foreign_account
+                    .storage().slots()
+                    
+                    .iter().find_map(|slot| match slot {
+                      StorageSlot::Map(storage_map) if  storage_map.root() == map_root => {Some(storage_map)},
+                      _ => None,
+                    })
                     .ok_or_else(|| {
                         DataStoreError::other(format!(
                             "failed to find storage map with root {map_root} in foreign account {account_id}"
                         ))
                     })?;
 
-                map.open(&map_key).map_err(|err| {
-                  DataStoreError::other_with_source(format!(
-                        "failed to open {map_key} in storage map of foreign account {account_id}"
-                    ), err)
-                })
+                Ok(map.open(&map_key))
             }
         }
     }

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -1,13 +1,11 @@
 use alloc::borrow::ToOwned;
 use alloc::collections::{BTreeMap, BTreeSet};
-use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::{Account, AccountId, PartialAccount, StorageMapWitness, StorageSlot};
 use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
-use miden_objects::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_objects::assembly::{SourceManager, SourceManagerSync};
 use miden_objects::asset::AssetWitness;
 use miden_objects::block::{AccountWitness, BlockHeader, BlockNumber};
@@ -68,11 +66,6 @@ pub struct TransactionContext {
 }
 
 impl TransactionContext {
-    pub fn execute_code2(&self, code: &str) -> anyhow::Result<ExecutionOutput> {
-        self.execute_code(code)
-            .map_err(|err| anyhow::anyhow!(PrintDiagnostic::new(err).to_string()))
-    }
-
     /// Executes arbitrary code within the context of a mocked transaction environment and returns
     /// the resulting [`ExecutionOutput`].
     ///

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -338,8 +338,8 @@ impl DataStore for TransactionContext {
                     .slots()
                     .iter()
                     .find_map(|slot| match slot {
-                      StorageSlot::Map(storage_map) if  storage_map.root() == map_root => {Some(storage_map)},
-                      _ => None,
+                        StorageSlot::Map(storage_map) if storage_map.root() == map_root => {Some(storage_map)},
+                        _ => None,
                     })
                     .ok_or_else(|| {
                         DataStoreError::other(format!(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -280,6 +280,8 @@ where
         map_root: Word,
         map_key: Word,
     ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
+        std::println!("request map key {map_key} for account {current_account_id}");
+
         let storage_map_witness = self
             .base_host
             .store()

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -280,8 +280,6 @@ where
         map_root: Word,
         map_key: Word,
     ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
-        std::println!("request map key {map_key} for account {current_account_id}");
-
         let storage_map_witness = self
             .base_host
             .store()

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -1,15 +1,13 @@
 use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::AccountId;
 use miden_objects::assembly::DefaultSourceManager;
 use miden_objects::assembly::debuginfo::SourceManagerSync;
 use miden_objects::asset::Asset;
-use miden_objects::block::{BlockHeader, BlockNumber};
+use miden_objects::block::BlockNumber;
 use miden_objects::transaction::{
-    AccountInputs,
     ExecutedTransaction,
     InputNote,
     InputNotes,
@@ -181,8 +179,7 @@ where
         notes: InputNotes<InputNote>,
         tx_args: TransactionArgs,
     ) -> Result<ExecutedTransaction, TransactionExecutorError> {
-        let tx_inputs =
-            self.prepare_transaction_inputs(account_id, block_ref, notes, &tx_args).await?;
+        let tx_inputs = self.prepare_transaction_inputs(account_id, block_ref, notes).await?;
 
         let (mut host, stack_inputs, advice_inputs) =
             self.prepare_transaction(&tx_inputs, &tx_args, None).await?;
@@ -223,14 +220,11 @@ where
         block_ref: BlockNumber,
         tx_script: TransactionScript,
         advice_inputs: AdviceInputs,
-        foreign_account_inputs: Vec<AccountInputs>,
     ) -> Result<[Felt; 16], TransactionExecutorError> {
-        let tx_args = TransactionArgs::new(Default::default(), foreign_account_inputs)
-            .with_tx_script(tx_script);
+        let tx_args = TransactionArgs::default().with_tx_script(tx_script);
 
         let notes = InputNotes::default();
-        let tx_inputs =
-            self.prepare_transaction_inputs(account_id, block_ref, notes, &tx_args).await?;
+        let tx_inputs = self.prepare_transaction_inputs(account_id, block_ref, notes).await?;
 
         let (mut host, stack_inputs, advice_inputs) =
             self.prepare_transaction(&tx_inputs, &tx_args, Some(advice_inputs)).await?;
@@ -259,7 +253,6 @@ where
         account_id: AccountId,
         block_ref: BlockNumber,
         input_notes: InputNotes<InputNote>,
-        tx_args: &TransactionArgs,
     ) -> Result<TransactionInputs, TransactionExecutorError> {
         let mut ref_blocks = validate_input_notes(&input_notes, block_ref)?;
         ref_blocks.insert(block_ref);
@@ -269,8 +262,6 @@ where
             .get_transaction_inputs(account_id, ref_blocks)
             .await
             .map_err(TransactionExecutorError::FetchTransactionInputsFailed)?;
-
-        validate_account_inputs(tx_args, &ref_block)?;
 
         let tx_inputs = TransactionInputs::new(account, ref_block, mmr, input_notes)
             .map_err(TransactionExecutorError::InvalidTransactionInputs)?;
@@ -404,25 +395,6 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
         advice_inputs,
         tx_progress.into(),
     ))
-}
-
-/// Validates the account inputs against the reference block header.
-fn validate_account_inputs(
-    tx_args: &TransactionArgs,
-    ref_block: &BlockHeader,
-) -> Result<(), TransactionExecutorError> {
-    // Validate that foreign account inputs are anchored in the reference block
-    for foreign_account in tx_args.foreign_account_inputs() {
-        let computed_account_root = foreign_account.compute_account_root().map_err(|err| {
-            TransactionExecutorError::InvalidAccountWitness(foreign_account.id(), err)
-        })?;
-        if computed_account_root != ref_block.account_root() {
-            return Err(TransactionExecutorError::ForeignAccountNotAnchoredInReference(
-                foreign_account.id(),
-            ));
-        }
-    }
-    Ok(())
 }
 
 /// Validates that input notes were not created after the reference block.

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -119,7 +119,7 @@ where
         let notes = InputNotes::from(notes);
         let tx_inputs = self
             .0
-            .prepare_transaction_inputs(target_account_id, block_ref, notes, &tx_args)
+            .prepare_transaction_inputs(target_account_id, block_ref, notes)
             .await
             .map_err(NoteCheckerError::TransactionPreparation)?;
 

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -246,6 +246,8 @@ where
 
         let transaction_event = TransactionEvent::try_from(event_id).map_err(EventError::from)?;
 
+        std::println!("{} -> {}", transaction_event, transaction_event.event_id());
+
         // Privileged events can only be emitted from the root context.
         if process.ctx() != ContextId::root() && transaction_event.is_privileged() {
             return Err(Box::new(TransactionEventError::NotRootContext(transaction_event)));

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -246,8 +246,6 @@ where
 
         let transaction_event = TransactionEvent::try_from(event_id).map_err(EventError::from)?;
 
-        std::println!("{} -> {}", transaction_event, transaction_event.event_id());
-
         // Privileged events can only be emitted from the root context.
         if process.ctx() != ContextId::root() && transaction_event.is_privileged() {
             return Err(Box::new(TransactionEventError::NotRootContext(transaction_event)));


### PR DESCRIPTION

Enables lazy loading by default in all tests by changing the conversion from `Account` to `PartialAccount` to only represent the minimal account and by setting `TransactionContextBuilder::is_lazy_loading_enabled = true`.

The changes:
- Remove `TransactionArgs::foreign_account_inputs`. So, foreign accounts are now no longer loaded upfront but only when they are needed.
- Change how `Account` is converted to `PartialAccount` . Essentially: New accounts are converted to a "full" partial representation and existing accounts are converted to a minimal representation.
	- This cleaned up a few lazy loading things in test code like `minimal_partial_account`.
- `MockChain::get_foreign_account_inputs` returns `Account` instead of `PartialAccount`. See https://github.com/0xMiden/miden-base/issues/1473#issuecomment-3356589681 for details.
- `transaction_with_stale_foreign_account_inputs_fails` was removed because the checks it was testing no longer exist. In principle, we could move this check to `TransactionExecutorHost::on_foreign_account_requested` but in practice it makes little difference: We're already in the middle of transaction execution and so whether the host aborts or the kernel isn't very important. The pro for having it is that the host could return a better error than the tx kernel while the pro for not having it is that it makes testing the kernel logic possible at all. For now it's the latter.
- Overhaul `test_epilogue_asset_preservation_violation_too_few_input` and `test_epilogue_asset_preservation_violation_too_many_fungible_input` to be more concise, execute a full transaction instead of `execute_code`. This turned out to be unnecessary in hindsight, but also partially addresses https://github.com/0xMiden/miden-base/issues/1845, which I think is a plus.

closes https://github.com/0xMiden/miden-base/issues/1473
