### PR TITLE
chore: remove circular check for generated files in `build.rs`

### DIFF
--- a/crates/miden-lib/build.rs
+++ b/crates/miden-lib/build.rs
@@ -91,9 +91,6 @@ fn main() -> Result<()> {
     // set target directory to {OUT_DIR}/assets
     let target_dir = Path::new(&build_dir).join(ASSETS_DIR);
 
-    // re-build if any of the generated files were modified
-    println!("cargo::rerun-if-changed={}", target_dir.display());
-
     // compile transaction kernel
     let mut assembler =
         compile_tx_kernel(&source_dir.join(ASM_TX_KERNEL_DIR), &target_dir.join("kernels"))?;


### PR DESCRIPTION
The build script was watching its own output directory (`{OUT_DIR}/assets`), creating a circular dependency that triggered recompilation on every cargo invocation.
We shouldn't need to recompile `miden-lib` if only modifying files downstream of `miden-lib`, like in `miden-testing`.
Example:

**Before**
```
touch crates/miden-testing/src/lib.rs 
cargo test --profile=test-dev --no-run
   Compiling miden-lib v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-lib)
   Compiling miden-tx v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-tx)
   Compiling miden-block-prover v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-block-prover)
   Compiling miden-tx-batch-prover v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-tx-batch-prover)
   Compiling miden-testing v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-testing)
   Compiling bench-note-checker v0.1.0 (/home/marti/dev/miden-base-main/bin/bench-note-checker)
   Compiling bench-transaction v0.1.0 (/home/marti/dev/miden-base-main/bin/bench-transaction)
    Finished `test-dev` profile [optimized + debuginfo] target(s) in 4.45s
```

**After**
```
touch crates/miden-testing/src/lib.rs 
cargo test --profile=test-dev --no-run
   Compiling miden-testing v0.12.0 (/home/marti/dev/miden-base-main/crates/miden-testing)
   Compiling bench-note-checker v0.1.0 (/home/marti/dev/miden-base-main/bin/bench-note-checker)
   Compiling bench-transaction v0.1.0 (/home/marti/dev/miden-base-main/bin/bench-transaction)
    Finished `test-dev` profile [optimized + debuginfo] target(s) in 1.91s
```