### PR TITLE
feat: Introduce Word wrapper for asset vault keys

### DIFF
--- a/crates/miden-lib/src/testing/mock_account.rs
+++ b/crates/miden-lib/src/testing/mock_account.rs
@@ -70,7 +70,7 @@ pub trait MockAccountExt {
 
         let asset = NonFungibleAsset::mock(&constants::NON_FUNGIBLE_ASSET_DATA_2);
         let non_fungible_storage_map =
-            StorageMap::with_entries([(asset.vault_key(), asset.into())]).unwrap();
+            StorageMap::with_entries([(asset.vault_key().inner(), asset.into())]).unwrap();
         let storage =
             AccountStorage::new(vec![StorageSlot::Map(non_fungible_storage_map)]).unwrap();
 

--- a/crates/miden-objects/src/asset/fungible.rs
+++ b/crates/miden-objects/src/asset/fungible.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::string::ToString;
 use core::fmt;
 
+use super::vault::AssetKey;
 use super::{AccountType, Asset, AssetError, Felt, Word, ZERO, is_not_a_non_fungible_asset};
 use crate::account::{AccountId, AccountIdPrefix};
 use crate::utils::serde::{
@@ -83,8 +84,8 @@ impl FungibleAsset {
     }
 
     /// Returns the key which is used to store this asset in the account vault.
-    pub fn vault_key(&self) -> Word {
-        Self::vault_key_from_faucet(self.faucet_id)
+    pub fn vault_key(&self) -> AssetKey {
+        Self::vault_key_from_faucet(self.faucet_id).into()
     }
 
     // OPERATIONS

--- a/crates/miden-objects/src/asset/mod.rs
+++ b/crates/miden-objects/src/asset/mod.rs
@@ -22,7 +22,7 @@ mod token_symbol;
 pub use token_symbol::TokenSymbol;
 
 mod vault;
-pub use vault::{AssetVault, AssetWitness, PartialVault};
+pub use vault::{AssetKey, AssetVault, AssetWitness, PartialVault};
 
 // ASSET
 // ================================================================================================
@@ -137,7 +137,7 @@ impl Asset {
     }
 
     /// Returns the key which is used to store this asset in the account vault.
-    pub fn vault_key(&self) -> Word {
+    pub fn vault_key(&self) -> AssetKey {
         match self {
             Self::Fungible(asset) => asset.vault_key(),
             Self::NonFungible(asset) => asset.vault_key(),

--- a/crates/miden-objects/src/asset/nonfungible.rs
+++ b/crates/miden-objects/src/asset/nonfungible.rs
@@ -3,6 +3,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt;
 
+use super::vault::AssetKey;
 use super::{AccountIdPrefix, AccountType, Asset, AssetError, Felt, Hasher, Word};
 use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use crate::{FieldElement, WORD_SIZE};
@@ -106,7 +107,7 @@ impl NonFungibleAsset {
     /// It also ensures that there is never any collision in the leaf index between a non-fungible
     /// asset and a fungible asset, as the former's vault key always has the fungible bit set to `0`
     /// and the latter's vault key always has the bit set to `1`.
-    pub fn vault_key(&self) -> Word {
+    pub fn vault_key(&self) -> AssetKey {
         let mut vault_key = self.0;
 
         // Swap prefix of faucet ID with hash0.
@@ -116,7 +117,7 @@ impl NonFungibleAsset {
         vault_key[3] =
             AccountIdPrefix::clear_fungible_bit(self.faucet_id_prefix().version(), vault_key[3]);
 
-        vault_key
+        vault_key.into()
     }
 
     /// Return ID prefix of the faucet which issued this asset.

--- a/crates/miden-objects/src/asset/vault/asset_key.rs
+++ b/crates/miden-objects/src/asset/vault/asset_key.rs
@@ -1,0 +1,69 @@
+use core::fmt;
+
+use crate::account::AccountId;
+use crate::account::AccountType::{
+    FungibleFaucet,
+    NonFungibleFaucet,
+    RegularAccountImmutableCode,
+    RegularAccountUpdatableCode,
+};
+use crate::asset::{Asset, FungibleAsset, NonFungibleAsset};
+use crate::{AccountIdError, Word};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
+pub struct AssetKey(Word);
+
+impl AssetKey {
+    pub fn inner(&self) -> Word {
+        self.0
+    }
+
+    pub fn from_account_id(account_id: AccountId) -> Result<Self, AccountIdError> {
+        match account_id.account_type() {
+            FungibleFaucet => Ok(Self(FungibleAsset::vault_key_from_faucet(account_id))),
+            NonFungibleFaucet => !todo!(),
+            RegularAccountImmutableCode | RegularAccountUpdatableCode => {
+                Err(AccountIdError::UnknownAssetKey)
+            },
+        }
+    }
+}
+
+impl fmt::Display for AssetKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner())
+    }
+}
+
+impl Into<AssetKey> for Word {
+    fn into(self) -> AssetKey {
+        AssetKey(self)
+    }
+}
+
+// CONVERSIONS FROM ASSET
+// ================================================================================================
+
+impl From<Asset> for AssetKey {
+    fn from(asset: Asset) -> Self {
+        asset.vault_key()
+    }
+}
+
+// CONVERSIONS FROM FUNGIBLE ASSET
+// ================================================================================================
+
+impl From<FungibleAsset> for AssetKey {
+    fn from(fungible_asset: FungibleAsset) -> Self {
+        fungible_asset.vault_key()
+    }
+}
+
+// CONVERSIONS FROM NON-FUNGIBLE ASSET
+// ================================================================================================
+
+impl From<NonFungibleAsset> for AssetKey {
+    fn from(non_fungible_asset: NonFungibleAsset) -> Self {
+        non_fungible_asset.vault_key()
+    }
+}

--- a/crates/miden-objects/src/asset/vault/asset_witness.rs
+++ b/crates/miden-objects/src/asset/vault/asset_witness.rs
@@ -1,7 +1,8 @@
 use miden_crypto::merkle::{InnerNodeInfo, SmtLeaf, SmtProof};
 
+use super::asset_key::AssetKey;
+use crate::AssetError;
 use crate::asset::Asset;
-use crate::{AssetError, Word};
 
 /// A witness of an asset in an [`AssetVault`](super::AssetVault).
 ///
@@ -23,10 +24,10 @@ impl AssetWitness {
     pub fn new(smt_proof: SmtProof) -> Result<Self, AssetError> {
         for (vault_key, asset) in smt_proof.leaf().entries() {
             let asset = Asset::try_from(asset)?;
-            if asset.vault_key() != *vault_key {
+            if asset.vault_key().inner() != *vault_key {
                 return Err(AssetError::VaultKeyMismatch {
                     actual: *vault_key,
-                    expected: asset.vault_key(),
+                    expected: asset.vault_key().inner(),
                 });
             }
         }
@@ -46,7 +47,7 @@ impl AssetWitness {
     // --------------------------------------------------------------------------------------------
 
     /// Searches for an [`Asset`] in the witness with the given `vault_key`.
-    pub fn find(&self, vault_key: Word) -> Option<Asset> {
+    pub fn find(&self, vault_key: AssetKey) -> Option<Asset> {
         self.assets().find(|asset| asset.vault_key() == vault_key)
     }
 
@@ -114,14 +115,15 @@ mod tests {
         let fungible_asset = FungibleAsset::mock(500);
         let non_fungible_asset = NonFungibleAsset::mock(&[1]);
 
-        let smt = Smt::with_entries([(fungible_asset.vault_key(), non_fungible_asset.into())])?;
-        let proof = smt.open(&fungible_asset.vault_key());
+        let smt =
+            Smt::with_entries([(fungible_asset.vault_key().inner(), non_fungible_asset.into())])?;
+        let proof = smt.open(&fungible_asset.vault_key().inner());
 
         let err = AssetWitness::new(proof).unwrap_err();
 
         assert_matches!(err, AssetError::VaultKeyMismatch { actual, expected } => {
-            assert_eq!(actual, fungible_asset.vault_key());
-            assert_eq!(expected, non_fungible_asset.vault_key());
+            assert_eq!(actual, fungible_asset.vault_key().inner());
+            assert_eq!(expected, non_fungible_asset.vault_key().inner());
         });
 
         Ok(())

--- a/crates/miden-objects/src/asset/vault/mod.rs
+++ b/crates/miden-objects/src/asset/vault/mod.rs
@@ -24,6 +24,9 @@ pub use partial::PartialVault;
 mod asset_witness;
 pub use asset_witness::AssetWitness;
 
+mod asset_key;
+pub use asset_key::AssetKey;
+
 // ASSET VAULT
 // ================================================================================================
 
@@ -57,7 +60,7 @@ impl AssetVault {
     pub fn new(assets: &[Asset]) -> Result<Self, AssetVaultError> {
         Ok(Self {
             asset_tree: Smt::with_entries(
-                assets.iter().map(|asset| (asset.vault_key(), (*asset).into())),
+                assets.iter().map(|asset| (asset.vault_key().inner(), (*asset).into())),
             )
             .map_err(AssetVaultError::DuplicateAsset)?,
         })
@@ -74,7 +77,7 @@ impl AssetVault {
     /// Returns true if the specified non-fungible asset is stored in this vault.
     pub fn has_non_fungible_asset(&self, asset: NonFungibleAsset) -> Result<bool, AssetVaultError> {
         // check if the asset is stored in the vault
-        match self.asset_tree.get_value(&asset.vault_key()) {
+        match self.asset_tree.get_value(&asset.vault_key().inner()) {
             asset if asset == Smt::EMPTY_VALUE => Ok(false),
             _ => Ok(true),
         }
@@ -111,8 +114,8 @@ impl AssetVault {
     /// Returns an opening of the leaf associated with `vault_key`.
     ///
     /// The `vault_key` can be obtained with [`Asset::vault_key`].
-    pub fn open(&self, vault_key: Word) -> AssetWitness {
-        let smt_proof = self.asset_tree.open(&vault_key);
+    pub fn open(&self, vault_key: AssetKey) -> AssetWitness {
+        let smt_proof = self.asset_tree.open(&vault_key.inner());
         // SAFETY: The asset vault should only contain valid assets.
         AssetWitness::new_unchecked(smt_proof)
     }
@@ -140,9 +143,9 @@ impl AssetVault {
 
     // TODO: Replace with https://github.com/0xMiden/crypto/issues/515 once implemented.
     /// Returns the leaf index of a vault key.
-    pub fn vault_key_to_leaf_index(vault_key: Word) -> Felt {
+    pub fn vault_key_to_leaf_index(vault_key: AssetKey) -> Felt {
         // The third element in an SMT key is the index.
-        vault_key[3]
+        vault_key.inner()[3]
     }
 
     // PUBLIC MODIFIERS
@@ -204,7 +207,7 @@ impl AssetVault {
         asset: FungibleAsset,
     ) -> Result<FungibleAsset, AssetVaultError> {
         // fetch current asset value from the tree and add the new asset to it.
-        let new: FungibleAsset = match self.asset_tree.get_value(&asset.vault_key()) {
+        let new: FungibleAsset = match self.asset_tree.get_value(&asset.vault_key().inner()) {
             current if current == Smt::EMPTY_VALUE => asset,
             current => {
                 let current = FungibleAsset::new_unchecked(current);
@@ -212,7 +215,7 @@ impl AssetVault {
             },
         };
         self.asset_tree
-            .insert(new.vault_key(), new.into())
+            .insert(new.vault_key().inner(), new.into())
             .map_err(AssetVaultError::MaxLeafEntriesExceeded)?;
 
         // return the new asset
@@ -231,7 +234,7 @@ impl AssetVault {
         // add non-fungible asset to the vault
         let old = self
             .asset_tree
-            .insert(asset.vault_key(), asset.into())
+            .insert(asset.vault_key().inner(), asset.into())
             .map_err(AssetVaultError::MaxLeafEntriesExceeded)?;
 
         // if the asset already exists, return an error
@@ -275,7 +278,7 @@ impl AssetVault {
         asset: FungibleAsset,
     ) -> Result<FungibleAsset, AssetVaultError> {
         // fetch the asset from the vault.
-        let new: FungibleAsset = match self.asset_tree.get_value(&asset.vault_key()) {
+        let new: FungibleAsset = match self.asset_tree.get_value(&asset.vault_key().inner()) {
             current if current == Smt::EMPTY_VALUE => {
                 return Err(AssetVaultError::FungibleAssetNotFound(asset));
             },
@@ -291,7 +294,7 @@ impl AssetVault {
             _ => new.into(),
         };
         self.asset_tree
-            .insert(new.vault_key(), value)
+            .insert(new.vault_key().inner(), value)
             .map_err(AssetVaultError::MaxLeafEntriesExceeded)?;
 
         // return the asset that was removed.
@@ -311,7 +314,7 @@ impl AssetVault {
         // remove the asset from the vault.
         let old = self
             .asset_tree
-            .insert(asset.vault_key(), Smt::EMPTY_VALUE)
+            .insert(asset.vault_key().inner(), Smt::EMPTY_VALUE)
             .map_err(AssetVaultError::MaxLeafEntriesExceeded)?;
 
         // return an error if the asset did not exist in the vault.

--- a/crates/miden-objects/src/errors.rs
+++ b/crates/miden-objects/src/errors.rs
@@ -216,6 +216,8 @@ pub enum AccountIdError {
     AccountIdSuffixMostSignificantBitMustBeZero,
     #[error("least significant byte of account ID suffix must be zero")]
     AccountIdSuffixLeastSignificantByteMustBeZero,
+    #[error(r#"account not of type "FungibleFaucet", "NonFungibleFaucet""#)]
+    UnknownAssetKey,
 }
 
 // SLOT NAME ERROR

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -236,7 +236,7 @@ fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
         end
         "#,
         non_fungible_asset = Word::from(non_fungible_asset),
-        asset_vault_key = StorageMap::hash_key(asset_vault_key),
+        asset_vault_key = StorageMap::hash_key(asset_vault_key.inner()),
     );
 
     tx_context.execute_code(&code)?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -691,7 +691,7 @@ pub async fn create_account_non_fungible_faucet_invalid_initial_reserved_slot() 
     // Create a storage map with a mock asset to make it non-empty.
     let asset = NonFungibleAsset::mock(&[1, 2, 3, 4]);
     let non_fungible_storage_map =
-        StorageMap::with_entries([(asset.vault_key(), asset.into())]).unwrap();
+        StorageMap::with_entries([(asset.vault_key().inner(), asset.into())]).unwrap();
     let storage = AccountStorage::new(vec![StorageSlot::Map(non_fungible_storage_map)]).unwrap();
 
     let account = AccountBuilder::new([1; 32])

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -364,7 +364,7 @@ fn minimal_partial_account(account: &Account) -> anyhow::Result<PartialAccount> 
     // root as the full vault, but will not add any relevant merkle paths to the
     // merkle store, which will test lazy loading of assets.
     let mut partial_vault = PartialVault::default();
-    partial_vault.add(account.vault().open(Word::empty()))?;
+    partial_vault.add(account.vault().open(Word::empty().into()))?;
 
     // Construct a partial storage that tracks the empty word in all storage maps, but none
     // of the other keys, following the same rationale as the partial vault above.

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -8,7 +8,7 @@ use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::{Account, AccountId, PartialAccount, StorageMapWitness, StorageSlot};
 use miden_objects::assembly::debuginfo::{SourceLanguage, Uri};
 use miden_objects::assembly::{SourceManager, SourceManagerSync};
-use miden_objects::asset::AssetWitness;
+use miden_objects::asset::{AssetKey, AssetWitness};
 use miden_objects::block::{BlockHeader, BlockNumber};
 use miden_objects::note::Note;
 use miden_objects::transaction::{
@@ -213,7 +213,7 @@ impl DataStore for TransactionContext {
         &self,
         account_id: AccountId,
         vault_root: Word,
-        vault_key: Word,
+        vault_key: AssetKey,
     ) -> impl FutureMaybeSend<Result<AssetWitness, DataStoreError>> {
         async move {
             if account_id == self.account().id() {

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeSet;
 
 use miden_objects::account::{AccountId, PartialAccount, StorageMapWitness};
-use miden_objects::asset::AssetWitness;
+use miden_objects::asset::{AssetKey, AssetWitness};
 use miden_objects::block::{BlockHeader, BlockNumber};
 use miden_objects::transaction::{AccountInputs, PartialBlockchain};
 use miden_processor::{FutureMaybeSend, MastForestStore, Word};
@@ -50,7 +50,7 @@ pub trait DataStore: MastForestStore {
         &self,
         account_id: AccountId,
         vault_root: Word,
-        vault_key: Word,
+        vault_key: AssetKey,
     ) -> impl FutureMaybeSend<Result<AssetWitness, DataStoreError>>;
 
     /// Returns a witness for a storage map item identified by `map_key` in the requested account's

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -39,7 +39,7 @@ use miden_objects::account::{
     StorageMap,
     StorageSlotType,
 };
-use miden_objects::asset::{Asset, AssetVault, FungibleAsset};
+use miden_objects::asset::{Asset, AssetKey, AssetVault, FungibleAsset};
 use miden_objects::note::NoteId;
 use miden_objects::transaction::{
     InputNote,
@@ -929,7 +929,7 @@ where
                 TransactionEventData::AccountVaultAssetWitness {
                     current_account_id,
                     vault_root,
-                    asset,
+                    asset_key: asset.into(),
                 },
             ))
         }
@@ -1184,7 +1184,7 @@ pub(super) enum TransactionEventData {
         /// The vault root identifying the asset vault from which a witness is requested.
         vault_root: Word,
         /// The asset for which a witness is requested.
-        asset: Asset,
+        asset_key: AssetKey,
     },
     /// The data necessary to request a storage map witness from the data store.
     AccountStorageMapWitness {


### PR DESCRIPTION
Fixes #1890 


Few points to note: 
- Unsure about the conversion from `NonFungibleFaucet` to `AssetKey`, hence it is set to `todo`. Will proceed as advised.
- Do we want to convert all `vault_key()` to `asset_key()`?