### PR TITLE
feat: add `get_public_key_commitments` method to `AuthScheme` #1953

### DIFF
--- a/crates/miden-lib/src/auth.rs
+++ b/crates/miden-lib/src/auth.rs
@@ -1,40 +1,42 @@
 use alloc::vec::Vec;
 
-use miden_objects::Word;
-
 use crate::account::auth::PublicKeyCommitment;
 
 /// Defines authentication schemes available to standard and faucet accounts.
 pub enum AuthScheme {
-    /// A single-key authentication scheme which relies RPO Falcon512 signatures. RPO Falcon512 is
-    /// a variant of the [Falcon](https://falcon-sign.info/) signature scheme. This variant differs from
-    /// the standard in that instead of using SHAKE256 hash function in the hash-to-point algorithm
-    /// we use RPO256. This makes the signature more efficient to verify in Miden VM.
+    /// A minimal authentication scheme that provides no cryptographic authentication.
+    ///
+    /// It only increments the nonce if the account state has actually changed during transaction
+    /// execution, avoiding unnecessary nonce increments for transactions that don't modify the
+    /// account state.
+    NoAuth,
+    /// A single-key authentication scheme which relies RPO Falcon512 signatures.
+    ///
+    /// RPO Falcon512 is a variant of the [Falcon](https://falcon-sign.info/) signature scheme.
+    /// This variant differs from the standard in that instead of using SHAKE256 hash function in
+    /// the hash-to-point algorithm we use RPO256. This makes the signature more efficient to
+    /// verify in Miden VM.
     RpoFalcon512 { pub_key: PublicKeyCommitment },
     /// A multi-signature authentication scheme using RPO Falcon512 signatures.
+    ///
     /// Requires a threshold number of signatures from the provided public keys.
     RpoFalcon512Multisig {
         threshold: u32,
         pub_keys: Vec<PublicKeyCommitment>,
     },
-    /// A minimal authentication scheme that provides no cryptographic authentication.
-    /// It only increments the nonce if the account state has actually changed during
-    /// transaction execution, avoiding unnecessary nonce increments for transactions
-    /// that don't modify the account state.
-    NoAuth,
     /// A non-standard authentication scheme.
     Unknown,
 }
 
 impl AuthScheme {
-    /// Returns all public key commitments associated with this authentication scheme as Words.
-    pub fn get_public_key_commitments(&self) -> Vec<Word> {
+    /// Returns all public key commitments associated with this authentication scheme.
+    ///
+    /// For unknown schemes, an empty vector is returned.
+    pub fn get_public_key_commitments(&self) -> Vec<PublicKeyCommitment> {
         match self {
             AuthScheme::NoAuth => Vec::new(),
-            AuthScheme::RpoFalcon512 { pub_key } => vec![Word::from(*pub_key)],
-            AuthScheme::RpoFalcon512Multisig { pub_keys, .. } => {
-                pub_keys.iter().map(|key| Word::from(*key)).collect()
-            },
+            AuthScheme::RpoFalcon512 { pub_key } => vec![*pub_key],
+            AuthScheme::RpoFalcon512Multisig { pub_keys, .. } => pub_keys.clone(),
             AuthScheme::Unknown => Vec::new(),
         }
     }

--- a/crates/miden-lib/src/auth.rs
+++ b/crates/miden-lib/src/auth.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 
+use miden_objects::Word;
+
 use crate::account::auth::PublicKeyCommitment;
 
 /// Defines authentication schemes available to standard and faucet accounts.
@@ -22,4 +24,18 @@ pub enum AuthScheme {
     NoAuth,
     /// A non-standard authentication scheme.
     Unknown,
+}
+
+impl AuthScheme {
+    /// Returns all public key commitments associated with this authentication scheme as Words.
+    pub fn get_public_key_commitments(&self) -> Vec<Word> {
+        match self {
+            AuthScheme::NoAuth => Vec::new(),
+            AuthScheme::RpoFalcon512 { pub_key } => vec![Word::from(*pub_key)],
+            AuthScheme::RpoFalcon512Multisig { pub_keys, .. } => {
+                pub_keys.iter().map(|key| Word::from(*key)).collect()
+            },
+            AuthScheme::Unknown => Vec::new(),
+        }
+    }
 }

--- a/crates/miden-lib/src/testing/account_interface.rs
+++ b/crates/miden-lib/src/testing/account_interface.rs
@@ -3,26 +3,15 @@ use alloc::vec::Vec;
 use miden_objects::Word;
 use miden_objects::account::Account;
 
-use crate::AuthScheme;
 use crate::account::interface::AccountInterface;
 
 /// Helper function to extract public keys from an account
 pub fn get_public_keys_from_account(account: &Account) -> Vec<Word> {
-    let mut pub_keys = vec![];
     let interface: AccountInterface = account.into();
 
-    for auth in interface.auth() {
-        match auth {
-            AuthScheme::NoAuth => {},
-            AuthScheme::RpoFalcon512 { pub_key } => pub_keys.push(Word::from(*pub_key)),
-            AuthScheme::RpoFalcon512Multisig { pub_keys: multisig_keys, .. } => {
-                for key in multisig_keys {
-                    pub_keys.push(Word::from(*key));
-                }
-            },
-            AuthScheme::Unknown => {},
-        }
-    }
-
-    pub_keys
+    interface
+        .auth()
+        .iter()
+        .flat_map(|auth| auth.get_public_key_commitments())
+        .collect()
 }

--- a/crates/miden-lib/src/testing/account_interface.rs
+++ b/crates/miden-lib/src/testing/account_interface.rs
@@ -13,5 +13,6 @@ pub fn get_public_keys_from_account(account: &Account) -> Vec<Word> {
         .auth()
         .iter()
         .flat_map(|auth| auth.get_public_key_commitments())
+        .map(Word::from)
         .collect()
 }


### PR DESCRIPTION
Resolves #1953

Adds a `get_public_key_commitments` method to `AuthScheme`:
```rs
impl AuthScheme {
    pub fn get_public_key_commitments(&self) -> Vec<Word> {
        // returns all public keys in Word form
    }
}
```